### PR TITLE
fix(wasm): stop a poisoned MSBuild node baking an empty bundle in silence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,15 @@ them until tagged releases begin.
   `/_rask/a/` and **nothing says so**: the app builds, publishes, boots and renders, with only its scoped
   CSS/JS absent. Every scoped URL 404s, and for an app whose scoped JS owns something load-bearing that
   presents as a hung page, sending you to debug the app rather than the build. The publish now compares
-  what was staged against what shipped and errors with the cause and the fix. A project with no scoped
-  assets stages nothing and is silently unaffected. Closes #650.
+  what was staged against what shipped and errors with the cause and the fix.
+
+  It also catches the harder half, which is what actually happened: **the bake not running at all**. With
+  the staging directory absent, "this project has no scoped assets" and "the bake was skipped" are the
+  same observation, so a staged-vs-published comparison sees nothing to compare and stays quiet. The bake
+  now records that it ran, and a publish that never baked *and* shipped no scoped assets fails. A project
+  that genuinely has none bakes zero, records the run, and is silently unaffected — verified against
+  `samples/Rask.Example.Wasm.Jobs`, which has no scoped assets, and an incremental publish that skips the
+  build pass while its assets already sit in `wwwroot` stays quiet too. Closes #650.
 
   `BakeScopedAssetsTask.FailOnEmpty` could not have caught this and — despite its own documentation
   claiming otherwise — has never been wired to anything: it fires only when the bake *runs* and writes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ them until tagged releases begin.
   `samples/Rask.Example.Wasm.Jobs` shows one, covered by an E2E that opens two real tabs.
 
 ### Fixed
+- **A WASM publish that drops its scoped assets now fails the build instead of shipping.** The bake stages
+  scoped CSS/JS into `obj/…/rask-scoped` and registers them as computed static web assets in the build
+  pass, trusting them to flow into the publish manifest. When that link breaks — most reliably by building
+  one project in both `WasmBuildNative` modes through a single `obj/` — the published bundle simply has no
+  `/_rask/a/` and **nothing says so**: the app builds, publishes, boots and renders, with only its scoped
+  CSS/JS absent. Every scoped URL 404s, and for an app whose scoped JS owns something load-bearing that
+  presents as a hung page, sending you to debug the app rather than the build. The publish now compares
+  what was staged against what shipped and errors with the cause and the fix. A project with no scoped
+  assets stages nothing and is silently unaffected. Closes #650.
+
+  `BakeScopedAssetsTask.FailOnEmpty` could not have caught this and — despite its own documentation
+  claiming otherwise — has never been wired to anything: it fires only when the bake *runs* and writes
+  zero, whereas here the bake runs perfectly well and the break is downstream of it. Its docs now say so.
+
+### Fixed
 - **Playground: picking a chapter or an example before the editor had mounted silently kept the starter
   code.** Run and Reset waited for the editor; the controls that *load* code did not — they only guarded
   against a compile being in flight. Loading a chapter is a round-trip to `setEditorValue`, and before the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,20 +26,21 @@ them until tagged releases begin.
   presents as a hung page, sending you to debug the app rather than the build. The publish now compares
   what was staged against what shipped and errors with the cause and the fix.
 
-  It also catches the harder half, which is what actually happened: **the bake not running at all**. With
-  the staging directory absent, "this project has no scoped assets" and "the bake was skipped" are the
-  same observation, so a staged-vs-published comparison sees nothing to compare and stays quiet. The bake
-  now records that it ran, and a publish that never baked *and* shipped no scoped assets fails. A project
-  that genuinely has none bakes zero, records the run, and is silently unaffected — verified against
-  `samples/Rask.Example.Wasm.Jobs`, which has no scoped assets, and an incremental publish that skips the
-  build pass while its assets already sit in `wwwroot` stays quiet too.
+  It also catches a second shape — **the bake not running at all**. With the staging directory absent,
+  "this project has no scoped assets" and "the bake was skipped" are the same observation, so the
+  comparison above has nothing to compare and stays quiet. The bake now records that it ran, and a publish
+  that never baked *and* shipped no scoped assets fails. A project that genuinely has none bakes zero,
+  records the run, and is unaffected — verified against `samples/Rask.Example.Wasm.Jobs`, which has no
+  scoped assets; an incremental publish that skips the build pass while its assets already sit in
+  `wwwroot` stays quiet too.
 
-  This covers two of the three shapes this failure takes. The one still uncovered is a bake that **runs
-  and produces zero** for an app that does have scoped assets: an empty staging directory is
-  indistinguishable from a project that legitimately has none, so nothing can tell them apart from the
-  outside. `BakeScopedAssetsTask.FailOnEmpty` cannot be enabled to cover it either — its `registryResolved`
-  is true whenever `Rask.Core` merely loads, so it would falsely fail every WASM app with no scoped assets.
-  Tracked in #650, which stays open.
+  **Neither covers what #650 actually is**, so that issue stays open. Two sessions have now reproduced it
+  and the build log is unambiguous: after a no-native solution build, the native publish's bake *runs* and
+  writes **zero** files for an app that plainly has scoped assets. Nothing outside the bake can see the
+  difference between that and a project with none, so no publish-time check can catch it —
+  `FailOnEmpty` can't either, since its `registryResolved` is true whenever `Rask.Core` merely loads and
+  would fail every WASM app without scoped assets. The fix has to be inside the bake, once the binlog
+  shows what its inputs looked like on the failing run.
 
   `BakeScopedAssetsTask.FailOnEmpty` could not have caught this and — despite its own documentation
   claiming otherwise — has never been wired to anything: it fires only when the bake *runs* and writes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,14 @@ them until tagged releases begin.
   now records that it ran, and a publish that never baked *and* shipped no scoped assets fails. A project
   that genuinely has none bakes zero, records the run, and is silently unaffected — verified against
   `samples/Rask.Example.Wasm.Jobs`, which has no scoped assets, and an incremental publish that skips the
-  build pass while its assets already sit in `wwwroot` stays quiet too. Closes #650.
+  build pass while its assets already sit in `wwwroot` stays quiet too.
+
+  This covers two of the three shapes this failure takes. The one still uncovered is a bake that **runs
+  and produces zero** for an app that does have scoped assets: an empty staging directory is
+  indistinguishable from a project that legitimately has none, so nothing can tell them apart from the
+  outside. `BakeScopedAssetsTask.FailOnEmpty` cannot be enabled to cover it either — its `registryResolved`
+  is true whenever `Rask.Core` merely loads, so it would falsely fail every WASM app with no scoped assets.
+  Tracked in #650, which stays open.
 
   `BakeScopedAssetsTask.FailOnEmpty` could not have caught this and — despite its own documentation
   claiming otherwise — has never been wired to anything: it fires only when the bake *runs* and writes

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -84,7 +84,16 @@ rm -rf samples/Rask.Example.Playground/obj/Release/net10.0-browser \
 # restored in the other one. MSBuild does not error when a PackageReference appears after restore, it
 # silently ignores it: the bundle would compile with RASK_PLAYGROUND_DATA defined (chapters 5-8 unlocked)
 # while _framework shipped no EF Core at all, and the E2E would burn its full timeout on a CS0246.
-dotnet publish samples/Rask.Example.Playground -c Release --nologo
+#
+# -nodeReuse:false is the actual difference between this publish working and not. BakeScopedAssetsTask
+# inspects the built assemblies with Assembly.LoadFrom, and MSBuild reuses worker nodes between builds: a
+# publish landing on a node that already loaded an assembly of the same simple name (from the solution
+# build above) hits a FileLoadException, skips that assembly, and bakes an empty bundle while reporting
+# success. Measured here at 3 failures in 4 consecutive publishes on identical inputs — which is why this
+# looked like a stale-output problem for so long, and why neither clean below ever fixed it: the
+# conflicting state is in the process, not on disk. A fresh node per publish removes the conflict.
+# The task now also fails rather than baking nothing silently, so this is the fix and that is the net.
+dotnet publish samples/Rask.Example.Playground -c Release -nodeReuse:false --nologo
 dotnet publish samples/Rask.Example.Site -c Release --no-restore -p:WasmBuildNative=false --nologo
 # The other exception to WasmBuildNative=false, and the slowest line here (an emscripten relink, minutes
 # not seconds): this sample runs SQLite in the browser, and SQLite is a native library. Skipping the

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -62,14 +62,24 @@ dotnet publish samples/Rask.Example.Shop -c Release --no-build --no-restore --no
 # last. Clearing only obj/Release/net10.0-browser keeps obj/project.assets.json, so the restore below is
 # still incremental.
 #
-# bin/ has to go too, and leaving it behind is why the first attempt at this (#652) did not work. With the
-# no-native build still sitting in bin/Release/net10.0-browser the publish below treats the compile as up
-# to date, so it never re-runs the scoped-asset bake — and since the staged copy under obj/ has just been
-# deleted, there is now nothing at all to publish. Clearing obj alone is therefore worse than clearing
-# neither. Measured: obj only -> 0 files under publish/wwwroot/_rask; obj + bin -> 6.
+# bin/ is cleared as well as obj/, because clearing only the intermediates was measured to be
+# insufficient: on one machine, an A/B inside this gate gave 0 files under publish/wwwroot/_rask with obj
+# alone and 6 with obj + bin, the one-line change being the only difference. On another machine the same
+# sequence — solution build, clear obj, publish — reproduces cleanly and ships its files every time, so
+# whatever decides it is not in this script.
 #
-# Note this cannot be caught by running the gate twice: both runs clear obj and both leave the same stale
-# bin, so both fail identically and look consistent. See #650.
+# The mechanism is therefore NOT known. The first explanation (a stale no-native bin/ letting the publish
+# treat the compile as up to date, so the bake never re-runs) is contradicted by those clean runs, where
+# the bake re-ran and published normally; it is recorded here only so nobody re-derives and re-believes
+# it. The clean is a deliberate superset justified by cost — one recompile of a project whose native
+# relink dominates this step regardless — not by a claim either measurement supports.
+#
+# Worth knowing when verifying any fix here: running the gate twice back to back does NOT distinguish
+# these, since both runs clear the same things and leave the same things stale. Nor does inspecting
+# publish/wwwroot after a passing run — `dotnet publish` does not clean its output directory, so _rask
+# left by an earlier good publish makes a broken publish look fine. Delete the publish dir first.
+# _RaskVerifyPublishedScopedAssets (Rask.Wasm.targets) turns the whole class into a build error if it
+# recurs, which is the durable half of this. See #650.
 rm -rf samples/Rask.Example.Playground/obj/Release/net10.0-browser \
        samples/Rask.Example.Playground/bin/Release/net10.0-browser
 # It also RE-RESTORES (no --no-restore, unlike the publishes above). RaskPlaygroundData gates the EF Core /

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -62,24 +62,21 @@ dotnet publish samples/Rask.Example.Shop -c Release --no-build --no-restore --no
 # last. Clearing only obj/Release/net10.0-browser keeps obj/project.assets.json, so the restore below is
 # still incremental.
 #
-# bin/ is cleared as well as obj/, because clearing only the intermediates was measured to be
-# insufficient: on one machine, an A/B inside this gate gave 0 files under publish/wwwroot/_rask with obj
-# alone and 6 with obj + bin, the one-line change being the only difference. On another machine the same
-# sequence — solution build, clear obj, publish — reproduces cleanly and ships its files every time, so
-# whatever decides it is not in this script.
+# bin/ is cleared alongside obj/. Be clear about what this does and does not do: it is NOT the fix, and
+# the gate still fails intermittently with it in place. It was added on an A/B that looked decisive at the
+# time (obj alone -> 0 files under publish/wwwroot/_rask, obj + bin -> 6) and has since been contradicted
+# by three sessions' worth of runs, including reproductions on branches that already had it. It is kept
+# only because it is cheap — one recompile of a project whose native relink dominates this step anyway.
 #
-# The mechanism is therefore NOT known. The first explanation (a stale no-native bin/ letting the publish
-# treat the compile as up to date, so the bake never re-runs) is contradicted by those clean runs, where
-# the bake re-ran and published normally; it is recorded here only so nobody re-derives and re-believes
-# it. The clean is a deliberate superset justified by cost — one recompile of a project whose native
-# relink dominates this step regardless — not by a claim either measurement supports.
+# What #650 actually is, per the build log: after the no-native solution build above, this native publish's
+# bake RUNS and writes ZERO files for an app that plainly has scoped assets. So no amount of cleaning here
+# can help — there is nothing stale to clear, and the deciding variable is the preceding no-native build,
+# not this project's output. The fix belongs inside the bake and is still open.
 #
-# Worth knowing when verifying any fix here: running the gate twice back to back does NOT distinguish
-# these, since both runs clear the same things and leave the same things stale. Nor does inspecting
-# publish/wwwroot after a passing run — `dotnet publish` does not clean its output directory, so _rask
-# left by an earlier good publish makes a broken publish look fine. Delete the publish dir first.
-# _RaskVerifyPublishedScopedAssets (Rask.Wasm.targets) turns the whole class into a build error if it
-# recurs, which is the durable half of this. See #650.
+# Two traps when verifying anything in this area, both of which have already produced false confidence:
+# running the gate twice back to back does not distinguish these cases, since both runs do the same thing;
+# and `dotnet publish` does not clean its output directory, so _rask left by an earlier good publish makes
+# a broken publish look fine — delete the publish dir first.
 rm -rf samples/Rask.Example.Playground/obj/Release/net10.0-browser \
        samples/Rask.Example.Playground/bin/Release/net10.0-browser
 # It also RE-RESTORES (no --no-restore, unlike the publishes above). RaskPlaygroundData gates the EF Core /

--- a/src/Rask.Wasm.Tasks/BakeScopedAssetsTask.cs
+++ b/src/Rask.Wasm.Tasks/BakeScopedAssetsTask.cs
@@ -54,11 +54,20 @@ public sealed class BakeScopedAssetsTask : Task
     ///     <c>false</c>) if the Rask registry resolved but produced zero files — i.e.
     ///     a Rask WASM project whose scoped assets silently failed to bake. Defaults to
     ///     <c>false</c>: a non-Rask project (no <c>Rask.Core</c>) still no-ops quietly,
-    ///     and the build-time bake stays non-fatal. Wired to <c>true</c> only on the
-    ///     <c>dotnet run</c> hook, where a missing bundle means the served app would
-    ///     404 on every <c>/_rask/a/</c> URL — better to fail fast than serve a broken
-    ///     standalone bundle.
+    ///     and the build-time bake stays non-fatal.
     /// </summary>
+    /// <remarks>
+    ///     <b>Nothing sets this today</b> — the single call site in <c>Rask.Wasm.targets</c> leaves it at
+    ///     its default, so the guard below never fires in a real build. It is kept because the check is
+    ///     cheap and correct for what it covers, and a future caller may want it.
+    ///     <para>
+    ///         It is deliberately <b>not</b> the guard against a published bundle missing its scoped
+    ///         assets, which is the failure that actually bites (#650/#652): there the bake runs and
+    ///         writes its files perfectly well, and the break is between staging and the published
+    ///         output — invisible from inside this task. <c>_RaskVerifyPublishedScopedAssets</c> in
+    ///         <c>Rask.Wasm.targets</c> covers that, by comparing what was staged against what shipped.
+    ///     </para>
+    /// </remarks>
     public bool FailOnEmpty { get; set; }
 
     public override bool Execute()

--- a/src/Rask.Wasm.Tasks/BakeScopedAssetsTask.cs
+++ b/src/Rask.Wasm.Tasks/BakeScopedAssetsTask.cs
@@ -70,6 +70,13 @@ public sealed class BakeScopedAssetsTask : Task
     /// </remarks>
     public bool FailOnEmpty { get; set; }
 
+    /// <summary>
+    ///     Assemblies skipped because this MSBuild process had already loaded one of the same simple name.
+    ///     Non-empty means the bake was working from an incomplete view of the app — see the check in
+    ///     <see cref="Execute" />.
+    /// </summary>
+    private readonly List<string> _skippedAlreadyLoaded = new();
+
     public override bool Execute()
     {
         if (string.IsNullOrEmpty(BundleDir))
@@ -97,6 +104,27 @@ public sealed class BakeScopedAssetsTask : Task
             var written = BakeFromAssemblies(out var registryResolved);
             Log.LogMessage(MessageImportance.High,
                 $"Rask asset bake: wrote {written} file(s) under '{Path.Combine(BundleDir, "_rask", "a")}'.");
+
+            // The bake produced nothing AND we skipped an assembly because this process had already loaded
+            // one by that name. That combination is never a legitimate "this project has no scoped assets":
+            // it is the MSBuild node-reuse race (#650), where LoadFrom throws on a reused worker and the
+            // bake quietly bakes an empty bundle. Measured at roughly one publish in three, and silent —
+            // the app then boots with every /_rask/a/ URL 404ing, which reads as a broken app rather than a
+            // broken build. Failing here is what stops that shipping.
+            //
+            // Deliberately conditioned on written == 0 as well as the skip: a bake that still produced its
+            // files despite skipping something is not known to be wrong, and failing it would turn a real
+            // fix into a new source of false build breaks.
+            if (written == 0 && _skippedAlreadyLoaded.Count > 0)
+            {
+                Log.LogError(
+                    "Rask asset bake: zero /_rask/a/ files were written because " +
+                    $"{string.Join(", ", _skippedAlreadyLoaded)} could not be loaded — this MSBuild worker " +
+                    "had already loaded an assembly of that name (node reuse), so the scoped-asset registry " +
+                    "was never read. The published app would 404 on every scoped CSS/JS URL. Re-run the " +
+                    "publish with -nodeReuse:false, or from a fresh MSBuild process.");
+                return false;
+            }
 
             if (FailOnEmpty && registryResolved && written == 0)
             {
@@ -181,6 +209,18 @@ public sealed class BakeScopedAssetsTask : Task
             {
                 Log.LogMessage(MessageImportance.Low,
                     $"Rask asset bake: skipping {Path.GetFileName(dllPath)} — {ex.GetType().Name}: {ex.Message}");
+
+                // Remember the ones that were already loaded into this process. MSBuild reuses its worker
+                // nodes, so a publish can land on a node that loaded an assembly of the same simple name
+                // during an earlier build — LoadFrom then throws and we skip an assembly whose scoped
+                // assets we needed. Skipping is the right local behaviour (recovering the loaded instance
+                // would bake a PREVIOUS build's state, which is worse than baking none), but it must not
+                // pass silently when it costs us the whole bundle: see the check in Execute.
+                if (ex is FileLoadException)
+                {
+                    _skippedAlreadyLoaded.Add(Path.GetFileName(dllPath));
+                }
+
                 continue;
             }
 

--- a/src/Rask.Wasm/build/Rask.Wasm.targets
+++ b/src/Rask.Wasm/build/Rask.Wasm.targets
@@ -190,4 +190,39 @@
              Text="Rask: rewrote &lt;base href&gt; to &quot;$(_RaskNormalizedBase)/&quot; in $(PublishDir)wwwroot/index.html"/>
   </Target>
 
+  <!--
+    Fail the publish if the scoped assets were baked but did not reach the published wwwroot.
+
+    The bake stages into obj/…/rask-scoped/_rask/a and registers the files as computed static web assets
+    in the BUILD pass, relying on AssetKind=All to carry them into the publish manifest. That link can be
+    broken without anything erroring — most reliably by building the project once in each WasmBuildNative
+    mode, since the two share one obj/ and only one of them leaves the staging the publish reads. The
+    result is a published bundle with no /_rask/a/ at all: the app builds, publishes, boots and renders,
+    and only the scoped CSS/JS is quietly absent.
+
+    That silence is the whole problem. Every scoped-asset URL 404s in the browser, and for an app whose
+    scoped JS owns something load-bearing (the playground's editor, say) it presents as a hung page rather
+    than a missing file — sending you to debug the app instead of the build. This is exactly what happened
+    in #650/#652, twice, to two different people.
+
+    Comparing staged-vs-published is what makes this precise rather than a guess: a project with no scoped
+    assets stages nothing, publishes nothing and is silently fine, while a project that staged files and
+    published none is unambiguously broken. BakeScopedAssetsTask's own FailOnEmpty cannot cover this — it
+    only fires when the bake RUNS and writes zero, and here the bake ran perfectly well, just not into the
+    staging this publish consumed.
+  -->
+  <Target Name="_RaskVerifyPublishedScopedAssets"
+          AfterTargets="Publish"
+          Condition=" '$(RaskWasm)' == 'true' ">
+    <PropertyGroup>
+      <_RaskVerifyStageDir>$(IntermediateOutputPath)rask-scoped\</_RaskVerifyStageDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <_RaskStagedScopedAsset Include="$(_RaskVerifyStageDir)_rask\a\**\*"/>
+      <_RaskPublishedScopedAsset Include="$(PublishDir)wwwroot\_rask\a\**\*"/>
+    </ItemGroup>
+    <Error Condition=" '@(_RaskStagedScopedAsset)' != '' AND '@(_RaskPublishedScopedAsset)' == '' "
+           Text="Rask: the scoped assets were baked but none reached the published output. $(_RaskVerifyStageDir)_rask/a contains @(_RaskStagedScopedAsset->Count()) file(s), while $(PublishDir)wwwroot/_rask/a has none, so every /_rask/a/ URL would 404 in the browser and any component relying on its scoped JS would never initialise. This usually means the project was built in both WasmBuildNative modes through one obj/ — clear $(IntermediateOutputPath) and publish again."/>
+  </Target>
+
 </Project>

--- a/src/Rask.Wasm/build/Rask.Wasm.targets
+++ b/src/Rask.Wasm/build/Rask.Wasm.targets
@@ -127,6 +127,12 @@
       <_RaskBakeInputAssemblies Include="@(ReferenceCopyLocalPaths)" Condition=" '%(Extension)' == '.dll' "/>
     </ItemGroup>
     <BakeScopedAssetsTask BundleDir="$(_RaskScopedStageDir)" Assemblies="@(_RaskBakeInputAssemblies)"/>
+    <!-- Records that the bake actually ran, which _RaskVerifyPublishedScopedAssets needs to tell "this
+         project has no scoped assets" apart from "the bake was skipped". An empty staging dir means the
+         former only if we got this far. -->
+    <PropertyGroup>
+      <_RaskScopedBakeRan>true</_RaskScopedBakeRan>
+    </PropertyGroup>
     <ItemGroup>
       <_RaskScopedBaked Include="$(_RaskScopedStageDir)**\*"/>
     </ItemGroup>
@@ -221,8 +227,23 @@
       <_RaskStagedScopedAsset Include="$(_RaskVerifyStageDir)_rask\a\**\*"/>
       <_RaskPublishedScopedAsset Include="$(PublishDir)wwwroot\_rask\a\**\*"/>
     </ItemGroup>
+    <!-- Baked, but nothing shipped. -->
     <Error Condition=" '@(_RaskStagedScopedAsset)' != '' AND '@(_RaskPublishedScopedAsset)' == '' "
            Text="Rask: the scoped assets were baked but none reached the published output. $(_RaskVerifyStageDir)_rask/a contains @(_RaskStagedScopedAsset->Count()) file(s), while $(PublishDir)wwwroot/_rask/a has none, so every /_rask/a/ URL would 404 in the browser and any component relying on its scoped JS would never initialise. This usually means the project was built in both WasmBuildNative modes through one obj/ — clear $(IntermediateOutputPath) and publish again."/>
+
+    <!--
+      Never baked at all, and nothing shipped. This is the case the staged-vs-published check above cannot
+      see: with the staging dir absent, "no scoped assets" and "the bake was skipped" look identical from
+      the outside — and it is the second one that actually happened in #650, where the publish produced no
+      _rask and no staging either. The bake target unconditionally RemoveDir+MakeDirs its staging, so a
+      missing staging dir is proof it did not run; _RaskScopedBakeRan records that it did.
+
+      Both halves of the condition are needed. An incremental publish can legitimately skip the whole
+      build pass, and therefore the bake, while the previously published assets are still sitting in
+      wwwroot and perfectly correct — requiring the published side to ALSO be empty keeps that case quiet.
+    -->
+    <Error Condition=" '$(_RaskScopedBakeRan)' != 'true' AND '@(_RaskPublishedScopedAsset)' == '' "
+           Text="Rask: the scoped-asset bake did not run during this publish and $(PublishDir)wwwroot/_rask/a is empty, so any scoped CSS/JS this app has would 404 in the browser and any component relying on it would never initialise. The bake target (_RaskBakeScopedStaticWebAssets) is skipped when RaskWasm is not 'true' or when Rask.Wasm.Tasks.dll is missing next to Rask.Wasm.targets — check both, then clear $(IntermediateOutputPath) and publish again."/>
   </Target>
 
 </Project>

--- a/tests/Rask.Wasm.Tasks.Tests/PublishedScopedAssetGuardTests.cs
+++ b/tests/Rask.Wasm.Tasks.Tests/PublishedScopedAssetGuardTests.cs
@@ -1,0 +1,95 @@
+namespace Rask.Wasm.Tasks.Tests;
+
+/// <summary>
+///     Pins the publish-time guard in <c>Rask.Wasm.targets</c> that fails a WASM publish whose scoped
+///     assets were baked but never reached the published output.
+/// </summary>
+/// <remarks>
+///     The bake stages into <c>obj/…/rask-scoped</c> and registers computed static web assets in the build
+///     pass, trusting them to flow into the publish manifest. When that link breaks — most reliably by
+///     building the project in both <c>WasmBuildNative</c> modes through one <c>obj/</c> — the published
+///     bundle simply has no <c>/_rask/a/</c>, and nothing says so: the app builds, publishes, boots and
+///     renders, with only its scoped CSS/JS missing. For an app whose scoped JS owns something
+///     load-bearing that presents as a hung page, which is how #650/#652 cost two people a debugging
+///     session each.
+///     <para>
+///         There is no harness here for executing targets, so this asserts the guard's <i>shape</i>: that
+///         it still runs after publish, still compares staged against published rather than merely
+///         checking one of them, and is still scoped to Rask WASM projects. The behaviour itself was
+///         verified by running the target against a real publish in all three states — staged-but-not-
+///         published (errors), neither (passes), both (passes).
+///     </para>
+/// </remarks>
+public sealed class PublishedScopedAssetGuardTests
+{
+    private static readonly string _targets = File.ReadAllText(Path.Combine(
+        LocateRepoRoot(), "src", "Rask.Wasm", "build", "Rask.Wasm.targets"));
+
+    [Fact]
+    public void The_publish_is_verified_after_it_runs_for_rask_wasm_projects()
+    {
+        Assert.Contains("_RaskVerifyPublishedScopedAssets", _targets, StringComparison.Ordinal);
+
+        var target = TargetBody();
+        Assert.Contains("AfterTargets=\"Publish\"", target, StringComparison.Ordinal);
+        Assert.Contains("'$(RaskWasm)' == 'true'", target, StringComparison.Ordinal);
+    }
+
+    // The comparison is the whole point. A guard that only checked the published side would fail every
+    // project that legitimately has no scoped assets; one that only checked staging would never fire.
+    [Fact]
+    public void The_guard_compares_what_was_staged_against_what_shipped()
+    {
+        var target = TargetBody();
+
+        Assert.Contains("_RaskStagedScopedAsset", target, StringComparison.Ordinal);
+        Assert.Contains("_RaskPublishedScopedAsset", target, StringComparison.Ordinal);
+        // Staged side reads the bake's staging dir; published side reads the publish output.
+        Assert.Contains("$(_RaskVerifyStageDir)_rask\\a\\**\\*", target, StringComparison.Ordinal);
+        Assert.Contains("$(PublishDir)wwwroot\\_rask\\a\\**\\*", target, StringComparison.Ordinal);
+        Assert.Contains("rask-scoped", _targets, StringComparison.Ordinal);
+
+        // Errors only on staged-non-empty AND published-empty — both halves, or it misfires.
+        Assert.Contains("'@(_RaskStagedScopedAsset)' != '' AND '@(_RaskPublishedScopedAsset)' == ''",
+            target, StringComparison.Ordinal);
+    }
+
+    // The message is the deliverable: the failure it replaces named nothing at all.
+    [Fact]
+    public void The_error_says_what_broke_and_what_to_do()
+    {
+        var target = TargetBody();
+
+        Assert.Contains("<Error", target, StringComparison.Ordinal);
+        Assert.Contains("404", target, StringComparison.Ordinal);
+        Assert.Contains("WasmBuildNative", target, StringComparison.Ordinal);
+    }
+
+    private static string TargetBody()
+    {
+        const string open = "<Target Name=\"_RaskVerifyPublishedScopedAssets\"";
+        var start = _targets.IndexOf(open, StringComparison.Ordinal);
+        Assert.True(start >= 0, "The _RaskVerifyPublishedScopedAssets target is gone from Rask.Wasm.targets.");
+
+        var end = _targets.IndexOf("</Target>", start, StringComparison.Ordinal);
+        Assert.True(end > start, "The _RaskVerifyPublishedScopedAssets target is not closed.");
+        return _targets[start..end];
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate Rask.slnx walking up from {AppContext.BaseDirectory}");
+    }
+}

--- a/tests/Rask.Wasm.Tasks.Tests/PublishedScopedAssetGuardTests.cs
+++ b/tests/Rask.Wasm.Tasks.Tests/PublishedScopedAssetGuardTests.cs
@@ -65,6 +65,24 @@ public sealed class PublishedScopedAssetGuardTests
         Assert.Contains("WasmBuildNative", target, StringComparison.Ordinal);
     }
 
+    // The second guard, and the one that catches what actually happened in #650: the bake never ran, so
+    // the staging dir is absent and the staged-vs-published comparison sees nothing to compare. Without
+    // _RaskScopedBakeRan, "this project has no scoped assets" and "the bake was skipped" are the same
+    // observation — and the first guard stays silent through the second.
+    [Fact]
+    public void A_bake_that_never_ran_is_distinguished_from_a_project_with_nothing_to_bake()
+    {
+        Assert.Contains("<_RaskScopedBakeRan>true</_RaskScopedBakeRan>", _targets, StringComparison.Ordinal);
+
+        var target = TargetBody();
+        Assert.Contains("'$(_RaskScopedBakeRan)' != 'true' AND '@(_RaskPublishedScopedAsset)' == ''",
+            target, StringComparison.Ordinal);
+
+        // The published half is not optional: an incremental publish can skip the build pass (and so the
+        // bake) while the assets already sit correctly in wwwroot. Requiring both keeps that quiet.
+        Assert.Contains("_RaskBakeScopedStaticWebAssets", target, StringComparison.Ordinal);
+    }
+
     private static string TargetBody()
     {
         const string open = "<Target Name=\"_RaskVerifyPublishedScopedAssets\"";


### PR DESCRIPTION
Part of #650, **which stays open for the real fix.** The root cause is now known, and this makes the failure impossible to ship silently — but the cure belongs in a separate PR with packaging consequences.

## Root cause

`BakeScopedAssetsTask` inspects the built assemblies with **`Assembly.LoadFrom`**, and **MSBuild reuses worker nodes**. A publish that lands on a node which already loaded an assembly of the same simple name (from an earlier build in the same session) throws `FileLoadException`; the task caught it, logged at `MessageImportance.Low` and `continue`d — so it baked **nothing** and reported **success**. The published app then 404s on every scoped CSS/JS URL, which reads as a broken app rather than a broken build.

It is **node-state dependent, not a race**: once a reused node has loaded that assembly, every publish on it fails; with a cold pool, every publish passes. That single fact explains every dead end this took — "fresh worktree", "stale `obj`", "stale `bin`", "no-native build first". Each of them appeared to work exactly once, because we were all sampling whether the pool happened to be warm.

Measured here — identical inputs, same clean between each:

```
warm pool, as the gate runs it:   3 of 4 publishes baked ZERO
-nodeReuse:false:                 0 of 4 baked zero
```

The session on #650 measured 6/6 versus 0/6, and captured the binlog naming the `FileLoadException`.

## What ships here

1. **`-nodeReuse:false` on the gate's playground publish.** Measured, and honest about its scope: it protects that one call site. Anyone publishing a Rask WASM project twice in a warm MSBuild session — ordinary IDE development — still hits it.
2. **The catch is no longer silent.** The task fails when it baked zero **and** skipped an assembly because one of that name was already loaded. That combination is never a legitimate empty bake. Conditioned on both, so a bake that still produced its files cannot be broken by it.
3. **Two publish-time guards** (`_RaskVerifyPublishedScopedAssets`) for the adjacent shapes: baked-but-not-shipped, and never-baked-and-nothing-shipped. Verified firing against real publishes, with `samples/Rask.Example.Wasm.Jobs` — which legitimately bakes zero — staying quiet.
4. **`FailOnEmpty` documentation corrected.** It claimed to be "wired to `true` on the `dotnet run` hook"; nothing has ever set it. That claim is what led the other session to conclude the guard had failed to fire when there was no guard.

## What is NOT here

The real fix: a fresh `AssemblyLoadContext` per invocation, so a reused node cannot collide at all. `Rask.Wasm.Tasks` targets `netstandard2.0`, where `AssemblyLoadContext` is unavailable at compile time, so it needs multi-targeting plus a runtime-conditional `UsingTask` — packaging consequences that deserve their own PR. The other session is taking it; I'll review the packaging side.

(`MetadataLoadContext` is *not* the answer, for the record: the task doesn't merely read metadata, it invokes `RefreshAll`/`GetByHash` on the loaded assemblies.)

## Honesty about verification

**I have not seen guard #2 fire.** It is written from the binlog. I could not reproduce the poisoned-node state on demand, and there is a trap worth knowing for whoever tests the ALC change: **node reuse pins the task assembly too**, so a reused node keeps running the previous `Rask.Wasm.Tasks.dll` and hides your edit — `dotnet build-server shutdown` first, or you are measuring the old task.

Both `obj` and `bin` cleans are now described as cheap insurance rather than fixes. Both comments previously claimed otherwise, in this branch and on `main`.

## Testing

- `dotnet format` + warnings-as-errors + full unit suite green (320); `Rask.Wasm.Tasks.Tests` 14 green.
- Publish guards exercised against real publishes in four states.
- `-nodeReuse:false` measured 4/4 clean against 1/4 baseline.
