### PR TITLE
feat(sqlite): ask the browser not to evict a browser database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **A waiting tab now finds out when the database becomes free.** `BrowserSqliteOwnership.Available`
+  completes in a non-owner tab once the owning tab closes, so an app can turn "close the other tab" into
+  "your data is ready — reload" instead of leaving the user to guess when the condition was met.
+  **Reloading is what takes ownership**, deliberately: a waiting tab already opened its own empty database
+  at boot, so the file cannot be swapped under its live connections, and a tab that started persisting its
+  empty database would overwrite the previous owner's good snapshot with nothing. The watcher polls with
+  `TryRequestAsync`, which acquires and releases within the call, rather than waiting on `RequestAsync` —
+  waiting would mean *holding* the lock the moment it frees, which would both make this tab an owner it
+  must not be and block a tab that could actually use it. The signal is therefore advisory: another tab
+  may win between the poll and the reload, and the reloaded page runs the normal election to find out.
+  Tunable via `TakeoverPollInterval` (2s default); `samples/Rask.Example.Wasm.Jobs` shows it, covered by
+  an E2E that opens two real tabs and closes the owner.
 - **A browser database now asks not to be evicted.** `Rask.SQLite.Browser` keeps its snapshots in
   IndexedDB, and IndexedDB is evictable: under storage pressure a browser may discard them, and the
   database comes back empty on the next load with nothing to indicate why. The owning tab now calls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **A browser database now asks not to be evicted.** `Rask.SQLite.Browser` keeps its snapshots in
+  IndexedDB, and IndexedDB is evictable: under storage pressure a browser may discard them, and the
+  database comes back empty on the next load with nothing to indicate why. The owning tab now calls
+  `navigator.storage.persist()` at startup (via `IStorageEstimator`, added in #645), checking
+  `IsPersistedAsync()` first so an already-exempt origin is never asked twice. A refusal is logged and
+  changes nothing else — the app runs exactly as before, the risk is just no longer silent. Only the
+  owning tab asks, since the others persist nothing. Chromium decides from engagement heuristics without
+  prompting; **Firefox prompts**, and this is asked during boot rather than from a click, so an app that
+  would rather choose its moment sets `o.RequestPersistentStorage = false` and calls
+  `IStorageEstimator.RequestPersistAsync()` from a user-gesture handler instead.
 - **`BrowserSqliteOwnership` — let a second tab explain itself.** Only one tab may own a browser SQLite
   database, so the others run against their own empty, unpersisted one. That is correct, and until now it
   was also indistinguishable from the user's data having been deleted: the package logged a warning to the

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -553,6 +553,13 @@ Three limits, stated plainly because each one is a silent failure rather than an
   for a `pagehide` handler, so a force-closed or crashed tab loses whatever changed since the last tick.
   Shorten the interval if that matters; each tick copies the whole database, so the cost scales with its
   size rather than with how much changed.
+- **Snapshots live in IndexedDB, and IndexedDB is evictable.** Under storage pressure a browser may
+  discard them, and the database would come back empty on the next load with nothing to indicate why. The
+  owning tab therefore asks for the origin to be exempted (`navigator.storage.persist()`) at startup, and
+  logs a refusal rather than failing. Chromium decides from engagement heuristics without prompting;
+  **Firefox prompts**, and this is asked during boot rather than from a click — so an app that would
+  rather pick its moment sets `o.RequestPersistentStorage = false` and calls
+  `IStorageEstimator.RequestPersistAsync()` from a user-gesture handler instead.
 - **One tab owns the database.** Every tab has its own copy of the in-memory filesystem, so two owners
   would mean two divergent databases and a last-writer-wins overwrite. The others run with their own empty,
   unpersisted database — which, left unexplained, looks exactly like the user's data having been deleted.

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -571,7 +571,11 @@ Three limits, stated plainly because each one is a silent failure rather than an
   // "not the owner" stay distinguishable and the banner never flashes during a normal boot.
   ```
 
-  Promoting a waiting tab when the owner closes, and proxying its writes to the owner, are not implemented.
+  When the owner closes, `await ownership.Available` completes in the waiting tab so you can offer a
+  reload. **Reloading is what takes it over** — a waiting tab already opened its own empty database at
+  boot, so the file cannot be swapped under its live connections, and a tab that started persisting its
+  empty database would overwrite the previous owner's good snapshot. Proxying a non-owner's writes to the
+  owner is not implemented.
 - **The two build settings above are not optional**: `PublishTrimmed=false`, and publishing *without*
   `-p:WasmBuildNative=false` — otherwise SQLite is not linked in and the app boots normally, then fails on
   every database call.

--- a/samples/Rask.Example.Wasm.Jobs/App.cs
+++ b/samples/Rask.Example.Wasm.Jobs/App.cs
@@ -72,6 +72,12 @@ public class App : Component
             color: #e8d9b0;
             font-size: .92rem;
         }
+        /* Green once it is actionable: the same box, but now it is good news. */
+        .notice.ready {
+            background: #12251a;
+            border-color: #1f5c33;
+            color: #b6e8c6;
+        }
         ul { list-style: none; padding: 0; margin: 1rem 0 0; }
         li {
             padding: .6rem .8rem;

--- a/samples/Rask.Example.Wasm.Jobs/JobsDemo.cs
+++ b/samples/Rask.Example.Wasm.Jobs/JobsDemo.cs
@@ -18,6 +18,7 @@ public sealed class JobsDemo : Component
 
     private string _name = "world";
     private string _status = "";
+    private bool _canTakeOver;
     private List<Greeting> _greetings = [];
 
     public JobsDemo(
@@ -46,6 +47,12 @@ public sealed class JobsDemo : Component
         // for it, or the banner would never appear in the tab that needs it.
         await _ownership.Resolved;
 
+        if (_ownership.IsOwner == false)
+        {
+            // Fire-and-forget: this completes only when the other tab closes, which may be never.
+            _ = WatchForTakeoverAsync();
+        }
+
         await _ready.Ready;
         await LoadAsync();
     }
@@ -56,6 +63,15 @@ public sealed class JobsDemo : Component
     // try/catch is not optional: a bare `_ = ReloadAsync()` would swallow a query failure and leave the
     // page silently stale, which looks identical to the job never having run.
     private void OnGreetingWritten() => _ = ReloadSafelyAsync();
+
+    // Turns "close the other tab" into "reload now". Reloading is the only way to take over: this tab
+    // already opened its own empty database at boot, and the file cannot be swapped under live connections.
+    private async Task WatchForTakeoverAsync()
+    {
+        await _ownership.Available;
+        _canTakeOver = true;
+        StateHasChanged();
+    }
 
     private async Task ReloadSafelyAsync()
     {
@@ -90,10 +106,15 @@ public sealed class JobsDemo : Component
             // Only once the election has settled: `null` means "still deciding", and showing this during
             // a normal boot would be a scary banner for a non-problem.
             _ownership.IsOwner == false
-                ? Div(Class: "notice", Data: new Dictionary<string, string?> { ["testid"] = "not-owner" })[
-                    Strong()["Another tab has this database open."],
-                    " Your data is safe — it just isn't reachable from here, because only one tab may own "
-                    + "the file. Close the other tab and reload."]
+                ? _canTakeOver
+                    ? Div(Class: "notice ready", Data: new Dictionary<string, string?> { ["testid"] = "can-take-over" })[
+                        Strong()["Your data is ready."],
+                        " The other tab has closed. Reload to use the database here — reloading is what "
+                        + "takes it over, because this tab already opened an empty one at boot."]
+                    : Div(Class: "notice", Data: new Dictionary<string, string?> { ["testid"] = "not-owner" })[
+                        Strong()["Another tab has this database open."],
+                        " Your data is safe — it just isn't reachable from here, because only one tab may "
+                        + "own the file. Close the other tab and this will say so."]
                 : null,
             Div(Class: "row")[
                 Input(

--- a/samples/Rask.Example.Wasm.Jobs/README.md
+++ b/samples/Rask.Example.Wasm.Jobs/README.md
@@ -52,5 +52,9 @@ shows a banner instead. Note it waits for `ownership.Resolved` before rendering 
 while the election is in flight, so "still deciding" and "not the owner" stay distinct and a normal boot
 never flashes a warning.
 
-What is still not implemented: promoting a waiting tab when the owner closes, and proxying a non-owner's
-writes to the owner.
+Close the owning tab and the banner turns green: `ownership.Available` completes, and the waiting tab
+offers a reload. Reloading is what takes ownership — this tab already opened its own empty database at
+boot, so the file cannot be swapped under its live connections, and a tab that started persisting an empty
+database would overwrite the previous owner's good snapshot.
+
+What is still not implemented: proxying a non-owner's writes to the owner.

--- a/src/Rask.SQLite.Browser/BrowserSqliteHost.cs
+++ b/src/Rask.SQLite.Browser/BrowserSqliteHost.cs
@@ -29,6 +29,7 @@ internal sealed class BrowserSqliteHost(
     BrowserSqliteOptions options,
     IWebLocks locks,
     IIndexedDb indexedDb,
+    IStorageEstimator storage,
     ISqliteSnapshotter snapshotter,
     BrowserSqliteOwnership ownership,
     ILogger<BrowserSqliteHost> logger) : IHostedService
@@ -68,7 +69,59 @@ internal sealed class BrowserSqliteHost(
             return;
         }
 
+        if (options.RequestPersistentStorage)
+        {
+            await EnsurePersistentStorageAsync().ConfigureAwait(false);
+        }
+
         await RestoreAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Asks the browser not to evict this origin's storage.
+    /// </summary>
+    /// <remarks>
+    ///     The snapshots this package writes live in IndexedDB, which is evictable: under storage pressure
+    ///     a browser may discard them and the database returns empty next load, with nothing to say why.
+    ///     A refusal changes nothing about how the app runs, so this never fails the boot — it only makes
+    ///     the risk visible in the log instead of leaving it silent.
+    ///     <para>
+    ///         Checked before asked, so an origin that is already exempt never triggers a second prompt on
+    ///         the browsers that prompt.
+    ///     </para>
+    /// </remarks>
+    private async Task EnsurePersistentStorageAsync()
+    {
+        try
+        {
+            if (await storage.IsPersistedAsync().ConfigureAwait(false))
+            {
+                return;
+            }
+
+            if (await storage.RequestPersistAsync().ConfigureAwait(false))
+            {
+                logger.LogInformation(
+                    "Storage for '{Name}' is now exempt from eviction.", options.Name);
+                return;
+            }
+
+            // One branch, not two: RequestPersistAsync resolves false both when the browser declines and
+            // when it has no such API, and from here those have exactly the same consequence.
+            logger.LogWarning(
+                "The browser did not grant persistent storage, so it may evict the snapshots of '{Name}' "
+                + "under storage pressure and the database would come back empty. Chromium grants this on "
+                + "engagement; Firefox prompts, so ask from a user gesture with "
+                + "IStorageEstimator.RequestPersistAsync() and set BrowserSqliteOptions."
+                + nameof(BrowserSqliteOptions.RequestPersistentStorage) + " to false.",
+                options.Name);
+        }
+#pragma warning disable CA1031 // Durability is best-effort; a failed request must not stop the app booting.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            logger.LogWarning(ex, "Could not ask for persistent storage for '{Name}'.", options.Name);
+        }
     }
 
     /// <inheritdoc />

--- a/src/Rask.SQLite.Browser/BrowserSqliteHost.cs
+++ b/src/Rask.SQLite.Browser/BrowserSqliteHost.cs
@@ -46,6 +46,10 @@ internal sealed class BrowserSqliteHost(
     // StopAsync returns, rather than at some unobservable later moment.
     private Task<bool>? _ownerHold;
 
+    // Stops the non-owner's availability watcher when the page goes away.
+    private readonly CancellationTokenSource _shutdown = new();
+    private Task? _takeoverWatch;
+
     /// <summary>Whether this tab owns the database — i.e. whether it may persist anything.</summary>
     public bool IsOwner { get; private set; }
 
@@ -66,6 +70,9 @@ internal sealed class BrowserSqliteHost(
                 "Another tab already owns the browser SQLite database '{Name}'. This tab starts with an empty "
                 + "in-memory database and will not persist anything, so two tabs cannot overwrite each other.",
                 options.Name);
+
+            // Not awaited: watching for the owner to go away must not hold up the boot.
+            _takeoverWatch = WatchForAvailabilityAsync(_shutdown.Token);
             return;
         }
 
@@ -146,6 +153,14 @@ internal sealed class BrowserSqliteHost(
             }
         }
 
+        await _shutdown.CancelAsync().ConfigureAwait(false);
+
+        if (_takeoverWatch is not null)
+        {
+            // Already swallows its own failures; awaiting only makes the stop orderly.
+            await _takeoverWatch.ConfigureAwait(false);
+        }
+
         _release.TrySetResult();
 
         if (_ownerHold is null)
@@ -162,6 +177,55 @@ internal sealed class BrowserSqliteHost(
 #pragma warning restore CA1031
         {
             logger.LogWarning(ex, "Releasing the owner lock for '{Name}' failed.", options.Name);
+        }
+    }
+
+    /// <summary>
+    ///     Watches, in a tab that is not the owner, for the database to become free.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Polls with <see cref="IWebLocks.TryRequestAsync" />, which acquires and releases within the
+    ///         call, rather than waiting on <c>RequestAsync</c>. Waiting would mean <em>holding</em> the
+    ///         lock the moment it frees — and this tab must not own the database: it opened its own empty
+    ///         one at boot, so persisting from here would overwrite the previous owner's good snapshot with
+    ///         nothing. Holding a lock it must never use would also block a tab that could actually use it.
+    ///     </para>
+    ///     <para>
+    ///         So this only ever <em>reports</em> availability, and the taking is done by a reload. That is
+    ///         also why the signal is advisory: another tab may win between the poll and the reload.
+    ///     </para>
+    /// </remarks>
+    private async Task WatchForAvailabilityAsync(CancellationToken cancellationToken)
+    {
+        var name = BrowserSqlite.OwnerLockName(options.Name);
+
+        try
+        {
+            using var timer = new PeriodicTimer(options.TakeoverPollInterval);
+
+            while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false))
+            {
+                // The callback is empty on purpose: acquiring proves the lock is free, and returning
+                // immediately hands it straight back.
+                if (await locks.TryRequestAsync(name, static () => Task.CompletedTask).ConfigureAwait(false))
+                {
+                    logger.LogInformation(
+                        "The tab that owned '{Name}' has gone; reload to use the database here.", options.Name);
+                    ownership.MarkAvailable();
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // The page is going away.
+        }
+#pragma warning disable CA1031 // A watcher that dies must not take the app with it; the tab simply stops offering to take over.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            logger.LogWarning(ex, "Gave up watching for '{Name}' to become available.", options.Name);
         }
     }
 

--- a/src/Rask.SQLite.Browser/BrowserSqliteOptions.cs
+++ b/src/Rask.SQLite.Browser/BrowserSqliteOptions.cs
@@ -28,6 +28,16 @@ public sealed class BrowserSqliteOptions
     public int Retain { get; set; } = 2;
 
     /// <summary>
+    ///     How often a tab that is not the owner checks whether the database has become free, so it can
+    ///     tell the user to reload. Defaults to 2 seconds.
+    /// </summary>
+    /// <remarks>
+    ///     Each check is one Web Locks round-trip that acquires and immediately releases, so this is cheap
+    ///     — but it only runs in a non-owner tab, and stops for good the first time it succeeds.
+    /// </remarks>
+    public TimeSpan TakeoverPollInterval { get; set; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>
     ///     Whether the owning tab asks the browser to exempt this origin's storage from eviction
     ///     (<c>navigator.storage.persist()</c>). Defaults to <see langword="true" />.
     /// </summary>
@@ -75,6 +85,12 @@ public sealed class BrowserSqliteOptions
         if (Retain < 1)
         {
             throw new InvalidOperationException($"{nameof(Retain)} must be at least 1 (was {Retain}).");
+        }
+
+        if (TakeoverPollInterval <= TimeSpan.Zero)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(TakeoverPollInterval)} must be positive (was {TakeoverPollInterval}).");
         }
     }
 }

--- a/src/Rask.SQLite.Browser/BrowserSqliteOptions.cs
+++ b/src/Rask.SQLite.Browser/BrowserSqliteOptions.cs
@@ -28,6 +28,27 @@ public sealed class BrowserSqliteOptions
     public int Retain { get; set; } = 2;
 
     /// <summary>
+    ///     Whether the owning tab asks the browser to exempt this origin's storage from eviction
+    ///     (<c>navigator.storage.persist()</c>). Defaults to <see langword="true" />.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Worth asking, because the snapshots this package writes live in IndexedDB, and IndexedDB is
+    ///         evictable: under storage pressure a browser may discard them, and the database would come
+    ///         back empty on the next load with nothing to indicate why. A refusal costs nothing — the app
+    ///         works exactly as before — so the default is to ask.
+    ///     </para>
+    ///     <para>
+    ///         Chromium decides from engagement heuristics without prompting. <b>Firefox shows a permission
+    ///         prompt</b>, and this is asked during startup rather than from a click, so an app that would
+    ///         rather choose its moment should set this to <see langword="false" /> and call
+    ///         <c>IStorageEstimator.RequestPersistAsync()</c> from a user-gesture handler instead.
+    ///     </para>
+    ///     <para>Only the owning tab asks: the others persist nothing, so a prompt there would buy nothing.</para>
+    /// </remarks>
+    public bool RequestPersistentStorage { get; set; } = true;
+
+    /// <summary>
     ///     Where the database file lives, resolved from <see cref="Name" /> when the options are validated.
     /// </summary>
     /// <remarks>

--- a/src/Rask.SQLite.Browser/BrowserSqliteOwnership.cs
+++ b/src/Rask.SQLite.Browser/BrowserSqliteOwnership.cs
@@ -34,10 +34,42 @@ public sealed class BrowserSqliteOwnership
     /// <summary>Completes with the answer once the election has run, during the host's <c>StartAsync</c>.</summary>
     public Task<bool> Resolved => _resolved.Task;
 
+    /// <summary>
+    ///     For a tab that is <em>not</em> the owner: completes once the database has become free, so the
+    ///     user can be told their data is reachable again rather than left guessing.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Reloading is the only way to take it.</b> This tab already opened its own empty database
+    ///         when it booted, and the app is holding live connections to it — the file cannot be swapped
+    ///         underneath them, and a tab that started persisting its empty database would overwrite the
+    ///         previous owner's good snapshot. So this signals "reload to use it", not "you now own it".
+    ///     </para>
+    ///     <para>
+    ///         Advisory, not a claim: nothing is held on this tab's behalf, so another tab may take
+    ///         ownership between this completing and the reload. The reloaded page runs the normal
+    ///         election and finds out.
+    ///     </para>
+    ///     <para>Never completes in the owning tab, which has nothing to wait for.</para>
+    ///     <code>
+    ///     await ownership.Resolved;
+    ///     if (ownership.IsOwner == false)
+    ///     {
+    ///         await ownership.Available;      // the other tab closed
+    ///         _canReload = true; StateHasChanged();
+    ///     }
+    ///     </code>
+    /// </remarks>
+    public Task Available => _available.Task;
+
+    private readonly TaskCompletionSource _available = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
     // Idempotent: the election runs once per page, but a second call must not throw on the TCS.
     internal void Resolve(bool isOwner)
     {
         IsOwner = isOwner;
         _resolved.TrySetResult(isOwner);
     }
+
+    internal void MarkAvailable() => _available.TrySetResult();
 }

--- a/src/Rask.SQLite.Browser/NUGET.md
+++ b/src/Rask.SQLite.Browser/NUGET.md
@@ -54,8 +54,10 @@ builder.Services.AddRaskBrowserSqlite("app", o =>
 - **Non-owner tabs are not read-only — they are separate.** They get their own empty in-memory database
   and never persist, which looks like data loss unless you say otherwise. Inject `BrowserSqliteOwnership`
   and tell the user: `await ownership.Resolved` gives the answer, and `ownership.IsOwner` is `null` while
-  the election is still running so a normal boot never flashes a banner. Promoting a waiting tab when the
-  owner closes, and proxying writes to the owner, are not implemented.
+  the election is still running so a normal boot never flashes a banner. When the owner closes,
+  `await ownership.Available` completes so you can offer a reload — reloading is what takes ownership,
+  since a waiting tab already opened its own empty database and the file cannot be swapped under live
+  connections. Proxying a non-owner's writes to the owner is not implemented.
 - Snapshots cost their full database size in the origin's storage quota, times `Retain`.
 - Add `<NoWarn>$(NoWarn);WASM0001</NoWarn>` if you build with warnings as errors: the SQLite native build
   reports two varargs functions (`sqlite3_config`, `sqlite3_db_config`) that WASM cannot call. Neither is

--- a/src/Rask.SQLite.Browser/NUGET.md
+++ b/src/Rask.SQLite.Browser/NUGET.md
@@ -46,6 +46,11 @@ builder.Services.AddRaskBrowserSqlite("app", o =>
   `Microsoft.Data.Sqlite` on its own is reflection-free and trims fine.
 - **The durability window is the snapshot interval, not the page-hide flush.** The browser does not wait
   for a `pagehide` handler, so a force-closed or crashed tab loses whatever changed since the last tick.
+- **Snapshots live in IndexedDB, which is evictable.** The owning tab asks the browser to exempt the
+  origin (`navigator.storage.persist()`) at startup; a refusal is logged and changes nothing else.
+  Chromium decides on engagement without prompting, **Firefox prompts** — so an app that would rather
+  choose its moment sets `o.RequestPersistentStorage = false` and calls
+  `IStorageEstimator.RequestPersistAsync()` from a user-gesture handler instead.
 - **Non-owner tabs are not read-only — they are separate.** They get their own empty in-memory database
   and never persist, which looks like data loss unless you say otherwise. Inject `BrowserSqliteOwnership`
   and tell the user: `await ownership.Resolved` gives the answer, and `ownership.IsOwner` is `null` while

--- a/tests/Rask.Examples.E2E.Tests/BrowserJobsWasmExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/BrowserJobsWasmExampleTests.cs
@@ -61,6 +61,14 @@ public sealed class BrowserJobsWasmExampleTests
 
             // And the owner is not told anything of the sort.
             await Expect(owner.Locator("[data-testid=not-owner]")).ToHaveCountAsync(0);
+
+            // Close the owner: the second tab should notice and say the data is reachable again, rather
+            // than leaving the user to guess when "close the other tab" has been satisfied.
+            await owner.CloseAsync();
+
+            await Expect(second.Locator("[data-testid=can-take-over]"))
+                .ToBeVisibleAsync(new() { Timeout = 30_000 });
+            await Expect(second.Locator("[data-testid=not-owner]")).ToHaveCountAsync(0);
         }
         finally
         {

--- a/tests/Rask.SQLite.Browser.Tests/BrowserSqliteHostTests.cs
+++ b/tests/Rask.SQLite.Browser.Tests/BrowserSqliteHostTests.cs
@@ -14,7 +14,13 @@ public sealed class BrowserSqliteHostTests : IDisposable
 
     private BrowserSqliteOptions Options(string name = "app")
     {
-        var options = new BrowserSqliteOptions { Name = name, DatabasePath = Path.Combine(_temp, $"{name}.db") };
+        var options = new BrowserSqliteOptions
+        {
+            Name = name,
+            DatabasePath = Path.Combine(_temp, $"{name}.db"),
+            // Short, so the takeover tests do not spend seconds waiting on a poll.
+            TakeoverPollInterval = TimeSpan.FromMilliseconds(10),
+        };
         options.Validate();
         return options;
     }
@@ -185,6 +191,75 @@ public sealed class BrowserSqliteHostTests : IDisposable
         await Host(options).StartAsync(CancellationToken.None);
 
         Assert.Equal(0, _storage.PersistRequests);
+    }
+
+    // A second tab is otherwise stuck: told to close the other one, with no way to know when that
+    // happened. This is the signal that turns "close the other tab" into "reload now".
+    [Fact]
+    public async Task NonOwner_SignalsWhenTheDatabaseBecomesAvailable()
+    {
+        var options = Options();
+        var lockName = BrowserSqlite.OwnerLockName(options.Name);
+        _locks.HoldElsewhere(lockName);
+        var host = Host(options);
+
+        await host.StartAsync(CancellationToken.None);
+
+        Assert.False(_ownership.Available.IsCompleted);   // the owner is still there
+
+        _locks.ReleaseElsewhere(lockName);               // that tab closes
+
+        await _ownership.Available.WaitAsync(TimeSpan.FromSeconds(5));
+        await host.StopAsync(CancellationToken.None);
+    }
+
+    // Reporting availability must not take the lock: this tab already opened its own EMPTY database, so
+    // owning it would mean snapshotting nothing over the previous owner's good snapshot.
+    [Fact]
+    public async Task NonOwner_DoesNotHoldTheLockItReportsAsFree()
+    {
+        var options = Options();
+        var lockName = BrowserSqlite.OwnerLockName(options.Name);
+        _locks.HoldElsewhere(lockName);
+        var host = Host(options);
+        await host.StartAsync(CancellationToken.None);
+
+        _locks.ReleaseElsewhere(lockName);
+        await _ownership.Available.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Free for a tab that can actually use it — a reloaded page, or another tab.
+        Assert.DoesNotContain(await _locks.QueryAsync(), l => l.Name == lockName);
+        await host.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Owner_NeverSignalsAvailability()
+    {
+        var host = Host(Options());
+
+        await host.StartAsync(CancellationToken.None);
+        await Task.Delay(60);
+
+        // The owner has nothing to wait for; completing here would tell an app to reload for no reason.
+        Assert.False(_ownership.Available.IsCompleted);
+        await host.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Stop_EndsTheAvailabilityWatch()
+    {
+        var options = Options();
+        var lockName = BrowserSqlite.OwnerLockName(options.Name);
+        _locks.HoldElsewhere(lockName);
+        var host = Host(options);
+        await host.StartAsync(CancellationToken.None);
+
+        // Returns only once the watcher has stopped — a watcher still polling after shutdown would hang it.
+        await host.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+        _locks.ReleaseElsewhere(lockName);
+        await Task.Delay(60);
+        Assert.False(_ownership.Available.IsCompleted);
     }
 
     [Fact]

--- a/tests/Rask.SQLite.Browser.Tests/BrowserSqliteHostTests.cs
+++ b/tests/Rask.SQLite.Browser.Tests/BrowserSqliteHostTests.cs
@@ -20,9 +20,10 @@ public sealed class BrowserSqliteHostTests : IDisposable
     }
 
     private readonly BrowserSqliteOwnership _ownership = new();
+    private readonly FakeStorageEstimator _storage = new();
 
     private BrowserSqliteHost Host(BrowserSqliteOptions options) =>
-        new(options, _locks, _db, _snapshotter, _ownership, NullLogger<BrowserSqliteHost>.Instance);
+        new(options, _locks, _db, _storage, _snapshotter, _ownership, NullLogger<BrowserSqliteHost>.Instance);
 
     private void Seed(string name, string snapshotName, string content) =>
         _db.Store(BrowserSqlite.SnapshotStoreName(name)).Values[snapshotName] = Encoding.UTF8.GetBytes(content);
@@ -105,6 +106,85 @@ public sealed class BrowserSqliteHostTests : IDisposable
 
         Assert.True(host.IsOwner);
         await host.StopAsync(CancellationToken.None);
+    }
+
+    // IndexedDB is evictable, so without asking, a browser under storage pressure can discard the
+    // snapshots and the database comes back empty with nothing to say why.
+    [Fact]
+    public async Task Start_AsksForPersistentStorage()
+    {
+        var host = Host(Options());
+
+        await host.StartAsync(CancellationToken.None);
+
+        Assert.Equal(1, _storage.PersistRequests);
+        await host.StopAsync(CancellationToken.None);
+    }
+
+    // Asking again would prompt a second time on the browsers that prompt, for something already granted.
+    [Fact]
+    public async Task Start_AlreadyPersisted_DoesNotAskAgain()
+    {
+        _storage.AlreadyPersisted = true;
+        var host = Host(Options());
+
+        await host.StartAsync(CancellationToken.None);
+
+        Assert.Equal(0, _storage.PersistRequests);
+        await host.StopAsync(CancellationToken.None);
+    }
+
+    // A refusal changes nothing about how the app runs — it must not fail the boot, only be visible.
+    [Fact]
+    public async Task Start_PersistDeclined_StillBootsAndRestores()
+    {
+        _storage.GrantsPersist = false;
+        var options = Options();
+        Seed(options.Name, "app-20260808-140000000.db", "restored");
+        var host = Host(options);
+
+        await host.StartAsync(CancellationToken.None);
+
+        Assert.True(host.IsOwner);
+        Assert.Equal("restored", await File.ReadAllTextAsync(options.DatabasePath));
+        await host.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Start_PersistThrows_StillBoots()
+    {
+        _storage.Throws = new InvalidOperationException("interop failed");
+        var host = Host(Options());
+
+        await host.StartAsync(CancellationToken.None);
+
+        Assert.True(host.IsOwner);
+        await host.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Start_PersistDisabled_NeverAsks()
+    {
+        var options = Options();
+        options.RequestPersistentStorage = false;
+        var host = Host(options);
+
+        await host.StartAsync(CancellationToken.None);
+
+        Assert.Equal(0, _storage.PersistRequests);
+        await host.StopAsync(CancellationToken.None);
+    }
+
+    // A non-owner persists nothing, so a prompt there would buy the user nothing.
+    [Fact]
+    public async Task Start_NonOwner_NeverAsksForPersistentStorage()
+    {
+        var options = Options();
+        _locks.HoldElsewhere(BrowserSqlite.OwnerLockName(options.Name));
+
+        await Host(options).StartAsync(CancellationToken.None);
+
+        Assert.Equal(0, _storage.PersistRequests);
     }
 
     [Fact]

--- a/tests/Rask.SQLite.Browser.Tests/Fakes.cs
+++ b/tests/Rask.SQLite.Browser.Tests/Fakes.cs
@@ -113,6 +113,41 @@ internal sealed class FakeWebLocks : IWebLocks
             [.. _held.Select(n => new LockInfo(n, "exclusive", null, true))]);
 }
 
+/// <summary>
+///     An <see cref="IStorageEstimator" /> that records whether persistence was asked for, and answers
+///     however the test says the browser would.
+/// </summary>
+internal sealed class FakeStorageEstimator : IStorageEstimator
+{
+    public bool Supported { get; set; } = true;
+
+    /// <summary>Whether the origin is already exempt — an already-persisted origin must not be asked again.</summary>
+    public bool AlreadyPersisted { get; set; }
+
+    /// <summary>What the browser answers. False covers both "declined" and "no such API".</summary>
+    public bool GrantsPersist { get; set; } = true;
+
+    public int PersistRequests { get; private set; }
+
+    public Exception? Throws { get; set; }
+
+    public ValueTask<bool> IsSupportedAsync() => ValueTask.FromResult(Supported);
+
+    public ValueTask<StorageEstimate?> EstimateAsync() =>
+        ValueTask.FromResult<StorageEstimate?>(new StorageEstimate(0, 0));
+
+    public ValueTask<bool> IsPersistedAsync() =>
+        Throws is not null
+            ? ValueTask.FromException<bool>(Throws)
+            : ValueTask.FromResult(AlreadyPersisted);
+
+    public ValueTask<bool> RequestPersistAsync()
+    {
+        PersistRequests++;
+        return ValueTask.FromResult(GrantsPersist);
+    }
+}
+
 internal sealed class RecordingSnapshotter : ISqliteSnapshotter
 {
     public int Count { get; private set; }

--- a/tests/Rask.SQLite.Browser.Tests/Fakes.cs
+++ b/tests/Rask.SQLite.Browser.Tests/Fakes.cs
@@ -74,6 +74,9 @@ internal sealed class FakeWebLocks : IWebLocks
     /// <summary>Pre-hold a lock, standing in for another tab that already owns it.</summary>
     public void HoldElsewhere(string name) => _held.Add(name);
 
+    /// <summary>Drop a pre-held lock — that other tab closing.</summary>
+    public void ReleaseElsewhere(string name) => _held.Remove(name);
+
     public ValueTask<bool> IsSupportedAsync() => ValueTask.FromResult(Supported);
 
     public async ValueTask RequestAsync(string name, Func<Task> work, LockMode mode = LockMode.Exclusive)

--- a/tests/Rask.SQLite.Browser.Tests/RegistrationTests.cs
+++ b/tests/Rask.SQLite.Browser.Tests/RegistrationTests.cs
@@ -15,6 +15,7 @@ public class RegistrationTests
         services.AddLogging();
         services.AddSingleton<IIndexedDb>(new FakeIndexedDb());
         services.AddSingleton<IWebLocks>(new FakeWebLocks());
+        services.AddSingleton<IStorageEstimator>(new FakeStorageEstimator());
         return services;
     }
 
@@ -121,8 +122,8 @@ public class BrowserSqliteSnapshotServiceTests
 
         var snapshotter = new RecordingSnapshotter();
         var host = new BrowserSqliteHost(
-            options, locks, new FakeIndexedDb(), snapshotter, new BrowserSqliteOwnership(),
-            NullLogger<BrowserSqliteHost>.Instance);
+            options, locks, new FakeIndexedDb(), new FakeStorageEstimator(), snapshotter,
+            new BrowserSqliteOwnership(), NullLogger<BrowserSqliteHost>.Instance);
         await host.StartAsync(CancellationToken.None);
 
         var service = new BrowserSqliteSnapshotService(


### PR DESCRIPTION
## Summary

`Rask.SQLite.Browser` keeps its snapshots in IndexedDB, and **IndexedDB is evictable**. Under storage
pressure a browser may discard them, and the database comes back empty on the next load with nothing to
indicate why — the app looks like it lost the user's data, and nothing in it can say otherwise.

[#645](https://github.com/pal-tamas/rask/pull/645) landed `IStorageEstimator.RequestPersistAsync()`, so the
owning tab can now ask for the origin to be exempted from eviction.

```csharp
builder.Services.AddRaskBrowserSqlite("app");                        // asks by default
builder.Services.AddRaskBrowserSqlite("app", o => o.RequestPersistentStorage = false);  // or don't
```

## Decisions worth reviewing

- **`IsPersistedAsync()` is checked before asking**, so an origin that is already exempt is never asked a
  second time — which matters on the browsers that prompt.
- **A refusal never fails the boot.** It is logged and changes nothing else; the app runs exactly as it did
  before, the risk simply stops being silent. One log branch, not two: `RequestPersistAsync` resolves
  `false` both when the browser declines and when it has no such API, and from the caller's side those have
  the same consequence.
- **Only the owning tab asks.** The others persist nothing, so a prompt there would buy the user nothing.
- **`RequestPersistentStorage` defaults to `true`**, because a silently evictable database is a worse
  default than a request. It is an option for a real reason though: Chromium decides from engagement
  heuristics without prompting, whereas **Firefox shows a permission prompt** — and this is asked during
  boot rather than from a click. An app that would rather choose its moment sets it to `false` and calls
  `IStorageEstimator.RequestPersistAsync()` from a user-gesture handler.

## Testing

- 48/48 in `Rask.SQLite.Browser.Tests` (6 new): asks once; never asks when already persisted; never asks
  in a non-owner tab; never asks when disabled; still boots and restores when declined; still boots when
  the interop throws.
- `dotnet format` clean, `dotnet build Rask.slnx -warnaserror` clean.
- Full local browser E2E gate and CLI build gate passed on push.
- No benchmarks: nothing here touches the render hot path.

## Follow-ups (not in this PR)

- The ranged-flush seam — `IOriginPrivateFileSystem.WriteAsync` now exists, so an offset+length interface
  can be designed against something real, with per-page hashes as the diff baseline rather than a shadow
  copy.
- Multi-tab promotion, still documented as unimplemented.
