### PR TITLE
fix(docs): render GitHub's heading anchors, and guard that doc links resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,32 @@ them until tagged releases begin.
   `BakeScopedAssetsTask.FailOnEmpty` could not have caught this and — despite its own documentation
   claiming otherwise — has never been wired to anything: it fires only when the bake *runs* and writes
   zero, whereas here the bake runs perfectly well and the break is downstream of it. Its docs now say so.
+- **62 in-page anchors across the docs sent readers to the top of the page instead of the section they
+  named.** The docs under `docs/` are authored and reviewed on GitHub, and their `#anchor` links are
+  written against GitHub's heading slugs — but the guides site rendered Markdig's, which differ wherever
+  a heading holds punctuation. GitHub *deletes* the character and keeps the spaces either side of it, so
+  `## Rask db — migrations` becomes `#rask-db--migrations`, while Markdig collapses the run to
+  `#rask-db-migrations`; leading numbers survive on GitHub (`#1-two-way-binding`) and are stripped by
+  Markdig. Every one of those links still navigated, which is why none of them looked broken.
+  Heading ids are now stamped GitHub-style, so the same anchor resolves in both places a doc is read.
+  Markdig's own `AutoIdentifierOptions.GitHub` does **not** close this gap — it produces identical output
+  to the default, verified — so the slug is ours. The on-this-page rail reads ids from the same pipeline
+  and follows automatically.
+  Five anchors were genuinely dead rather than mis-slugged (a heading reworded, one that never existed)
+  and are repointed at the sections they meant.
+
+### Added
+- **The docs suite now checks that links *inside* a doc resolve, not just that every doc is reachable.**
+  `DocsIndexTests` guarded reachability from `docs/README.md` and `GuidesTests` guarded catalogue parity;
+  neither looked at whether a link written in a doc pointed at anything, so both misses above were found
+  by a person reading rather than by a test. `DocsLinkTests` adds three checks over every `docs/**/*.md`:
+  a relative `*.md` link resolves to a file that exists; it resolves to a doc the app can actually serve
+  (the renderer rewrites `dir/x.md` to the SPA route `/guides/x` by bare leaf, so a doc present on disk
+  but not embedded under that slug is a link a reader can follow to a 404); and an `#anchor` — in the
+  same doc or another — names a real heading. Anchors are checked against the ids Markdig actually
+  stamps, by parsing with the renderer's own pipeline rather than a second slugifier that could disagree
+  with the first. External `http(s)` links are left alone: checking them needs the network and would buy
+  flakiness for no benefit.
 
 ### Fixed
 - **Playground: picking a chapter or an example before the editor had mounted silently kept the starter

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -104,7 +104,7 @@ document-unique and every `aria-describedby`/`for` resolves to the right field.
 
 Building your own control from the core `Input`/`ValidationMessage` primitives? Mirror the same three
 attributes: `Aria: new() { ["invalid"] = "true", ["describedby"] = errorId }` on the control, and render
-the message in a `Div(Id: errorId, Role: "alert")`. See [forms.md](forms-validation.md#accessible-validation).
+the message in a `Div(Id: errorId, Role: "alert")`. See [forms-validation.md](forms-validation.md).
 
 ## Focus trapping (overlays)
 

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -156,7 +156,7 @@ mistake, the rule notes the ID.
 - **A faulted async hook is silent** — the framework logs to `Console.Error` and does *not* re-render
   or surface an error. The classic symptom is a component stuck on its loading placeholder. Wrap
   risky hook work in `try/catch` to render your own error state, or use an `ErrorBoundary`. See
-  [lifecycle → gotchas](lifecycle.md#gotcha-faulted-async-hooks-are-silent).
+  [lifecycle → gotchas](lifecycle.md#gotcha-a-faulted-async-hook-takes-the-page-not-the-component).
 - **Never `StateHasChanged()` in unmount** — the component is already leaving the tree, so it's a
   no-op by design. Use `OnUnmount` to tear down subscriptions, nothing more. Compose nested layouts
   with `[ParentRoute]` + `Outlet()`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -252,7 +252,7 @@ audit stamps + a domain-events buffer), so a generated `feature` needs **EF Core
 `Rask.Bootstrap` / the validation library; pass `--no-restore` to skip). It then **writes the DI
 registration** (`AddRaskCqrs()` + `AddRaskData()` + `AddDbContextFactory` with the interceptors) into
 `Program.cs` for you — falling back to printing it if it can't find the file — and prints the migration
-to create and apply with [`rask db`](#rask-db--ef-core-migrations) before it works.
+to create and apply with [`rask db`](#rask-db--migrations-and-getting-the-database-in-and-out) before it works.
 
 Every command has short aliases: `rask g` = `rask generate`, and `g f` / `g c` / `g p` scaffold a
 feature / component / page.

--- a/docs/mail.md
+++ b/docs/mail.md
@@ -52,7 +52,7 @@ protected override void OnModelCreating(ModelBuilder modelBuilder)
 }
 ```
 
-> **Skip the wiring:** [`rask generate email <Name>`](cli.md#rask-generate--scaffold-into-a-project) scaffolds
+> **Skip the wiring:** [`rask generate email <Name>`](cli.md#rask-generate--scaffold-code) scaffolds
 > the body component **and** does both of the above for you — it registers `AddRaskMail<Ctx>` in `Program.cs`
 > and adds `modelBuilder.AddRaskMail()` to your context (when it finds a single `DbContext`, or with
 > `--context <Name>`). You're left with just the SMTP config and the migration.

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -55,7 +55,7 @@ your user count.** Splitting a 200-row grid into pages of 20 buys more than a bi
 | --- | --- |
 | Brief network blip | Nothing. The socket reconnects against the intact session within `SessionGracePeriod` (30 s). |
 | Tab backgrounded past the grace period | The session is gone, but the page is [rebuilt from the client's resume record](configuration.md#surviving-a-restart-or-a-redeploy) — same route, whatever state the app declared. |
-| Deploy or restart | The departing host [hands clients over](deployment.md#connected-clients-are-handed-over-not-dropped): they reconnect immediately and rebuild, rather than sitting out a backoff and reloading. |
+| Deploy or restart | The departing host [hands clients over](deployment.md#the-shutdown-ladder): they reconnect immediately and rebuild, rather than sitting out a backoff and reloading. |
 | Host at capacity | New sessions get `503` + `Retry-After`; `/health` reports Degraded at 80% of `MaxSessions` so an orchestrator sheds first. |
 | Host killed outright | Whatever was in flight is lost. Sessions rebuild on the next reconnect if their record is still valid. |
 

--- a/samples/Rask.Example.Shared/Shared/Markdown.cs
+++ b/samples/Rask.Example.Shared/Shared/Markdown.cs
@@ -24,14 +24,80 @@ namespace Rask.Example.Shared;
 // docs/*.md renders on GitHub, so the guides stay dual-purpose (repo docs + on-site).
 public sealed partial class Markdown : Component
 {
-    // AutoIdentifiers gives every heading a stable id (anchor links); the advanced extensions cover
-    // tables, fenced code, task lists, etc. — the Markdown the guides actually use. Thread-safe, reused.
+    // The advanced extensions cover tables, fenced code, task lists, etc. — the Markdown the guides
+    // actually use — and bring AutoIdentifiers, which gives every heading an id. Thread-safe, reused.
     // Internal so GuideChrome extracts headings through the *same* pipeline, guaranteeing the ids it
-    // links to match the ids Markdig stamps on the rendered <h2>/<h3>.
-    internal static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
-        .UseAdvancedExtensions()
-        .UseAutoIdentifiers()
-        .Build();
+    // links to match the ids stamped on the rendered <h2>/<h3>.
+    //
+    // The ids are then RESTAMPED GitHub-style. The docs under docs/ are authored and reviewed on GitHub,
+    // and their in-page links are written against GitHub's anchors — which differ from Markdig's wherever
+    // a heading holds punctuation, because GitHub deletes the character and keeps the space around it
+    // ("Context & DI" → context--di) while Markdig collapses the run (context-di). Rendering Markdig's ids
+    // meant 62 links across the docs still navigated and silently landed the reader at the top of the page.
+    // Markdig's own AutoIdentifierOptions.GitHub does NOT close this gap (verified: identical output), so
+    // the slug is ours. Subscribed AFTER UseAdvancedExtensions so this runs after AutoIdentifiers and wins.
+    internal static readonly MarkdownPipeline Pipeline = BuildPipeline();
+
+    private static MarkdownPipeline BuildPipeline()
+    {
+        var builder = new MarkdownPipelineBuilder().UseAdvancedExtensions();
+        builder.DocumentProcessed += StampGitHubHeadingIds;
+        return builder.Build();
+    }
+
+    private static void StampGitHubHeadingIds(MarkdownDocument document)
+    {
+        // Per document, because GitHub disambiguates repeats within one page.
+        var seen = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var heading in document.Descendants<HeadingBlock>())
+        {
+            var slug = GitHubSlug(InlineText(heading.Inline));
+            if (slug.Length == 0)
+            {
+                continue;
+            }
+
+            if (seen.TryGetValue(slug, out var count))
+            {
+                seen[slug] = count + 1;
+                slug = $"{slug}-{count}";
+            }
+            else
+            {
+                seen[slug] = 1;
+            }
+
+            heading.GetAttributes().Id = slug;
+        }
+    }
+
+    /// <summary>
+    /// GitHub's heading slug: lower-case, drop everything that isn't a letter, digit, hyphen or
+    /// underscore, and turn each remaining whitespace character into a hyphen.
+    /// </summary>
+    /// <remarks>
+    /// The load-bearing detail is what it does NOT do: it never collapses the hyphens that result. A
+    /// dropped "&amp;" or em dash leaves the spaces on either side of it, so they become two hyphens —
+    /// which is why the docs are full of anchors like <c>#rask-db--ef-core-migrations</c>. Leading digits
+    /// survive too (<c>#1-two-way-binding</c>), where Markdig strips them.
+    /// </remarks>
+    private static string GitHubSlug(string headingText)
+    {
+        var sb = new StringBuilder(headingText.Length);
+        foreach (var ch in headingText)
+        {
+            if (char.IsWhiteSpace(ch))
+            {
+                sb.Append('-');
+            }
+            else if (char.IsLetterOrDigit(ch) || ch is '-' or '_')
+            {
+                sb.Append(char.ToLowerInvariant(ch));
+            }
+        }
+
+        return sb.ToString();
+    }
 
     private static readonly ConcurrentDictionary<string, string> HtmlCache = new(StringComparer.Ordinal);
 

--- a/tests/Rask.Example.Shared.Tests/Guides/GuideChromeTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Guides/GuideChromeTests.cs
@@ -40,6 +40,28 @@ public sealed class GuideChromeTests
         Assert.Equal("Programmatic navigation — Navigator", Assert.Single(headings).Text);
     }
 
+    [Theory]
+    // The docs are authored on GitHub and their in-page links are written against GitHub's anchors, so
+    // the rendered ids have to be GitHub's. The distinguishing behaviour is that a dropped character
+    // leaves the spaces either side of it — "db — migrations" becomes db--migrations, not db-migrations —
+    // and that a leading number survives. Markdig's own slug does neither, which silently sent readers to
+    // the top of the page for 62 links across docs/.
+    [InlineData("## `rask db` — migrations, and getting it out", "rask-db--migrations-and-getting-it-out")]
+    [InlineData("## Context & dependency injection", "context--dependency-injection")]
+    [InlineData("## 1. Two-way binding", "1-two-way-binding")]
+    [InlineData("## Callbacks (child → parent)", "callbacks-child--parent")]
+    [InlineData("## Gotcha: don't `StateHasChanged()` in unmount", "gotcha-dont-statehaschanged-in-unmount")]
+    public void Headings_UseGitHubAnchorSlugs(string markdown, string expectedId) =>
+        Assert.Equal(expectedId, Assert.Single(Markdown.Headings(markdown)).Id);
+
+    [Fact]
+    public void Headings_DisambiguateRepeatedTitlesTheWayGitHubDoes()
+    {
+        var ids = Markdown.Headings("## Notes\n\n## Notes\n\n## Notes\n").Select(h => h.Id).ToArray();
+
+        Assert.Equal(["notes", "notes-1", "notes-2"], ids);
+    }
+
     [Fact]
     public void ReadingOrder_FollowsGroupOrderThenCatalogOrder()
     {

--- a/tests/Rask.Example.Shared.Tests/Pages/DocsLinkTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/DocsLinkTests.cs
@@ -1,0 +1,184 @@
+using System.Text.RegularExpressions;
+using Markdig.Renderers.Html;
+using Markdig.Syntax;
+using Rask.Example.Shared;
+using Rask.Example.Shared.Features;
+
+namespace Rask.Example.Shared.Tests.Pages;
+
+/// <summary>
+/// <see cref="DocsIndexTests"/> guards that every doc is <em>reachable</em>; this guards that the links
+/// inside one <em>resolve</em>. They are different failures: an unreachable doc can't be found, while a
+/// broken link is found and then goes nowhere — and the docs are the product's front door.
+///
+/// <para>Three checks, each for a miss that shipped. A link to a file that doesn't exist (easy to write
+/// across two branches, where the target lands in the other one). A link to a doc the app can't serve — the
+/// renderer rewrites <c>x.md</c> to the SPA route <c>/guides/x</c>, so a doc that isn't embedded under that
+/// slug renders a 404 rather than a dead file. And an anchor that names no heading, which is the worst of
+/// the three because it still navigates: the reader lands at the top of the page and never knows they were
+/// sent to the wrong place.</para>
+///
+/// <para>Anchors are checked against the ids <em>Markdig's AutoIdentifiers actually stamps</em>, by parsing
+/// with the renderer's own <see cref="Markdown.Pipeline"/> — a hand-rolled slugifier here would be a second
+/// implementation to disagree with the first.</para>
+/// </summary>
+public sealed partial class DocsLinkTests
+{
+    [Fact]
+    public void Every_relative_doc_link_points_at_a_doc_that_exists()
+    {
+        var broken = AllLinks()
+            .Where(link => link.Path is not null && !File.Exists(Path.Combine(DocsDirectory(), link.Path)))
+            .Select(link => $"{link.Source} → {link.Target}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(
+            broken.Length == 0,
+            "These links point at a doc that doesn't exist. A link written against a file that lands in "
+            + $"another branch ships a 404:{Environment.NewLine}  "
+            + string.Join($"{Environment.NewLine}  ", broken));
+    }
+
+    [Fact]
+    public void Every_linked_doc_is_servable_under_the_slug_the_renderer_rewrites_to()
+    {
+        // Markdown.RewriteLinks turns `dir/x.md#frag` into `/guides/x#frag`, keying off the BARE LEAF. So a
+        // doc that exists on disk but isn't embedded under that slug is a link the reader can follow to a
+        // 404 — the file being present is not enough.
+        var unservable = AllLinks()
+            .Where(link => link.Path is not null && File.Exists(Path.Combine(DocsDirectory(), link.Path)))
+            .Where(link => GuideCatalog.ReadMarkdown(Slug(link.Path!)) is null)
+            .Select(link => $"{link.Source} → {link.Target} (would route to /guides/{Slug(link.Path!)})")
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(
+            unservable.Length == 0,
+            "These links resolve on disk but the app can't serve the route they rewrite to, so following "
+            + $"one 404s:{Environment.NewLine}  "
+            + string.Join($"{Environment.NewLine}  ", unservable));
+    }
+
+    [Fact]
+    public void Every_anchor_names_a_heading_in_the_document_it_points_at()
+    {
+        var docs = DocsDirectory();
+        var anchors = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+
+        var dangling = new List<string>();
+        foreach (var link in AllLinks().Where(l => l.Fragment.Length > 0))
+        {
+            // A link whose file is missing is already reported by the test above; don't report it twice.
+            var target = link.Path ?? link.SourcePath;
+            var full = Path.Combine(docs, target);
+            if (!File.Exists(full))
+            {
+                continue;
+            }
+
+            if (!anchors.TryGetValue(target, out var ids))
+            {
+                anchors[target] = ids = HeadingIds(File.ReadAllText(full));
+            }
+
+            if (!ids.Contains(link.Fragment))
+            {
+                dangling.Add($"{link.Source} → {link.Target}");
+            }
+        }
+
+        Assert.True(
+            dangling.Count == 0,
+            "These anchors name no heading in the document they point at. The link still navigates, so the "
+            + $"reader lands at the top of the page instead — usually a heading that was reworded or is "
+            + $"bold text rather than a heading:{Environment.NewLine}  "
+            + string.Join($"{Environment.NewLine}  ", dangling.Order(StringComparer.Ordinal)));
+    }
+
+    /// <summary>The heading ids Markdig stamps for <paramref name="source"/>, at every level.</summary>
+    /// <remarks>
+    /// Not <c>Markdown.Headings</c>: that surfaces the TOC and so keeps only <c>##</c>/<c>###</c>, while an
+    /// anchor may legitimately point at any heading. Same pipeline, so the ids are the rendered ones.
+    /// </remarks>
+    private static HashSet<string> HeadingIds(string source) =>
+        Markdig.Markdown.Parse(source, Markdown.Pipeline)
+            .Descendants<HeadingBlock>()
+            .Select(h => h.GetAttributes().Id)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .ToHashSet(StringComparer.Ordinal)!;
+
+    /// <summary>The route slug the renderer rewrites a doc path to — its bare leaf, without ".md".</summary>
+    private static string Slug(string docPath) =>
+        Path.GetFileNameWithoutExtension(docPath);
+
+    private readonly record struct DocLink(string Source, string SourcePath, string Target, string? Path, string Fragment);
+
+    /// <summary>
+    /// Every in-repo markdown link in every doc, with its target split into a docs-relative path and an
+    /// anchor. Skipped: external schemes (checking those needs the network, which buys flakiness), and
+    /// <c>../</c> paths — the renderer sends those to GitHub rather than routing them, so they aren't the
+    /// app's problem and they point outside <c>docs/</c>.
+    /// </summary>
+    private static IEnumerable<DocLink> AllLinks()
+    {
+        var docs = DocsDirectory();
+        foreach (var file in Directory.GetFiles(docs, "*.md", SearchOption.AllDirectories).Order(StringComparer.Ordinal))
+        {
+            var sourcePath = Path.GetRelativePath(docs, file).Replace('\\', '/');
+            var folder = Path.GetDirectoryName(sourcePath)?.Replace('\\', '/') ?? string.Empty;
+
+            foreach (Match match in LinkRegex().Matches(File.ReadAllText(file)))
+            {
+                var target = match.Groups[1].Value.Trim();
+                if (target.Length == 0
+                    || target.Contains("://", StringComparison.Ordinal)
+                    || target.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)
+                    || target.Contains("../", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var hash = target.IndexOf('#', StringComparison.Ordinal);
+                var path = hash < 0 ? target : target[..hash];
+                var fragment = hash < 0 ? string.Empty : target[(hash + 1)..];
+
+                // Only .md targets route through the guide pages; an image or a code file linked relatively
+                // is a plain asset and out of scope here.
+                if (path.Length > 0 && !path.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var resolved = path.Length == 0
+                    ? null
+                    : Normalize(folder.Length == 0 ? path : $"{folder}/{path}");
+
+                yield return new DocLink(sourcePath, sourcePath, target, resolved, fragment);
+            }
+        }
+    }
+
+    /// <summary>Collapses "tutorial/../cli.md" and the like without touching the filesystem.</summary>
+    private static string Normalize(string combined) =>
+        new Uri(new Uri("doc:///"), combined).AbsolutePath.TrimStart('/');
+
+    // Markdown inline links: ](target). Deliberately not matching reference-style or bare autolinks —
+    // the docs use inline links throughout, and a narrow regex beats a wrong one.
+    [GeneratedRegex(@"\]\(([^)\s]+)\)")]
+    private static partial Regex LinkRegex();
+
+    private static string DocsDirectory()
+    {
+        for (var dir = AppContext.BaseDirectory; dir is not null; dir = Path.GetDirectoryName(dir))
+        {
+            if (File.Exists(Path.Combine(dir, "Rask.slnx")))
+            {
+                return Path.Combine(dir, "docs");
+            }
+        }
+
+        throw new InvalidOperationException("Could not locate the repo root (Rask.slnx) from the test base directory.");
+    }
+}


### PR DESCRIPTION
## Summary

Adds the guard #656 asked for — and the guard immediately found a systemic bug the issue didn't
anticipate, so this fixes that too.

## The bug the guard found: 62 anchors pointed nowhere

The docs under `docs/` are authored and reviewed **on GitHub**, and their `#anchor` links are written
against GitHub's heading slugs. The guides site rendered **Markdig's**, which differ wherever a heading
holds punctuation:

| Heading | GitHub (what docs link to) | Markdig (what shipped) |
|---|---|---|
| `## Rask db — migrations` | `#rask-db--migrations` | `#rask-db-migrations` |
| `## Context & dependency injection` | `#context--dependency-injection` | `#context-dependency-injection` |
| `## 1. Two-way binding` | `#1-two-way-binding` | `#two-way-binding` |

GitHub **deletes** the character and keeps the spaces either side of it, so a dropped `&` or em dash
leaves *two* hyphens; Markdig collapses the run, and strips leading numbers. **Every one of those 62
links still navigated** — the reader just landed at the top of the page — which is why none of them ever
looked broken, and why a person reading spotted the first one rather than a test.

Heading ids are now stamped GitHub-style, so one anchor resolves in both places a doc is read.
**Markdig's own `AutoIdentifierOptions.GitHub` does not close this gap** — I probed it against the
default and the output is identical — so the slug is ours: lower-case, drop anything that isn't a
letter/digit/`-`/`_`, whitespace to `-`, and crucially *never collapse the result*. The on-this-page rail
reads ids from the same pipeline and follows automatically.

Five of the 62 were genuinely dead rather than mis-slugged (a heading reworded, one that never existed)
and are repointed at the sections they meant.

## The guard

`DocsIndexTests` guarded that every doc is *reachable*; `GuidesTests` guarded catalogue parity. Neither
looked at whether a link written **inside** a doc pointed at anything. `DocsLinkTests` walks every
`docs/**/*.md` and checks three things:

1. **A relative `*.md` link resolves to a file that exists.** The easy one to get wrong across two
   branches, where the target lands in the other one.
2. **It resolves to a doc the app can serve.** The renderer rewrites `dir/x.md` to the SPA route
   `/guides/x` by **bare leaf**, so a doc present on disk but not embedded under that slug is a link a
   reader can follow to a 404. (No duplicate leaves exist today, so the scheme is sound — but nothing
   was checking.)
3. **An `#anchor` — same doc or another — names a real heading.** The one that caught nobody, because a
   wrong anchor still navigates.

Anchors are checked against the ids the renderer *actually stamps*, by parsing with its own pipeline —
a second slugifier in the test would be a second thing to disagree with the first. External `http(s)`
links are deliberately not checked: that needs the network and buys flakiness for no benefit.

`GuideChromeTests` gains five cases pinning the slug contract itself (including GitHub's `-1`/`-2`
disambiguation of repeated headings), since it's now load-bearing rather than incidental.

## Testing

- `dotnet format` clean, `CI=true dotnet build Rask.slnx -warnaserror -m:1` clean, full unit suite green,
  browser E2E **57/57**.
- The `docs/` entry is in the pre-commit filter (#652), so this guard actually runs for the docs-only
  commits that most need it — the interaction #656 flagged.
- Rebased onto #654, whose new `docs/sync.md` the guard now walks; it passes.

## Unrelated failure worth knowing

The first E2E run failed on `PlaygroundExampleTests` — **#650**, not this change. Confirmed with that
issue's own diagnostic (`0` files under `publish/wwwroot/_rask`), and clearing `bin` as well as `obj`
took it to `6` files and 57/57. Posted as an independent reproduction on #650, including that this
worktree had already run the gate green twice today, so a recent green run is not evidence the publish
is sound.

Closes #656.
