### PR TITLE
fix(cli): stop reading a wasm-hosted Server project as a browser app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **`rask generate job` in the Server half of a `wasm-hosted` solution treated it as a browser app.**
+  Browser detection matched `Rask.Wasm` as a substring, and the Server project references
+  **`Rask.Wasm.Hosting`** — so the one project a background job actually belongs in got the browser
+  next-steps (`AddRaskBrowserSqlite`, "`rask db` does not apply") and had `Rask.SQLite.Browser` added to
+  it. That package doesn't resolve for a server project, so the command finished with *"the files were
+  written, but the wiring above didn't complete"* and exit 1 — broken, not merely misleading.
+  All three signals are now matched precisely rather than as substrings: `-browser` on the
+  `TargetFramework(s)` element rather than anywhere in the file, `<RaskWasm>true</RaskWasm>` rather than
+  `<RaskWasm>` (which also matched an explicit `false`), and a reference to `Rask.Wasm` itself as either
+  a package or a project — anchored so `Rask.Wasm.Hosting` can't satisfy it. A genuine browser app,
+  including the Client half of the same solution, is unaffected.
+
 ### Added
 - **`BrowserSqliteOwnership` — let a second tab explain itself.** Only one tab may own a browser SQLite
   database, so the others run against their own empty, unpersisted one. That is correct, and until now it

--- a/src/Rask.Cli/Scaffolding/ProjectContext.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectContext.cs
@@ -78,23 +78,43 @@ internal sealed partial class ProjectContext(
     [GeneratedRegex(@"<RootNamespace>\s*(.+?)\s*</RootNamespace>", RegexOptions.IgnoreCase)]
     private static partial Regex RootNamespaceRegex();
 
+    // A browser TFM on either the singular or plural element. Matched by the "-browser" suffix rather
+    // than the framework version, so a bump doesn't silently stop detecting it — but scoped to the
+    // element, because the bare string also occurs in comments, constants and package ids.
+    [GeneratedRegex(@"<TargetFrameworks?>[^<]*-browser", RegexOptions.IgnoreCase)]
+    private static partial Regex BrowserTargetFrameworkRegex();
+
+    // A reference to the WASM host itself, as a package (Include="Rask.Wasm") or as a project
+    // (Include="..\..\src\Rask.Wasm\Rask.Wasm.csproj") — the repo's own samples use the latter.
+    // Anchored on the closing quote so it does NOT match Rask.Wasm.Hosting, which is the giveaway of a
+    // SERVER project, not a browser one.
+    [GeneratedRegex(@"Include=""(?:[^""]*[\\/])?Rask\.Wasm(?:\.csproj)?""", RegexOptions.IgnoreCase)]
+    private static partial Regex WasmHostReferenceRegex();
+
     /// <summary>
     /// Whether a project file describes a browser (WASM) app.
     /// </summary>
     /// <remarks>
     /// Three independent signals, because an app can be recognisably a browser app by any of them: the
     /// browser target framework, the framework's own <c>RaskWasm</c> marker, or a reference to the WASM
-    /// host. Matching any one of them is deliberate — a project that is a browser app by only one signal
-    /// is still a browser app, and the cost of a false positive here is next-steps text that mentions a
-    /// package the reader does not have, not a broken build.
+    /// host. Matching any one is deliberate — a project that is a browser app by only one signal is still
+    /// a browser app.
+    /// <para>
+    /// Each signal is matched precisely rather than as a substring, because a false positive here is not
+    /// cosmetic: it hands a server project the browser next-steps and adds <c>Rask.SQLite.Browser</c> to
+    /// it, which doesn't resolve there. The one that bites is <c>Rask.Wasm.Hosting</c> — referenced by the
+    /// <b>Server</b> half of a <c>wasm-hosted</c> solution, which is precisely the project a background
+    /// job belongs in. Keeping the closing quote on the package check is what separates the two.
+    /// </para>
     /// </remarks>
     internal static bool DetectBrowser(string csprojText)
     {
         ArgumentNullException.ThrowIfNull(csprojText);
 
-        return csprojText.Contains("-browser", StringComparison.OrdinalIgnoreCase)
-            || csprojText.Contains("<RaskWasm>", StringComparison.OrdinalIgnoreCase)
-            || csprojText.Contains("Rask.Wasm", StringComparison.OrdinalIgnoreCase);
+        return BrowserTargetFrameworkRegex().IsMatch(csprojText)
+            // The value, not just the element: <RaskWasm>false</RaskWasm> asserts the opposite.
+            || csprojText.Contains("<RaskWasm>true</RaskWasm>", StringComparison.OrdinalIgnoreCase)
+            || WasmHostReferenceRegex().IsMatch(csprojText);
     }
 
     internal static string ReadRootNamespace(IFileSystem fileSystem, string csprojPath)

--- a/tests/Rask.Cli.Tests/JobGeneratorBrowserTests.cs
+++ b/tests/Rask.Cli.Tests/JobGeneratorBrowserTests.cs
@@ -18,6 +18,46 @@ public class JobGeneratorBrowserTests
         Assert.True(ProjectContext.DetectBrowser($"<Project>{marker}</Project>"));
     }
 
+    // The Server half of a `wasm-hosted` solution references Rask.Wasm.Hosting (ProjectGenerator.
+    // WasmHosted.cs), whose id contains "Rask.Wasm". Reading it as a browser app is the costly direction
+    // to be wrong in: that project is precisely where a background job belongs, and misdetecting it both
+    // prints the browser next-steps and adds Rask.SQLite.Browser to a server project, which doesn't
+    // resolve there — `rask g j` exits 1 with "the wiring didn't complete".
+    [Theory]
+    [InlineData("""<PackageReference Include="Rask.Wasm.Hosting" Version="0.20.0"/>""")]
+    [InlineData("""<ProjectReference Include="..\..\src\Rask.Wasm.Hosting\Rask.Wasm.Hosting.csproj"/>""")]
+    public void DetectBrowser_WasmHostedServerProject_IsNotBrowser(string reference)
+    {
+        var csproj = $"""
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>
+              <ItemGroup>{reference}</ItemGroup>
+            </Project>
+            """;
+
+        Assert.False(ProjectContext.DetectBrowser(csproj));
+    }
+
+    // <RaskWasm>false</RaskWasm> asserts the opposite of what it was being read as.
+    [Fact]
+    public void DetectBrowser_RaskWasmExplicitlyFalse_IsNotBrowser() =>
+        Assert.False(ProjectContext.DetectBrowser(
+            "<Project><PropertyGroup><RaskWasm>false</RaskWasm></PropertyGroup></Project>"));
+
+    // "-browser" is matched on the TargetFramework element, not anywhere in the file: a comment or a
+    // package id that happens to contain it says nothing about how the project runs.
+    [Theory]
+    [InlineData("<!-- the -browser TFM is covered in docs/wasm.md -->")]
+    [InlineData("""<PackageReference Include="Some.Vendor-browser.Tools" Version="1.0.0"/>""")]
+    public void DetectBrowser_IncidentalMentionOfBrowser_IsNotBrowser(string line)
+    {
+        var csproj = $"""
+            <Project><PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>{line}</Project>
+            """;
+
+        Assert.False(ProjectContext.DetectBrowser(csproj));
+    }
+
     [Fact]
     public void DetectBrowser_PlainServerProject_IsNotBrowser()
     {


### PR DESCRIPTION
## Summary

**A live regression on `main`.** When #648 merged, the detection review comment on it wasn't applied, so
`ProjectContext.DetectBrowser` still matches `Rask.Wasm` as a plain substring:

```csharp
|| csprojText.Contains("Rask.Wasm", StringComparison.OrdinalIgnoreCase);
```

The **Server** half of a `wasm-hosted` solution references **`Rask.Wasm.Hosting`**
(`ProjectGenerator.WasmHosted.cs:416`), so it is classified as a browser app — and that is precisely the
project a background job belongs in.

Reproduced with the shipped CLI before changing anything (`rask new Shop -t wasm-hosted`, then
`rask g j` inside `Shop.Server`):

```
Next steps (browser/WASM app):
       host.Services.AddRaskBrowserSqlite("app");   // restores + persists the database
     not apply. Register a hosted service after AddRaskBrowserSqlite that calls
...
error: NU1101: Unable to find package Rask.SQLite.Browser.
  The files were written, but the wiring above didn't complete — the project won't build until you finish it.
EXIT=1
```

So it isn't merely misleading: it adds a package that cannot resolve for a server TFM and **exits 1
having half-wired the project**.

## The fix

All three signals now match precisely rather than as substrings:

| Signal | Before | After |
|---|---|---|
| Browser TFM | `Contains("-browser")` anywhere in the file | `<TargetFrameworks?>[^<]*-browser` — the element, not a comment or a package id |
| Framework marker | `Contains("<RaskWasm>")` — also matched an explicit `false` | `<RaskWasm>true</RaskWasm>` |
| Host reference | `Contains("Rask.Wasm")` — matched `Rask.Wasm.Hosting` | `Include="…Rask.Wasm(.csproj)?"`, anchored on the closing quote |

The host-reference check deliberately accepts **both** a `PackageReference` (`Include="Rask.Wasm"`) and a
`ProjectReference` (`Include="..\..\src\Rask.Wasm\Rask.Wasm.csproj"`) — the repo's own samples use the
latter, and #648's existing theory covers it, so narrowing to packages alone would have broken it.

## Testing

- **Both directions verified on one scaffolded solution**, which is the point: `Shop.Server` → server
  next-steps, exit 0, no `Rask.SQLite.Browser`; `Shop.Client` — a genuine browser app in the same
  solution — still gets the browser next-steps.
- Five new cases in `JobGeneratorBrowserTests`: the `wasm-hosted` Server as both package and project
  reference, `<RaskWasm>false</RaskWasm>`, and two incidental mentions of `-browser` (a comment, and a
  package id containing it). All of #648's existing cases still pass unchanged.
- `dotnet format` clean, full format + unit gate green, browser E2E **60/60**.

Fixes the CLI half of #646, which #648 closed.
