### PR TITLE
fix(samples): stop the battery watch overwriting the read you just asked for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ them until tagged releases begin.
   `<RaskWasm>` (which also matched an explicit `false`), and a reference to `Rask.Wasm` itself as either
   a package or a project — anchored so `Rask.Wasm.Hosting` can't satisfy it. A genuine browser app,
   including the Client half of the same solution, is unaffected.
+- **The battery demo's live subscription no longer overwrites what you just read.** `BatteryDemo` showed
+  one "Status" line written by two independent sources: the `WatchAsync` subscription stamped `live` on
+  every push from the device, and the *Read now* button stamped `read`. Whichever wrote last won — so a
+  push arriving after a click replaced the answer with `live` and **never put it back**, making the
+  button look like it had done nothing. The two are now separate lines, `Watch:` and `Status:`, each with
+  exactly one writer; the level and charging figures stay shared, since both sources describe the same
+  battery and the freshest value is the right one whichever produced it.
+  This also removes an intermittent red from the **longest test in the E2E gate** — the shared journey
+  asserted that one label after clicking Read, so a chance push failed the whole journey on unrelated
+  branches ([#661](https://github.com/pal-tamas/rask/issues/661)).
 
 ### Added
 - **A waiting tab now finds out when the database becomes free.** `BrowserSqliteOwnership.Available`

--- a/samples/Rask.Example.Shared/Features/Browser/BatteryDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/BatteryDemo.cs
@@ -12,7 +12,16 @@ namespace Rask.Example.Shared.Features;
 public sealed class BatteryDemo(IBattery battery) : Component, IAsyncDisposable
 {
     private BatteryStatus? _status;
-    private string _state = "(read or watch)";
+
+    // Two labels, not one, because the two halves of this demo write on their own schedules: the watch
+    // pushes whenever the device changes, and the button reports what a one-shot read just returned.
+    // Sharing a field made whichever wrote last the visible truth — a push landing after a click replaced
+    // "read" with "live" and never put it back, which read as the button having done nothing.
+    private string _watchState = "(starting…)";
+    private string _readState = "(not read yet)";
+
+    // The level/charging figures ARE shared on purpose: both sources describe the same battery, so the
+    // freshest value is the right one to show whichever produced it.
     private IAsyncDisposable? _watch;
     private bool _started;
 
@@ -26,7 +35,8 @@ public sealed class BatteryDemo(IBattery battery) : Component, IAsyncDisposable
         _started = true;
         if (!await battery.IsSupportedAsync())
         {
-            _state = "not supported on this browser";
+            _watchState = "not supported on this browser";
+            _readState = "not supported on this browser";
             StateHasChanged();
             return;
         }
@@ -34,7 +44,7 @@ public sealed class BatteryDemo(IBattery battery) : Component, IAsyncDisposable
         _watch = await battery.WatchAsync(s =>
         {
             _status = s;
-            _state = "live";
+            _watchState = "live";
             StateHasChanged();
             return Task.CompletedTask;
         });
@@ -51,7 +61,9 @@ public sealed class BatteryDemo(IBattery battery) : Component, IAsyncDisposable
                     "Level: ", Code(Id: "battery-level")[_status is { } s ? $"{s.Level * 100:0}%" : "(none)"]],
                 Div(Class: "small text-secondary mb-1")[
                     "Charging: ", Code(Id: "battery-charging")[_status is { } c ? (c.Charging ? "yes" : "no") : "(none)"]],
-                Div(Class: "small text-secondary")["Status: ", Code(Id: "battery-status")[_state]]
+                Div(Class: "small text-secondary mb-1")[
+                    "Watch: ", Code(Id: "battery-watch")[_watchState]],
+                Div(Class: "small text-secondary")["Status: ", Code(Id: "battery-status")[_readState]]
             ]
         ];
 
@@ -60,11 +72,11 @@ public sealed class BatteryDemo(IBattery battery) : Component, IAsyncDisposable
         try
         {
             _status = await battery.GetStatusAsync();
-            _state = _status is null ? "not supported" : "read";
+            _readState = _status is null ? "not supported" : "read";
         }
         catch (Exception ex)
         {
-            _state = "failed: " + ex.Message;
+            _readState = "failed: " + ex.Message;
         }
     }
 

--- a/tests/Rask.Example.Shared.Tests/Guides/DemoMarkup.golden.txt
+++ b/tests/Rask.Example.Shared.Tests/Guides/DemoMarkup.golden.txt
@@ -2292,6 +2292,8 @@ div .mb-1 .small .text-secondary
 code
 div .mb-1 .small .text-secondary
 code
+div .mb-1 .small .text-secondary
+code
 div .small .text-secondary
 code
 

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -2201,7 +2201,11 @@ public abstract partial class SharedSmokeTests
         await Expect(Page.Locator("#locks-status")).ToContainTextAsync("acquired", contains);
 
         // Battery — one-shot read of navigator.getBattery (headless Chromium provides a mock manager, so
-        // GetStatusAsync resolves rather than returning null); the status flips to "read".
+        // GetStatusAsync resolves rather than returning null); the read label flips to "read".
+        //
+        // Asserted on #battery-status, which ONLY the read writes. The demo used to share one label with
+        // the watch subscription, so a push arriving after this click replaced "read" with "live" and
+        // never restored it — an intermittent red on the longest test in the gate (#661).
         await Page.Locator("#battery-read").ClickAsync();
         await Expect(Page.Locator("#battery-status")).ToContainTextAsync("read", contains);
 


### PR DESCRIPTION
## Summary

`BatteryDemo` showed **one status line written by two independent sources**:

```csharp
_watch = await battery.WatchAsync(s => { _status = s; _state = "live";  … });  // every device push
…
_state = _status is null ? "not supported" : "read";                            // the "Read now" button
```

Whichever wrote last won. A push arriving after a click replaced the answer with `live` and **never put
it back** — so the button looked like it had done nothing, with nothing on screen to explain why. The two
controls are documented as demonstrating different things (a one-shot read vs a subscription), and they
were fighting over one label.

They are now separate lines, `Watch:` and `Status:`, each with exactly one writer. The level and charging
figures stay shared **on purpose**: both sources describe the same battery, so the freshest value is the
right one to show whichever produced it.

## Why this is worth a PR rather than a test retry

It removes an intermittent red from the **longest test in the E2E gate**. The shared journey clicks *Read
now* and asserts that label, so a chance push failed the entire journey — for **every host**, on whichever
unrelated branch happened to be running when headless Chromium's mock manager pushed.

It cost a gate cycle here on a CLI-only change, which is how it was found. It is also a genuine demo bug
first and a test bug second: the user-facing behaviour was wrong, and the test becoming deterministic
falls out of fixing that rather than being the goal.

Diagnosed as stable rather than transient: the failing run resolved `live` across **all 24 retries**, so
the value had been overwritten and stayed that way — not a slow transition.

## Testing

- The journey now asserts `#battery-status`, which only the read writes, with a comment recording why.
- `DemoMarkup.golden.txt` regenerated through its own documented path (`RASK_UPDATE_GOLDEN=1`) for the
  added line. Per that file's header — *"that diff IS the review"* — the diff is exactly the two expected
  entries and nothing else:
  ```
  +div .mb-1 .small .text-secondary
  +code
  ```
- `dotnet format` clean, `CI=true dotnet build Rask.slnx -warnaserror -m:1` clean, full unit suite green,
  browser E2E **60/60**.

Closes #661.
