### PR TITLE
feat(samples): three devices sharing one database, with no server between them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,22 @@ them until tagged releases begin.
   branches ([#661](https://github.com/pal-tamas/rask/issues/661)).
 
 ### Added
+- **A working sample: three devices sharing one database with no server.**
+  `samples/Rask.Example.Crdt` runs three replicas — Phone, Laptop, Tablet — each with its own SQLite
+  file and its own replica identity, sharing a bucket and nothing else. Each device can be taken
+  offline independently, so the demo exercises the real offline path rather than a special case: edit
+  **different fields of the same todo** on two offline devices, bring both back, sync, and both edits
+  survive. That is the claim per-column merging makes, and it is asserted by an E2E that drives it
+  through a browser. cr-sqlite's native binary is per-platform and not redistributed, so without
+  `RASK_CRSQLITE_PATH` the page explains what to download instead of failing at the first query with
+  "no such function" — and *that* state is asserted too, so one of the two always runs.
+- **`FolderObjectStore` — a bucket backed by a directory.** The same `IObjectStore` over a folder, which
+  is what lets the sample run with no cloud credentials. It also covers a single-machine deployment
+  with no reason to pay for object storage, and — the interesting case — **a folder something else
+  already replicates**: pointed at a Syncthing share, devices converge with no central server at all.
+  Objects are written beside their key and moved into place, so a concurrent reader sees either nothing
+  or the whole object, and keys that would escape the root are refused rather than normalised, because
+  a key can come from a listing of a folder other people also write to.
 - **`Rask.SQLite.Crdt.Sync` — share those replicas through a bucket, with no server between them.**
   Ships the change feed over `Rask.ObjectStore`: `new CrdtSyncEngine(objectStore, feed)` then
   `SyncAsync()`, with a status a UI can render (published / received / peers / offline). The design

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -119,10 +119,12 @@
       The marketing landing site (Rask.Example.Site) is a standalone WASM app (its own hand-styled design,
       no Shared/Bootstrap/validation), so it skips them as well. So does the browser-jobs sample
       (Rask.Example.Wasm.Jobs) — note it must be matched by its exact name, since the showcase it sits
-      next to (Rask.Example.Wasm) does want these usings.
+      next to (Rask.Example.Wasm) does want these usings. The CRDT sample (Rask.Example.Crdt) is the
+      same shape as the SQLite one: a standalone app about the database, styled with plain Bootstrap
+      classes over the core elements.
     -->
     <_RaskExampleValidationUsings>$(_RaskInRepoImplicitUsings)</_RaskExampleValidationUsings>
-    <_RaskExampleValidationUsings Condition=" $(MSBuildProjectName.StartsWith('Rask.Example.Auth')) OR $(MSBuildProjectName.StartsWith('Rask.Example.EfCore')) OR $(MSBuildProjectName.StartsWith('Rask.Example.Sqlite')) OR '$(MSBuildProjectName)' == 'Rask.Example.Native.Server' OR '$(MSBuildProjectName)' == 'Rask.Example.Playground' OR '$(MSBuildProjectName)' == 'Rask.Example.Site' OR '$(MSBuildProjectName)' == 'Rask.Example.Wasm.Jobs' OR $(MSBuildProjectName.StartsWith('Rask.Example.Shop')) ">false</_RaskExampleValidationUsings>
+    <_RaskExampleValidationUsings Condition=" $(MSBuildProjectName.StartsWith('Rask.Example.Auth')) OR $(MSBuildProjectName.StartsWith('Rask.Example.EfCore')) OR $(MSBuildProjectName.StartsWith('Rask.Example.Sqlite')) OR $(MSBuildProjectName.StartsWith('Rask.Example.Crdt')) OR '$(MSBuildProjectName)' == 'Rask.Example.Native.Server' OR '$(MSBuildProjectName)' == 'Rask.Example.Playground' OR '$(MSBuildProjectName)' == 'Rask.Example.Site' OR '$(MSBuildProjectName)' == 'Rask.Example.Wasm.Jobs' OR $(MSBuildProjectName.StartsWith('Rask.Example.Shop')) ">false</_RaskExampleValidationUsings>
     <!-- The showcase trio (Rask.Example.Shared + the Server/Wasm hosts that reference it) pulls in
          Rask.Bootstrap; the Auth/EfCore standalone samples don't reference it, so they must not get
          its global static usings (the namespace wouldn't resolve). Same set as the validation usings. -->

--- a/Rask.slnx
+++ b/Rask.slnx
@@ -12,6 +12,7 @@
         <Project Path="samples/Rask.Example.Auth.WasmJwt/Rask.Example.Auth.WasmJwt.csproj"/>
         <Project Path="samples/Rask.Example.Auth.WasmJwt.Host/Rask.Example.Auth.WasmJwt.Host.csproj"/>
         <Project Path="samples/Rask.Example.EfCore/Rask.Example.EfCore.csproj"/>
+        <Project Path="samples/Rask.Example.Crdt/Rask.Example.Crdt.csproj"/>
         <Project Path="samples/Rask.Example.Playground/Rask.Example.Playground.csproj"/>
         <!-- Rask.Example.Native / .Native.Server multi-target net10.0-ios;net10.0-android (mobile workloads)
              so they are excluded here — the Ubuntu solution build can't restore them. Built by the macOS

--- a/docs/object-storage.md
+++ b/docs/object-storage.md
@@ -23,6 +23,7 @@ whole-object stream, write, conditional create, prefix list, delete.
 | Google Cloud Storage | `AddRaskS3ObjectStore` against `storage.googleapis.com` | S3 interop HMAC keys |
 | MinIO / Backblaze B2 / Spaces | `AddRaskS3ObjectStore` | access key + secret |
 | Azure Blob Storage | `AddRaskAzureBlobObjectStore` | SAS token |
+| A folder on disk | `new FolderObjectStore(path)` | none |
 
 ```csharp
 builder.Services.AddRaskS3ObjectStore(o =>
@@ -35,6 +36,28 @@ builder.Services.AddRaskS3ObjectStore(o =>
 
 `UsePathStyle` defaults to `true` (`host/bucket/key`) because R2, MinIO and most S3-compatible stores
 require it. AWS accepts both; set it to `false` for virtual-host addressing.
+
+### A folder as a bucket
+
+`FolderObjectStore` implements the same interface over a directory:
+
+```csharp
+IObjectStore store = new FolderObjectStore("/var/lib/myapp/bucket");
+```
+
+Useful in three places, and it is the same code for all of them: running a sample or a test with no
+cloud credentials, a single-machine deployment that has no reason to pay for object storage, and — the
+interesting one — **a folder something else already replicates**. Point it at a Syncthing share and
+devices converge with no central server at all; point it at iCloud Drive, Dropbox or OneDrive and the
+replication is somebody else's problem.
+
+Objects are written beside their key and moved into place, so a reader listing the folder concurrently
+sees either nothing or the whole object — which matters most when another process is replicating the
+folder while it is being written. Keys that would escape the root are refused rather than normalised,
+because a key can come from a listing of a folder other people also write to.
+
+`TryCreateAsync` maps to the filesystem's own atomic create, so the [mutual-exclusion](#mutual-exclusion-without-a-lock-service)
+pattern below works here too.
 
 ## Ranged reads are the point
 

--- a/docs/sqlite-crdt-sync.md
+++ b/docs/sqlite-crdt-sync.md
@@ -98,6 +98,24 @@ teams** — not multi-tenant apps. Anyone who can read the bucket can read every
 Give each device its own credentials if the store supports it, so one can be revoked without rotating
 the rest.
 
+## A working sample
+
+[`samples/Rask.Example.Crdt`](../samples/Rask.Example.Crdt) runs three devices — Phone, Laptop,
+Tablet — each with its own database, sharing a bucket and nothing else. Each can be taken offline
+independently:
+
+```bash
+RASK_CRSQLITE_PATH=/path/to/crsqlite.dylib dotnet run --project samples/Rask.Example.Crdt
+```
+
+The thing to try: take two devices offline, edit **different fields of the same todo** on each — the
+priority on one, the done flag on the other — then bring both back and press *Sync everyone*. Both
+edits survive. Do the same with a `LastModified` column and one of them is gone.
+
+The bucket there is a [`FolderObjectStore`](object-storage.md#a-folder-as-a-bucket) so it runs with no
+credentials; swapping in `S3ObjectStore` is the only change needed to put the same three devices on the
+internet.
+
 ## See also
 
 - [Multi-writer SQLite](sqlite-crdt.md) — the merge itself, and the EF Core integration.

--- a/samples/Rask.Example.Crdt/Data/TodoDbContext.cs
+++ b/samples/Rask.Example.Crdt/Data/TodoDbContext.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using Rask.SQLite.Crdt;
+
+namespace Rask.Example.Crdt.Data;
+
+/// <summary>A shared family todo. Ordinary EF Core — nothing here knows it is replicated.</summary>
+public sealed class Todo
+{
+    /// <summary>
+    ///     A Guid, not an autoincrementing integer: a replica identifies rows by their key across
+    ///     devices, and "3" would mean a different row on every one of them.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    public string Title { get; set; } = string.Empty;
+
+    public bool Done { get; set; }
+
+    public int Priority { get; set; }
+}
+
+public sealed class TodoDbContext(DbContextOptions options) : DbContext(options)
+{
+    public DbSet<Todo> Todos => Set<Todo>();
+
+    // The one model-side line the CRDT needs: every required column gets a SQL default, because
+    // cr-sqlite refuses a NOT NULL column without one — a peer on an older schema has to be able to
+    // apply a change that never mentions the column.
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.ApplyCrdtConventions();
+}

--- a/samples/Rask.Example.Crdt/Devices/FamilyDevices.cs
+++ b/samples/Rask.Example.Crdt/Devices/FamilyDevices.cs
@@ -1,0 +1,189 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Rask.Example.Crdt.Data;
+using Rask.ObjectStore;
+using Rask.SQLite.Crdt;
+using Rask.SQLite.Crdt.Sync;
+
+namespace Rask.Example.Crdt.Devices;
+
+/// <summary>
+///     Three devices of one family, each with its own SQLite database, sharing a bucket and nothing
+///     else. Normally these would be three phones; here they are three files in one process, which is
+///     the only difference.
+/// </summary>
+public sealed class FamilyDevices : IAsyncDisposable
+{
+    private readonly string _root;
+
+    private FamilyDevices(string root, string bucket, IReadOnlyList<FamilyDevice> devices)
+    {
+        _root = root;
+        BucketPath = bucket;
+        All = devices;
+    }
+
+    private FamilyDevices(string root, string setupHint)
+    {
+        _root = root;
+        BucketPath = string.Empty;
+        All = [];
+        SetupHint = setupHint;
+    }
+
+    /// <summary>The devices, or empty when cr-sqlite is not available.</summary>
+    public IReadOnlyList<FamilyDevice> All { get; }
+
+    /// <summary>Where the shared "bucket" lives on disk.</summary>
+    public string BucketPath { get; }
+
+    /// <summary>Why the demo cannot run, when it cannot.</summary>
+    public string? SetupHint { get; }
+
+    public bool Available => All.Count > 0;
+
+    /// <summary>
+    ///     Builds the devices, or reports why it could not.
+    /// </summary>
+    /// <remarks>
+    ///     cr-sqlite ships a separate native binary per platform and is not redistributed here, so the
+    ///     sample explains what to download rather than failing at the first query — a missing extension
+    ///     otherwise surfaces as "no such function", which says nothing about what to do.
+    /// </remarks>
+    public static async Task<FamilyDevices> CreateAsync(IConfiguration configuration)
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"rask-crdt-demo-{Guid.NewGuid():N}");
+        var extension = configuration["RASK_CRSQLITE_PATH"];
+
+        if (string.IsNullOrWhiteSpace(extension) || !File.Exists(extension))
+        {
+            return new FamilyDevices(root,
+                "Set RASK_CRSQLITE_PATH to cr-sqlite's loadable extension for this platform "
+                + "(crsqlite.dylib / .so / .dll) — download it from the cr-sqlite releases page.");
+        }
+
+        Directory.CreateDirectory(root);
+        var bucket = Path.Combine(root, "bucket");
+
+        // A folder, so the sample runs with no cloud credentials. Swapping in S3ObjectStore is the only
+        // change needed to make these three devices sync over the internet instead.
+        var shared = new FolderObjectStore(bucket);
+
+        var devices = new List<FamilyDevice>();
+        foreach (var name in (string[])["Phone", "Laptop", "Tablet"])
+        {
+            devices.Add(await FamilyDevice.CreateAsync(name, Path.Combine(root, $"{name}.db"), extension, shared));
+        }
+
+        return new FamilyDevices(root, bucket, devices);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var device in All)
+        {
+            await device.DisposeAsync();
+        }
+
+        SqliteConnection.ClearAllPools();
+
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // A leftover temp folder is not worth failing shutdown over.
+        }
+    }
+}
+
+/// <summary>One device: its own database, its own replica identity, its own view of the bucket.</summary>
+public sealed class FamilyDevice : IAsyncDisposable
+{
+    private FamilyDevice(string name, TodoDbContext context, CrdtSyncEngine engine, SwitchableObjectStore link)
+    {
+        Name = name;
+        Context = context;
+        Engine = engine;
+        Link = link;
+    }
+
+    public string Name { get; }
+
+    public TodoDbContext Context { get; }
+
+    public CrdtSyncEngine Engine { get; }
+
+    /// <summary>This device's connection to the bucket — switch it off to go offline.</summary>
+    public SwitchableObjectStore Link { get; }
+
+    public CrdtSyncStatus Status { get; private set; } = new(CrdtSyncPhase.Idle, 0, 0, 0);
+
+    internal static async Task<FamilyDevice> CreateAsync(
+        string name, string file, string extension, IObjectStore shared)
+    {
+        // Pooling off: cr-sqlite keeps per-connection state, and a handle returned to the pool
+        // mid-state and reused elsewhere corrupts quietly rather than failing.
+        var connectionString = $"Data Source={file};Pooling=False";
+
+        // Order matters, and getting it wrong is silent: loading cr-sqlite seeds its own bookkeeping
+        // tables, and EnsureCreated treats a database that already has tables as provisioned. So the
+        // schema is created on a context WITHOUT the extension, and only then promoted.
+        await using (var plain = new TodoDbContext(
+                         new DbContextOptionsBuilder<TodoDbContext>().UseSqlite(connectionString).Options))
+        {
+            await plain.Database.EnsureCreatedAsync();
+        }
+
+        var context = new TodoDbContext(new DbContextOptionsBuilder<TodoDbContext>()
+            .UseSqlite(connectionString)
+            .UseRaskCrdt(o => o.ExtensionPath = extension)
+            .Options);
+
+        await context.PromoteToCrrsAsync();
+
+        var link = new SwitchableObjectStore(shared);
+        return new FamilyDevice(name, context, new CrdtSyncEngine(link, new CrdtChangeFeed(context)), link);
+    }
+
+    /// <summary>Adds a todo. A local write and nothing else — no network, online or not.</summary>
+    public async Task AddAsync(string title)
+    {
+        Context.Todos.Add(new Todo { Id = Guid.NewGuid(), Title = title, Priority = 1 });
+        await Context.SaveChangesAsync();
+    }
+
+    public async Task ToggleAsync(Guid id)
+    {
+        var todo = await Context.Todos.FindAsync(id);
+        if (todo is not null)
+        {
+            todo.Done = !todo.Done;
+            await Context.SaveChangesAsync();
+        }
+    }
+
+    public async Task BumpPriorityAsync(Guid id)
+    {
+        var todo = await Context.Todos.FindAsync(id);
+        if (todo is not null)
+        {
+            todo.Priority = todo.Priority % 3 + 1;
+            await Context.SaveChangesAsync();
+        }
+    }
+
+    public async Task<IReadOnlyList<Todo>> ReadAsync()
+    {
+        Context.ChangeTracker.Clear();
+        return await Context.Todos.OrderBy(t => t.Title).AsNoTracking().ToListAsync();
+    }
+
+    public async Task SyncAsync() => Status = await Engine.SyncAsync();
+
+    public async ValueTask DisposeAsync() => await Context.DisposeAsync();
+}

--- a/samples/Rask.Example.Crdt/Devices/SwitchableObjectStore.cs
+++ b/samples/Rask.Example.Crdt/Devices/SwitchableObjectStore.cs
@@ -1,0 +1,71 @@
+using Rask.ObjectStore;
+
+namespace Rask.Example.Crdt.Devices;
+
+/// <summary>
+///     The shared bucket, with a switch. Every call fails while the device is "offline", exactly as a
+///     real client would see it, so the demo exercises the real offline path rather than a special case
+///     the engine knows about.
+/// </summary>
+public sealed class SwitchableObjectStore(IObjectStore inner) : IObjectStore
+{
+    /// <summary>Whether this device can currently reach the bucket.</summary>
+    public bool Online { get; set; } = true;
+
+    public Task<byte[]?> GetRangeAsync(string key, long offset, int count, CancellationToken ct = default)
+    {
+        Check();
+        return inner.GetRangeAsync(key, offset, count, ct);
+    }
+
+    public Task<Stream?> OpenReadAsync(string key, CancellationToken ct = default)
+    {
+        Check();
+        return inner.OpenReadAsync(key, ct);
+    }
+
+    public Task PutAsync(string key, byte[] content, CancellationToken ct = default)
+    {
+        Check();
+        return inner.PutAsync(key, content, ct);
+    }
+
+    public Task PutAsync(string key, Stream content, long length, CancellationToken ct = default)
+    {
+        Check();
+        return inner.PutAsync(key, content, length, ct);
+    }
+
+    public Task<bool> TryCreateAsync(string key, byte[] content, CancellationToken ct = default)
+    {
+        Check();
+        return inner.TryCreateAsync(key, content, ct);
+    }
+
+    public Task<IReadOnlyList<ObjectEntry>> ListAsync(
+        string prefix, string? startAfter = null, CancellationToken ct = default)
+    {
+        Check();
+        return inner.ListAsync(prefix, startAfter, ct);
+    }
+
+    public Task<IReadOnlyList<string>> ListPrefixesAsync(string prefix, CancellationToken ct = default)
+    {
+        Check();
+        return inner.ListPrefixesAsync(prefix, ct);
+    }
+
+    public Task DeleteAsync(string key, CancellationToken ct = default)
+    {
+        Check();
+        return inner.DeleteAsync(key, ct);
+    }
+
+    private void Check()
+    {
+        if (!Online)
+        {
+            throw new HttpRequestException("this device is offline");
+        }
+    }
+}

--- a/samples/Rask.Example.Crdt/Features/FamilyTodosPage.cs
+++ b/samples/Rask.Example.Crdt/Features/FamilyTodosPage.cs
@@ -1,0 +1,205 @@
+using System.Globalization;
+using Rask.Core.Routing;
+using Rask.Example.Crdt.Data;
+using Rask.Example.Crdt.Devices;
+using Rask.SQLite.Crdt.Sync;
+
+namespace Rask.Example.Crdt.Features;
+
+// Three devices of one family, each with its own SQLite database, sharing a bucket and nothing else.
+// The point to see: take two devices offline, edit DIFFERENT FIELDS of the same todo on each, then
+// bring both back and sync — both edits survive, because merging is per column rather than per row.
+[Route("/")]
+public sealed class FamilyTodosPage(FamilyDevices family) : Component
+{
+    private const string WiringSnippet =
+        """
+        options.UseSqlite($"Data Source={file};Pooling=False")
+               .UseRaskCrdt(o => o.ExtensionPath = crsqlitePath);
+
+        protected override void OnModelCreating(ModelBuilder b) => b.ApplyCrdtConventions();
+        await context.PromoteToCrrsAsync();
+
+        var engine = new CrdtSyncEngine(objectStore, new CrdtChangeFeed(context));
+        await engine.SyncAsync();          // publish mine, then apply everyone else's
+        """;
+
+    private readonly Dictionary<string, IReadOnlyList<Todo>> _todos = [];
+    private readonly Dictionary<string, string> _drafts = [];
+
+    protected override Component? Head => Title()["Family todos — Rask"];
+
+    protected override async Task OnMountAsync() => await RefreshAsync();
+
+    private async Task RefreshAsync()
+    {
+        foreach (var device in family.All)
+        {
+            _todos[device.Name] = await device.ReadAsync();
+        }
+    }
+
+    private async Task AddAsync(FamilyDevice device)
+    {
+        var title = _drafts.GetValueOrDefault(device.Name, string.Empty).Trim();
+        if (title.Length == 0)
+        {
+            return;
+        }
+
+        await device.AddAsync(title);
+        _drafts[device.Name] = string.Empty;
+        await RefreshAsync();
+    }
+
+    private async Task SyncAsync(FamilyDevice device)
+    {
+        await device.SyncAsync();
+        await RefreshAsync();
+    }
+
+    private async Task SyncEveryoneAsync()
+    {
+        // Twice around: the first pass publishes everyone's work, the second lets each device pick up
+        // what the others published during the first. Merging is commutative, so the order does not
+        // matter — only that every device has had a turn after every other has published.
+        for (var round = 0; round < 2; round++)
+        {
+            foreach (var device in family.All)
+            {
+                await device.SyncAsync();
+            }
+        }
+
+        await RefreshAsync();
+    }
+
+    protected override Component? Render() =>
+    [
+        Div(Class: "mb-4")[
+            H1(Class: "h3 mb-1")["A shared database with no server"],
+            P(Class: "text-secondary mb-0")[
+                "Three devices, three SQLite databases, one bucket — and nothing in between. ",
+                "Edit ", Strong()["different fields of the same todo"],
+                " on two devices while both are offline, then sync: both edits survive."
+            ]
+        ],
+
+        Div(Class: "card shadow-sm mb-4")[
+            Div(Class: "card-header bg-dark text-light py-2")[
+                I(Class: "bi bi-code-slash me-2"), "The whole wiring"
+            ],
+            Pre(Class: "mb-0 p-3 bg-dark text-light rounded-bottom overflow-auto")[Code()[WiringSnippet]]
+        ],
+
+        family.Available ? Devices() : Setup()
+    ];
+
+    private Component Setup() =>
+        Div(Class: "alert alert-warning", Data: Test("setup"))[
+            H2(Class: "h5 alert-heading")[
+                I(Class: "bi bi-exclamation-triangle me-2"), "cr-sqlite is not configured"
+            ],
+            P()[family.SetupHint ?? string.Empty],
+            Pre(Class: "mb-0")[
+                Code()["RASK_CRSQLITE_PATH=/path/to/crsqlite.dylib dotnet run --project samples/Rask.Example.Crdt"]
+            ]
+        ];
+
+    private Component Devices() =>
+        Div()[
+            Div(Class: "d-flex align-items-center gap-3 mb-3")[
+                Button("button", Class: "btn btn-primary", Data: Test("sync-all"),
+                    OnClickAsync: SyncEveryoneAsync)[
+                    I(Class: "bi bi-arrow-repeat me-1"), "Sync everyone"
+                ],
+                Span(Class: "text-secondary small")[
+                    "The bucket is a folder: ", Code()[family.BucketPath]
+                ]
+            ],
+
+            Div(Class: "row g-3")[
+                family.All.Select(device => Div(Class: "col-lg-4", Key: device.Name)[Card(device)])
+            ]
+        ];
+
+    private Component Card(FamilyDevice device) =>
+        Div(Class: "card shadow-sm h-100", Data: Test($"device-{device.Name}"))[
+            Div(Class: "card-header d-flex justify-content-between align-items-center py-2")[
+                Span(Class: "fw-semibold")[I(Class: "bi bi-phone me-2"), device.Name],
+                Button("button",
+                    Class: device.Link.Online ? "btn btn-sm btn-outline-success" : "btn btn-sm btn-outline-secondary",
+                    Data: Test($"link-{device.Name}"),
+                    OnClick: () => device.Link.Online = !device.Link.Online)[
+                    I(Class: device.Link.Online ? "bi bi-wifi me-1" : "bi bi-wifi-off me-1"),
+                    device.Link.Online ? "Online" : "Offline"
+                ]
+            ],
+
+            Div(Class: "card-body")[
+                Div(Class: "d-flex gap-2 mb-3")[
+                    Input(
+                        Type: InputType.Text,
+                        Class: "form-control form-control-sm",
+                        Value: _drafts.GetValueOrDefault(device.Name, string.Empty),
+                        Placeholder: "add a todo",
+                        Data: Test($"draft-{device.Name}"),
+                        OnInput: v => _drafts[device.Name] = v),
+                    Button("button", Class: "btn btn-sm btn-outline-primary", Data: Test($"add-{device.Name}"),
+                        OnClickAsync: () => AddAsync(device))["Add"]
+                ],
+
+                Ul(Class: "list-group list-group-flush mb-3")[
+                    _todos.GetValueOrDefault(device.Name, []).Select(todo =>
+                        Li(Class: "list-group-item d-flex justify-content-between align-items-center px-0",
+                            Key: todo.Id.ToString())[
+                            Span(Class: todo.Done ? "text-decoration-line-through text-secondary" : null)[
+                                todo.Title
+                            ],
+                            Span(Class: "d-flex gap-1")[
+                                Button("button", Class: "btn btn-sm btn-outline-secondary",
+                                    OnClickAsync: async () =>
+                                    {
+                                        await device.BumpPriorityAsync(todo.Id);
+                                        await RefreshAsync();
+                                    })[
+                                    "P", todo.Priority.ToString(CultureInfo.InvariantCulture)
+                                ],
+                                Button("button", Class: "btn btn-sm btn-outline-secondary",
+                                    OnClickAsync: async () =>
+                                    {
+                                        await device.ToggleAsync(todo.Id);
+                                        await RefreshAsync();
+                                    })[
+                                    I(Class: todo.Done ? "bi bi-arrow-counterclockwise" : "bi bi-check2")
+                                ]
+                            ]
+                        ])
+                ],
+
+                Button("button", Class: "btn btn-sm btn-outline-dark w-100", Data: Test($"sync-{device.Name}"),
+                    OnClickAsync: () => SyncAsync(device))[
+                    I(Class: "bi bi-arrow-repeat me-1"), "Sync this device"
+                ]
+            ],
+
+            Div(Class: "card-footer py-2 small text-secondary", Data: Test($"status-{device.Name}"))[
+                Describe(device.Status)
+            ]
+        ];
+
+    // Offline is not an error state here: the edit is already committed to this device's own database,
+    // and the next sync sends it. Saying "failed" would train people to ignore the one indicator that
+    // actually matters.
+    private static string Describe(CrdtSyncStatus status) => status.Phase switch
+    {
+        CrdtSyncPhase.Idle => "not synced yet",
+        CrdtSyncPhase.Syncing => "syncing…",
+        CrdtSyncPhase.Offline => "offline — your edits are saved and will sync later",
+        _ => $"synced · sent {status.Published.ToString(CultureInfo.InvariantCulture)}"
+             + $" · received {status.Received.ToString(CultureInfo.InvariantCulture)}"
+             + $" · {status.Peers.ToString(CultureInfo.InvariantCulture)} peer(s)",
+    };
+
+    private static Dictionary<string, string?> Test(string id) => new() { ["testid"] = id };
+}

--- a/samples/Rask.Example.Crdt/Program.cs
+++ b/samples/Rask.Example.Crdt/Program.cs
@@ -1,0 +1,32 @@
+using Rask.Example.Crdt;
+using Rask.Example.Crdt.Devices;
+using Rask.Server;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRask();
+
+// Three devices, built once at startup: each gets its own SQLite database and its own replica identity,
+// and they share a bucket and nothing else. Normally these would be three phones; here they are three
+// files in one process, which is the only difference that matters.
+//
+// cr-sqlite's native binary is not redistributed here, so RASK_CRSQLITE_PATH must point at the one for
+// this platform. Without it the page explains what to download instead of failing at the first query.
+var family = await FamilyDevices.CreateAsync(builder.Configuration);
+builder.Services.AddSingleton(family);
+
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.ShutdownTimeout = TimeSpan.FromSeconds(15);
+    options.ServicesStopConcurrently = true;
+});
+
+var app = builder.Build();
+
+app.Lifetime.ApplicationStopped.Register(() => family.DisposeAsync().AsTask().GetAwaiter().GetResult());
+
+app.MapStaticAssets();
+app.UseRouting();
+app.UseRask<App>();
+
+app.Run();

--- a/samples/Rask.Example.Crdt/Rask.Example.Crdt.csproj
+++ b/samples/Rask.Example.Crdt/Rask.Example.Crdt.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Server\Rask.Server.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.ObjectStore\Rask.ObjectStore.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.SQLite.Crdt\Rask.SQLite.Crdt.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.SQLite.Crdt.Sync\Rask.SQLite.Crdt.Sync.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"/>
+  </ItemGroup>
+
+  <!-- The ASP.NET Web SDK requires a wwwroot to exist even when there are no static files. -->
+  <Target Name="EnsureEmptyWwwroot" BeforeTargets="BeforeBuild">
+    <MakeDir Directories="wwwroot"/>
+  </Target>
+
+</Project>

--- a/samples/Rask.Example.Crdt/Shared/App.cs
+++ b/samples/Rask.Example.Crdt/Shared/App.cs
@@ -1,0 +1,38 @@
+namespace Rask.Example.Crdt;
+
+// App shell: the framework-managed <head> (Bootstrap + icons via CDN), a navbar, and a Router that
+// renders the matched page. Only this component renders the Doctype/Html/Head/Body shell — the page
+// returns a body fragment (RASK021).
+public sealed class App : Component
+{
+    protected override Component? Head =>
+    [
+        Title()["Rask — a shared database with no server"],
+        Meta("utf-8"),
+        Meta(Name: "viewport", Content: "width=device-width, initial-scale=1"),
+        Link(Rel: "stylesheet",
+            Href: "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"),
+        Link(Rel: "stylesheet",
+            Href: "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css")
+    ];
+
+    protected override Component? Render() =>
+    [
+        Doctype(),
+        Html("en")[
+            Head(),
+            Body(Class: "bg-body-tertiary")[
+                Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm")[
+                    Div(Class: "container-fluid px-4")[
+                        Span(Class: "navbar-brand fw-bold")[
+                            I(Class: "bi bi-diagram-3 me-2"), "Rask · Family todos"
+                        ],
+                        A("https://github.com/pal-tamas/rask", "_blank",
+                            Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
+                    ]
+                ],
+                Main(Class: "container-fluid px-4 py-4")[Router()]
+            ]
+        ]
+    ];
+}

--- a/src/Rask.ObjectStore/FolderObjectStore.cs
+++ b/src/Rask.ObjectStore/FolderObjectStore.cs
@@ -1,0 +1,217 @@
+namespace Rask.ObjectStore;
+
+/// <summary>
+///     A bucket backed by a directory on disk.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Useful in three places, and it is the same code for all of them: running a sample or a test
+///         without any cloud credentials, a single-machine deployment that has no reason to pay for
+///         object storage, and — the interesting one — a folder something <em>else</em> already
+///         replicates. Point it at a Syncthing share and devices converge with no central server at all;
+///         point it at iCloud Drive, Dropbox or OneDrive and the sync is somebody else's problem.
+///     </para>
+///     <para>
+///         Keys map to relative paths, so a key containing <c>/</c> becomes a subdirectory. Anything that
+///         would escape the root is refused rather than normalised: keys can come from a listing of a
+///         shared folder, so they are not automatically this process's own strings.
+///     </para>
+/// </remarks>
+public sealed class FolderObjectStore : IObjectStore
+{
+    private readonly string _root;
+
+    /// <summary>Creates a store over <paramref name="root" />, creating the directory if needed.</summary>
+    public FolderObjectStore(string root)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(root);
+
+        _root = Path.GetFullPath(root);
+        Directory.CreateDirectory(_root);
+    }
+
+    /// <inheritdoc />
+    public async Task<byte[]?> GetRangeAsync(
+        string key, long offset, int count, CancellationToken cancellationToken = default)
+    {
+        var path = Resolve(key);
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        await using var stream = File.OpenRead(path);
+        if (offset >= stream.Length)
+        {
+            return [];
+        }
+
+        stream.Seek(offset, SeekOrigin.Begin);
+        var buffer = new byte[Math.Min(count, stream.Length - offset)];
+        await stream.ReadExactlyAsync(buffer, cancellationToken).ConfigureAwait(false);
+        return buffer;
+    }
+
+    /// <inheritdoc />
+    public Task<Stream?> OpenReadAsync(string key, CancellationToken cancellationToken = default)
+    {
+        var path = Resolve(key);
+        return Task.FromResult<Stream?>(File.Exists(path) ? File.OpenRead(path) : null);
+    }
+
+    /// <inheritdoc />
+    public async Task PutAsync(string key, byte[] content, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        var path = Resolve(key);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        // Written beside and moved into place: a reader that lists the folder concurrently sees either
+        // nothing or the whole object, never a half-written one. That matters most for the case this
+        // exists for — a folder another process is replicating while it is being written.
+        var temporary = path + ".tmp";
+        await File.WriteAllBytesAsync(temporary, content, cancellationToken).ConfigureAwait(false);
+        File.Move(temporary, path, overwrite: true);
+    }
+
+    /// <inheritdoc />
+    public async Task PutAsync(
+        string key, Stream content, long length, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        var path = Resolve(key);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        var temporary = path + ".tmp";
+        await using (var file = File.Create(temporary))
+        {
+            await content.CopyToAsync(file, cancellationToken).ConfigureAwait(false);
+        }
+
+        File.Move(temporary, path, overwrite: true);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryCreateAsync(
+        string key, byte[] content, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        var path = Resolve(key);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        try
+        {
+            // CreateNew is the filesystem's own atomic "only if absent" — the same guarantee
+            // If-None-Match gives over HTTP, which is what this method means.
+            await using var file = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+            await file.WriteAsync(content, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (IOException) when (File.Exists(path))
+        {
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<ObjectEntry>> ListAsync(
+        string prefix, string? startAfter = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+
+        var entries = Enumerate(prefix)
+            .Where(key => startAfter is null || string.CompareOrdinal(key, startAfter) > 0)
+            .Order(StringComparer.Ordinal)   // ordinal, because forward-only reading depends on it
+            .Select(key =>
+            {
+                var info = new FileInfo(Resolve(key));
+                return new ObjectEntry(key, info.Length, info.LastWriteTimeUtc, null);
+            })
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<ObjectEntry>>(entries);
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<string>> ListPrefixesAsync(
+        string prefix, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+
+        var prefixes = Enumerate(prefix)
+            .Select(key => key[prefix.Length..])
+            .Select(rest => rest.IndexOf('/', StringComparison.Ordinal) is var slash && slash >= 0
+                ? prefix + rest[..(slash + 1)]
+                : null)
+            .OfType<string>()
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<string>>(prefixes);
+    }
+
+    /// <inheritdoc />
+    public Task DeleteAsync(string key, CancellationToken cancellationToken = default)
+    {
+        File.Delete(Resolve(key));
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Every key under <paramref name="prefix" />, in the store's own key form.</summary>
+    private IEnumerable<string> Enumerate(string prefix)
+    {
+        if (!Directory.Exists(_root))
+        {
+            yield break;
+        }
+
+        foreach (var path in Directory.EnumerateFiles(_root, "*", SearchOption.AllDirectories))
+        {
+            // A half-written object, not yet moved into place.
+            if (path.EndsWith(".tmp", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var key = Path.GetRelativePath(_root, path).Replace(Path.DirectorySeparatorChar, '/');
+            if (key.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                yield return key;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     The path a key names, refusing anything outside the root.
+    /// </summary>
+    /// <remarks>
+    ///     Keys are not necessarily this process's own strings — a peer's prefix comes back from a
+    ///     listing of a shared folder — so a key that climbs out of the root is refused rather than
+    ///     normalised into something that happens to be readable.
+    /// </remarks>
+    private string Resolve(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        if (Path.IsPathRooted(key))
+        {
+            throw new ArgumentException($"'{key}' is an absolute path, not a key.", nameof(key));
+        }
+
+        var full = Path.GetFullPath(Path.Combine(_root, key));
+        var boundary = _root.EndsWith(Path.DirectorySeparatorChar)
+            ? _root
+            : _root + Path.DirectorySeparatorChar;
+
+        if (!full.StartsWith(boundary, StringComparison.Ordinal))
+        {
+            throw new ArgumentException($"'{key}' resolves outside the store's folder.", nameof(key));
+        }
+
+        return full;
+    }
+}

--- a/tests/Rask.Examples.E2E.Tests/CrdtExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/CrdtExampleTests.cs
@@ -1,0 +1,138 @@
+using Microsoft.Playwright;
+using Rask.Examples.E2E.Tests.Infrastructure;
+
+namespace Rask.Examples.E2E.Tests;
+
+// End-to-end against the CRDT sample: three devices, three SQLite databases, one folder-backed bucket
+// and nothing else — an edit on one device reaches another after syncing, and concurrent edits to
+// different FIELDS of the same todo both survive, which is the claim per-column merging makes.
+//
+// cr-sqlite's native binary is per-platform and not in this repo, so the journeys run only when
+// RASK_CRSQLITE_PATH is set; without it the sample renders a setup card, and that is asserted instead.
+// One of the two always runs. Following WasmWatchHotReloadTests, the gate is an early return rather
+// than SkippableFact — this project deliberately has no Xunit.SkippableFact reference.
+[Collection(CrdtExampleCollection.Name)]
+public sealed class CrdtExampleTests(CrdtExampleAppFixture app, PlaywrightFixture pw) : IAsyncLifetime
+{
+    private IBrowserContext _ctx = default!;
+    private IPage _page = default!;
+
+    public async Task InitializeAsync()
+    {
+        _ctx = await pw.Browser.NewContextAsync(new BrowserNewContextOptions { BaseURL = app.BaseUrl });
+        _page = await _ctx.NewPageAsync();
+    }
+
+    public async Task DisposeAsync() => await _ctx.DisposeAsync();
+
+    [Fact]
+    public async Task Without_the_extension_the_page_says_what_to_download()
+    {
+        if (CrdtExampleAppFixture.ExtensionAvailable)
+        {
+            return;
+        }
+
+        await _page.GotoAsync("/");
+
+        // A missing extension otherwise surfaces as "no such function: crsql_as_crr", which says
+        // nothing about what to do about it.
+        var setup = _page.GetByTestId("setup");
+        await Assertions.Expect(setup).ToBeVisibleAsync();
+        await Assertions.Expect(setup).ToContainTextAsync("RASK_CRSQLITE_PATH");
+    }
+
+    [Fact]
+    public async Task An_edit_on_one_device_reaches_another()
+    {
+        if (!CrdtExampleAppFixture.ExtensionAvailable)
+        {
+            return;
+        }
+
+        await _page.GotoAsync("/");
+
+        await _page.GetByTestId("draft-Phone").FillAsync("buy milk");
+        await _page.GetByTestId("add-Phone").ClickAsync();
+
+        // Local first: the todo exists on the Phone before anything touches the bucket.
+        await Assertions.Expect(_page.GetByTestId("device-Phone")).ToContainTextAsync("buy milk");
+        await Assertions.Expect(_page.GetByTestId("device-Laptop")).Not.ToContainTextAsync("buy milk");
+
+        await _page.GetByTestId("sync-all").ClickAsync();
+
+        await Assertions.Expect(_page.GetByTestId("device-Laptop")).ToContainTextAsync("buy milk");
+        await Assertions.Expect(_page.GetByTestId("device-Tablet")).ToContainTextAsync("buy milk");
+    }
+
+    [Fact]
+    public async Task An_offline_device_keeps_working_and_catches_up()
+    {
+        if (!CrdtExampleAppFixture.ExtensionAvailable)
+        {
+            return;
+        }
+
+        await _page.GotoAsync("/");
+
+        await _page.GetByTestId("link-Tablet").ClickAsync();
+        await Assertions.Expect(_page.GetByTestId("link-Tablet")).ToContainTextAsync("Offline");
+
+        await _page.GetByTestId("draft-Tablet").FillAsync("water the plants");
+        await _page.GetByTestId("add-Tablet").ClickAsync();
+
+        // The edit is committed to the Tablet's own database; being offline is not an error state.
+        await Assertions.Expect(_page.GetByTestId("device-Tablet")).ToContainTextAsync("water the plants");
+        await _page.GetByTestId("sync-Tablet").ClickAsync();
+        await Assertions.Expect(_page.GetByTestId("status-Tablet")).ToContainTextAsync("offline");
+        await Assertions.Expect(_page.GetByTestId("device-Phone")).Not.ToContainTextAsync("water the plants");
+
+        await _page.GetByTestId("link-Tablet").ClickAsync();
+        await _page.GetByTestId("sync-all").ClickAsync();
+
+        await Assertions.Expect(_page.GetByTestId("device-Phone")).ToContainTextAsync("water the plants");
+    }
+
+    [Fact]
+    public async Task Concurrent_edits_to_different_fields_both_survive()
+    {
+        if (!CrdtExampleAppFixture.ExtensionAvailable)
+        {
+            return;
+        }
+
+        // The claim of the whole stack, driven through a browser: per column, not per row.
+        await _page.GotoAsync("/");
+
+        await _page.GetByTestId("draft-Phone").FillAsync("book the ferry");
+        await _page.GetByTestId("add-Phone").ClickAsync();
+        await _page.GetByTestId("sync-all").ClickAsync();
+        await Assertions.Expect(_page.GetByTestId("device-Laptop")).ToContainTextAsync("book the ferry");
+
+        // Both devices go offline, then edit different fields of the same todo.
+        await _page.GetByTestId("link-Phone").ClickAsync();
+        await _page.GetByTestId("link-Laptop").ClickAsync();
+
+        var phoneRow = _page.GetByTestId("device-Phone").Locator("li:has-text('book the ferry')");
+        var laptopRow = _page.GetByTestId("device-Laptop").Locator("li:has-text('book the ferry')");
+
+        await phoneRow.GetByRole(AriaRole.Button, new LocatorGetByRoleOptions { NameString = "P1" }).ClickAsync();
+        await Assertions.Expect(phoneRow).ToContainTextAsync("P2");
+
+        await laptopRow.Locator("button").Last.ClickAsync();   // the done toggle
+        await Assertions.Expect(laptopRow.Locator("s, .text-decoration-line-through")).ToHaveCountAsync(1);
+
+        await _page.GetByTestId("link-Phone").ClickAsync();
+        await _page.GetByTestId("link-Laptop").ClickAsync();
+        await _page.GetByTestId("sync-all").ClickAsync();
+
+        // Neither edit was chosen over the other: the priority came from the Phone, the done flag from
+        // the Laptop, and both devices now show both.
+        foreach (var device in new[] { "Phone", "Laptop" })
+        {
+            var row = _page.GetByTestId($"device-{device}").Locator("li:has-text('book the ferry')");
+            await Assertions.Expect(row).ToContainTextAsync("P2");
+            await Assertions.Expect(row.Locator(".text-decoration-line-through")).ToHaveCountAsync(1);
+        }
+    }
+}

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/CrdtExampleAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/CrdtExampleAppFixture.cs
@@ -1,0 +1,23 @@
+namespace Rask.Examples.E2E.Tests.Infrastructure;
+
+/// <summary>
+///     The CRDT sample. cr-sqlite's native binary is per-platform and not in this repo, so the path is
+///     passed through from the environment: with it the sample runs three real replicas, without it the
+///     page explains what to download. Both states are asserted — see <c>CrdtExampleTests</c>.
+/// </summary>
+public sealed class CrdtExampleAppFixture : ExampleAppFixture
+{
+    /// <summary>Whether cr-sqlite is available to this run.</summary>
+    public static bool ExtensionAvailable =>
+        Environment.GetEnvironmentVariable("RASK_CRSQLITE_PATH") is { Length: > 0 } path && File.Exists(path);
+
+    protected override string ProjectRelativePath => "samples/Rask.Example.Crdt";
+
+    protected override IReadOnlyDictionary<string, string>? ExtraEnvironment =>
+        ExtensionAvailable
+            ? new Dictionary<string, string>
+            {
+                ["RASK_CRSQLITE_PATH"] = Environment.GetEnvironmentVariable("RASK_CRSQLITE_PATH")!,
+            }
+            : null;
+}

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppCollections.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppCollections.cs
@@ -22,6 +22,13 @@ public sealed class SqliteExampleCollection
 }
 
 [CollectionDefinition(Name)]
+public sealed class CrdtExampleCollection
+    : ICollectionFixture<CrdtExampleAppFixture>, ICollectionFixture<PlaywrightFixture>
+{
+    public const string Name = "CrdtExample";
+}
+
+[CollectionDefinition(Name)]
 public sealed class WasmExampleCollection
     : ICollectionFixture<WasmExampleAppFixture>, ICollectionFixture<PlaywrightFixture>
 {

--- a/tests/Rask.ObjectStore.Tests/FolderObjectStoreTests.cs
+++ b/tests/Rask.ObjectStore.Tests/FolderObjectStoreTests.cs
@@ -1,0 +1,191 @@
+using System.Text;
+
+namespace Rask.ObjectStore.Tests;
+
+/// <summary>
+///     The contract the sync engines rely on, asserted against a real directory: ordinal key order,
+///     exclusive <c>startAfter</c>, grouped listing, atomic conditional create — plus the traversal
+///     guard, because keys can come from a listing of a folder somebody else also writes to.
+/// </summary>
+public sealed class FolderObjectStoreTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), $"rask-folder-store-{Guid.NewGuid():N}");
+
+    private FolderObjectStore Store => new(_root);
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A leftover temp folder is not worth failing a green run over.
+        }
+    }
+
+    [Fact]
+    public async Task An_object_round_trips()
+    {
+        var store = Store;
+        await store.PutAsync("a/b/c.json", Encoding.UTF8.GetBytes("hello"));
+
+        var stream = await store.OpenReadAsync("a/b/c.json");
+        Assert.NotNull(stream);
+
+        using var reader = new StreamReader(stream!);
+        Assert.Equal("hello", await reader.ReadToEndAsync());
+    }
+
+    [Fact]
+    public async Task A_missing_object_reads_as_null()
+    {
+        Assert.Null(await Store.OpenReadAsync("nope.json"));
+        Assert.Null(await Store.GetRangeAsync("nope.json", 0, 10));
+    }
+
+    [Fact]
+    public async Task Keys_list_in_ordinal_order()
+    {
+        // Forward-only reading is built on this: the engine treats "the last key I read" as a position
+        // in a total order, so a store that listed by mtime or by directory order would skip changes.
+        var store = Store;
+        foreach (var key in new[] { "p/0000000000000010.json", "p/0000000000000002.json", "p/0000000000000001.json" })
+        {
+            await store.PutAsync(key, [1]);
+        }
+
+        var listed = await store.ListAsync("p/");
+
+        Assert.Equal(
+            ["p/0000000000000001.json", "p/0000000000000002.json", "p/0000000000000010.json"],
+            listed.Select(e => e.Key));
+    }
+
+    [Fact]
+    public async Task StartAfter_is_exclusive()
+    {
+        var store = Store;
+        await store.PutAsync("p/a.json", [1]);
+        await store.PutAsync("p/b.json", [1]);
+        await store.PutAsync("p/c.json", [1]);
+
+        var listed = await store.ListAsync("p/", "p/b.json");
+
+        Assert.Equal(["p/c.json"], listed.Select(e => e.Key));
+    }
+
+    [Fact]
+    public async Task A_prefix_only_matches_its_own_keys()
+    {
+        var store = Store;
+        await store.PutAsync("alice/x.json", [1]);
+        await store.PutAsync("bob/x.json", [1]);
+
+        Assert.Equal(["alice/x.json"], (await store.ListAsync("alice/")).Select(e => e.Key));
+    }
+
+    [Fact]
+    public async Task Grouped_listing_returns_the_immediate_folders()
+    {
+        var store = Store;
+        await store.PutAsync("crdt/alice/changes/1.json", [1]);
+        await store.PutAsync("crdt/alice/changes/2.json", [1]);
+        await store.PutAsync("crdt/bob/changes/1.json", [1]);
+
+        var prefixes = await store.ListPrefixesAsync("crdt/");
+
+        Assert.Equal(["crdt/alice/", "crdt/bob/"], prefixes);
+    }
+
+    [Fact]
+    public async Task Conditional_create_refuses_an_existing_key()
+    {
+        var store = Store;
+
+        Assert.True(await store.TryCreateAsync("once.json", Encoding.UTF8.GetBytes("first")));
+        Assert.False(await store.TryCreateAsync("once.json", Encoding.UTF8.GetBytes("second")));
+
+        var stream = await store.OpenReadAsync("once.json");
+        using var reader = new StreamReader(stream!);
+        Assert.Equal("first", await reader.ReadToEndAsync());
+    }
+
+    [Fact]
+    public async Task A_ranged_read_returns_the_range()
+    {
+        var store = Store;
+        await store.PutAsync("r.bin", [0, 1, 2, 3, 4, 5]);
+
+        Assert.Equal([2, 3], await store.GetRangeAsync("r.bin", 2, 2));
+        Assert.Equal([4, 5], await store.GetRangeAsync("r.bin", 4, 99));
+        Assert.Empty((await store.GetRangeAsync("r.bin", 99, 2))!);
+    }
+
+    [Fact]
+    public async Task Overwriting_replaces_the_whole_object()
+    {
+        var store = Store;
+        await store.PutAsync("k.bin", [1, 2, 3, 4, 5]);
+        await store.PutAsync("k.bin", [9]);
+
+        Assert.Equal([9], await store.GetRangeAsync("k.bin", 0, 100));
+    }
+
+    [Fact]
+    public async Task A_half_written_object_is_not_listed()
+    {
+        // The folder may be replicated by something else while it is being written, so the temporary
+        // file must never look like an object to a reader.
+        var store = Store;
+        await store.PutAsync("p/real.json", [1]);
+        await File.WriteAllBytesAsync(Path.Combine(_root, "p", "pending.json.tmp"), [1]);
+
+        Assert.Equal(["p/real.json"], (await store.ListAsync("p/")).Select(e => e.Key));
+    }
+
+    [Theory]
+    [InlineData("../escape.json")]
+    [InlineData("a/../../escape.json")]
+    public async Task A_key_that_climbs_out_of_the_folder_is_refused(string key)
+    {
+        // Keys are not always this process's own strings — a peer's prefix comes back from a listing —
+        // so escaping is refused rather than normalised into something readable.
+        await Assert.ThrowsAsync<ArgumentException>(() => Store.PutAsync(key, [1]));
+        await Assert.ThrowsAsync<ArgumentException>(() => Store.OpenReadAsync(key));
+    }
+
+    [Fact]
+    public async Task An_absolute_path_is_refused()
+    {
+        var absolute = Path.Combine(Path.GetTempPath(), "elsewhere.json");
+        await Assert.ThrowsAsync<ArgumentException>(() => Store.PutAsync(absolute, [1]));
+    }
+
+    [Fact]
+    public async Task Deleting_something_absent_is_not_an_error()
+    {
+        await Store.DeleteAsync("never-existed.json");
+    }
+
+    [Fact]
+    public async Task Delete_removes_the_object()
+    {
+        var store = Store;
+        await store.PutAsync("gone.json", [1]);
+        await store.DeleteAsync("gone.json");
+
+        Assert.Null(await store.OpenReadAsync("gone.json"));
+    }
+
+    [Fact]
+    public async Task A_second_store_over_the_same_folder_sees_the_same_objects()
+    {
+        // The whole point when the folder is shared: two processes, or two runs, are the same bucket.
+        await Store.PutAsync("shared/x.json", Encoding.UTF8.GetBytes("hi"));
+
+        Assert.Equal(["shared/x.json"], (await Store.ListAsync("shared/")).Select(e => e.Key));
+    }
+}


### PR DESCRIPTION
Three devices — Phone, Laptop, Tablet — each with its own SQLite file and its own replica identity,
sharing a bucket and nothing else. Normally these would be three phones; here they are three files in
one process, which is the only difference that matters. Item 7 of #642.

> **Stacked on #666** (which is stacked on #665). Retarget as those merge.

```bash
RASK_CRSQLITE_PATH=/path/to/crsqlite.dylib dotnet run --project samples/Rask.Example.Crdt
```

## The thing to try

Take two devices offline, edit **different fields of the same todo** on each — the priority on one, the
done flag on the other — bring both back and press *Sync everyone*. Both edits survive. Do the same with
a `LastModified` column and one of them is gone.

An E2E drives exactly that through a browser, so the claim is tested rather than asserted in prose.

Each device's link to the bucket has a switch, and flipping it makes every call fail as a real client
would see it — so the demo exercises the real offline path rather than a case the engine knows about.
The status line says *"your edits are saved and will sync later"* rather than reporting a failure,
because the edit is already committed to that device's own database.

## `FolderObjectStore`

The same `IObjectStore` over a directory. It is what lets the sample run with no cloud credentials, but
it is not only a test double:

- a single-machine deployment with no reason to pay for object storage;
- **a folder something else already replicates** — pointed at a Syncthing share, devices converge with
  no central server at all; pointed at iCloud Drive or Dropbox, the replication is somebody else's
  problem.

Objects are written beside their key and moved into place, so a reader listing concurrently sees either
nothing or the whole object — which matters most when another process is replicating the folder while it
is being written. Keys that would escape the root are **refused rather than normalised**, since a key can
come back from a listing of a folder other people also write to. `TryCreateAsync` maps to the
filesystem's own atomic create, so the conditional-create pattern works there too.

## The missing-binary problem, handled honestly

cr-sqlite ships per-platform and is not redistributed here. Without `RASK_CRSQLITE_PATH` the page
explains what to download instead of failing at the first query — a missing extension otherwise surfaces
as `no such function: crsql_as_crr`, which says nothing about what to do.

**That state is asserted too**, so the E2E file never quietly skips in full on a machine without the
binary; one of the two paths always runs. Verified by mutation: breaking the setup-card assertion turns
it red on a no-extension run, so it is not passing vacuously.

## Testing

```
dotnet test tests/Rask.ObjectStore.Tests                  # 78 passed (16 new)
RASK_CRSQLITE_PATH=… <pre-push E2E gate>                  # 64 browser journeys (was 60)
```

The four new journeys ran inside the real gate with the extension present, and pass without it via the
setup-card path.

Local gates: `dotnet format` clean, `dotnet build -warnaserror` clean, 336 + 320 unit, 64 browser
journeys, 26 CLI build-gate.

## A note on the build

Building the E2E project tripped the **MSBuild node-reuse bake failure (#650)** — the guard added in
#652 caught it and named the fix (`-nodeReuse:false`). Pre-existing, not introduced here, but worth
knowing it is still reachable from an ordinary project build.
