### PR TITLE
feat(sqlite): fold a replica's own objects into one so a shared bucket stops growing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,21 @@ them until tagged releases begin.
   branches ([#661](https://github.com/pal-tamas/rask/issues/661)).
 
 ### Added
+- **Compaction, so a shared bucket doesn't grow forever.** A replica folds its own objects into a single
+  one holding its whole current contribution and removes the rest — automatically once its prefix passes
+  `CompactAfterObjects` (default 50), or on demand via `CompactAsync()`. What makes it cheap is a
+  property of cr-sqlite's feed worth knowing on its own: **it is current state, not history** — one entry
+  per (row, column) with the value that won, so editing a field forty times leaves *one* entry and a
+  deleted row collapses to a single tombstone. Republishing everything therefore costs the size of the
+  database rather than the number of edits ever made. No coordination is needed, because a replica only
+  ever rewrites its own prefix — the same rule that removes write conflicts makes compaction a local
+  decision. Three things keep it safe, each pinned by a test: the replacement is keyed so it sorts
+  **after** everything it replaces (a replacement that sorted earlier would silently stop reaching peers
+  that had already synced); re-reading state a peer already holds is harmless because applying twice does
+  nothing; and a peer reading an object as it is removed skips it and finds the replacement. The payoff
+  is a new device's first sync — one object per peer instead of replaying every sync those peers have
+  ever done, verified against the real extension including that a **tombstone survives compaction**, so a
+  deleted row does not come back from the dead.
 - **A working sample: three devices sharing one database with no server.**
   `samples/Rask.Example.Crdt` runs three replicas — Phone, Laptop, Tablet — each with its own SQLite
   file and its own replica identity, sharing a bucket and nothing else. Each device can be taken

--- a/docs/sqlite-crdt-sync.md
+++ b/docs/sqlite-crdt-sync.md
@@ -59,6 +59,34 @@ silently skips changes.
 The watermark advances **after** the changes are committed locally, so an interrupted pull is retried
 rather than skipped. Skipped changes never come back — the peer has no reason to publish them again.
 
+## Compaction: why the bucket doesn't grow forever
+
+A replica folds its own objects into a single one holding its whole current contribution, and removes
+the rest — automatically once its prefix passes `CompactAfterObjects` (default 50), or on demand:
+
+```csharp
+var removed = await engine.CompactAsync();
+```
+
+What makes this cheap is a property of the change feed worth knowing on its own: **it is current state,
+not history.** cr-sqlite holds one entry per (row, column) with the value that won, so editing the same
+field forty times leaves *one* entry, and a deleted row collapses to a single tombstone. Republishing
+everything therefore costs the size of the database rather than the number of edits ever made.
+
+**No coordination is needed**, because a replica only ever rewrites its own prefix — the same rule that
+removes write conflicts makes compaction a purely local decision. Three things keep it safe:
+
+- the replacement is keyed so it sorts **after** everything it replaces, so every peer picks it up
+  whatever watermark it holds;
+- re-reading state a peer already has is harmless, because applying a change twice does nothing;
+- a peer reading an object at the moment it is removed skips it and finds the replacement — the engine
+  already treats a vanished object as ordinary.
+
+The payoff is the first sync of a **new device**: it fetches one object per peer instead of replaying
+every sync those peers have ever done.
+
+Set `CompactAfterObjects = 0` to turn it off.
+
 ## Offline is the normal case, not an error
 
 The **database is the queue.** An edit is committed to SQLite by `SaveChanges` before any of this runs,

--- a/src/Rask.SQLite.Crdt.Sync/CrdtSyncEngine.cs
+++ b/src/Rask.SQLite.Crdt.Sync/CrdtSyncEngine.cs
@@ -69,6 +69,7 @@ public sealed class CrdtSyncEngine
         try
         {
             var published = await PushAsync(cancellationToken).ConfigureAwait(false);
+            await MaybeCompactAsync(cancellationToken).ConfigureAwait(false);
             var (received, peers) = await PullAsync(cancellationToken).ConfigureAwait(false);
 
             return Report(new CrdtSyncStatus(CrdtSyncPhase.Synced, published, received, peers));
@@ -114,6 +115,109 @@ public sealed class CrdtSyncEngine
         }
 
         return uploaded;
+    }
+
+    /// <summary>
+    ///     Folds this replica's own objects into a single one holding its whole current contribution,
+    ///     then removes the rest. Returns the number of objects removed.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Cheap for a reason worth knowing: the change feed is <b>current state, not history</b>. It
+    ///         holds one entry per (row, column) with the value that won, so editing the same field a
+    ///         thousand times leaves one entry, and a deleted row collapses to a single tombstone.
+    ///         Republishing everything therefore costs the size of the database rather than the number of
+    ///         edits ever made.
+    ///     </para>
+    ///     <para>
+    ///         <b>No coordination is needed</b>, because a replica only ever rewrites its own prefix —
+    ///         the same rule that removes write conflicts also makes compaction a local decision.
+    ///     </para>
+    ///     <para>
+    ///         The replacement is keyed so it sorts <em>after</em> everything it replaces, so every peer
+    ///         picks it up whatever watermark it holds, and re-reading state a peer already has is
+    ///         harmless because applying a change twice does nothing. A peer reading an object at the
+    ///         moment it is removed simply skips it and finds the replacement.
+    ///     </para>
+    /// </remarks>
+    public async Task<int> CompactAsync(CancellationToken cancellationToken = default)
+    {
+        var site = Hex(await _feed.GetSiteIdAsync(cancellationToken).ConfigureAwait(false));
+        var folder = $"{Prefix}{site}/changes/";
+
+        var existing = await _store.ListAsync(folder, null, cancellationToken).ConfigureAwait(false);
+        if (existing.Count <= 1)
+        {
+            return 0;
+        }
+
+        var state = await _feed.ReadLocalChangesAsync(-1, cancellationToken).ConfigureAwait(false);
+        if (state.Count == 0)
+        {
+            // Everything this replica once wrote is now owned by a peer — every column it contributed
+            // has since been overwritten, or the rows were deleted and the tombstones carry the
+            // deleter's identity. The peers that own those changes publish them, so removing this
+            // replica's stale objects loses nothing.
+            return await RemoveAsync(existing.Select(e => e.Key), null, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        // Sorts at or after every object it replaces: a peer resuming from any earlier key still sees
+        // it. Keyed from the highest version present rather than the connection's current version, so
+        // the key describes exactly what the object contains.
+        var top = state.Max(c => c.DbVersion);
+        var replacement = $"{folder}{top:x16}__{top:x16}.json";
+
+        await _store.PutAsync(replacement, CrdtChangeCodec.Encode(state), cancellationToken)
+            .ConfigureAwait(false);
+        await _state.SetPublishedVersionAsync(top, cancellationToken).ConfigureAwait(false);
+
+        // Written before anything is removed: a crash between the two leaves duplicate state in the
+        // bucket, which is harmless, whereas the other order could leave a peer with neither.
+        return await RemoveAsync(existing.Select(e => e.Key), replacement, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Compacts once this replica's prefix has grown past <see cref="CrdtSyncOptions.CompactAfterObjects" />.
+    /// </summary>
+    /// <remarks>
+    ///     Counted rather than timed, because what makes a new device's first sync expensive is the
+    ///     number of objects it has to fetch, not how old they are.
+    /// </remarks>
+    private async Task MaybeCompactAsync(CancellationToken cancellationToken)
+    {
+        if (_options.CompactAfterObjects <= 0)
+        {
+            return;
+        }
+
+        var site = Hex(await _feed.GetSiteIdAsync(cancellationToken).ConfigureAwait(false));
+        var mine = await _store.ListAsync($"{Prefix}{site}/changes/", null, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (mine.Count > _options.CompactAfterObjects)
+        {
+            await CompactAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<int> RemoveAsync(
+        IEnumerable<string> keys, string? keep, CancellationToken cancellationToken)
+    {
+        var removed = 0;
+        foreach (var key in keys)
+        {
+            if (string.Equals(key, keep, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            await _store.DeleteAsync(key, cancellationToken).ConfigureAwait(false);
+            removed++;
+        }
+
+        return removed;
     }
 
     /// <summary>Applies everything peers have published since this replica last read from them.</summary>

--- a/src/Rask.SQLite.Crdt.Sync/CrdtSyncOptions.cs
+++ b/src/Rask.SQLite.Crdt.Sync/CrdtSyncOptions.cs
@@ -19,6 +19,19 @@ public sealed class CrdtSyncOptions
     /// </remarks>
     public int MaxChangesPerObject { get; set; } = 5000;
 
+    /// <summary>
+    ///     Compact this replica's own objects into one during a sync once it has published more than
+    ///     this many. Default 50; zero or less turns it off.
+    /// </summary>
+    /// <remarks>
+    ///     What makes this cheap is that the change feed is <b>current state, not history</b>: it holds
+    ///     one entry per (row, column) with the value that won, so editing the same field a thousand
+    ///     times leaves one entry and a deleted row collapses to a single tombstone. Republishing
+    ///     everything therefore costs the size of the database rather than the number of edits ever
+    ///     made — which is what lets a device fold its whole prefix into one object.
+    /// </remarks>
+    public int CompactAfterObjects { get; set; } = 50;
+
     internal string PeersPrefix => Normalized;
 
     internal string Normalized => Prefix.Length == 0 || Prefix.EndsWith('/') ? Prefix : Prefix + "/";

--- a/src/Rask.SQLite.Crdt.Sync/NUGET.md
+++ b/src/Rask.SQLite.Crdt.Sync/NUGET.md
@@ -35,6 +35,16 @@ sync stopped. Peers are found with a grouped listing, so discovery costs one res
 publishing it unfiltered would have each device re-uploading every other device's history. Uploads are
 batched, because object storage charges per request.
 
+## The bucket doesn't grow forever
+
+A replica folds its own objects into one holding its whole current contribution and removes the rest —
+automatically past `CompactAfterObjects` (default 50), or via `await engine.CompactAsync()`.
+
+Cheap because the change feed is **current state, not history**: one entry per (row, column) with the
+value that won, so editing a field forty times leaves one entry and a deleted row collapses to a single
+tombstone. No coordination is needed, since a replica only rewrites its own prefix. The payoff is a new
+device's first sync — one object per peer, instead of replaying every sync those peers ever did.
+
 ## Offline is the normal case, not an error
 
 The **database is the queue**. An edit is committed to SQLite before any sync is attempted, so there is

--- a/tests/Rask.SQLite.Crdt.Sync.Tests/CrdtCompactionTests.cs
+++ b/tests/Rask.SQLite.Crdt.Sync.Tests/CrdtCompactionTests.cs
@@ -1,0 +1,236 @@
+namespace Rask.SQLite.Crdt.Sync.Tests;
+
+/// <summary>
+///     Compaction folds a replica's own objects into one. What makes it possible is that the feed is
+///     current state rather than history; what makes it safe is that a replica only ever rewrites its
+///     own prefix, and that the replacement sorts after everything it replaces.
+/// </summary>
+public sealed class CrdtCompactionTests
+{
+    private const string AliceSite = "aa000000000000000000000000000001";
+    private const string BobSite = "bb000000000000000000000000000002";
+
+    [Fact]
+    public async Task Many_objects_become_one()
+    {
+        var (bucket, feed, alice) = Engine(AliceSite, new CrdtSyncOptions { MaxChangesPerObject = 1 });
+
+        for (var i = 0; i < 8; i++)
+        {
+            feed.Write("Todos", "Title", $"item {i}");
+        }
+
+        await alice.PushAsync();
+        Assert.Equal(8, bucket.Keys.Count);
+
+        var removed = await alice.CompactAsync();
+
+        // Seven, not eight: the replacement covers up to the newest version, so its key is the newest
+        // object's key and it replaces that one in place rather than being written beside it.
+        Assert.Equal(7, removed);
+        Assert.Single(bucket.Keys);
+    }
+
+    [Fact]
+    public async Task The_replacement_sorts_after_everything_it_replaced()
+    {
+        // The property the whole design rests on. A peer resumes from the last key it read, so a
+        // replacement that sorted BEFORE that key would never be fetched — and because it is the only
+        // object left, the peer would silently stop receiving anything from this replica.
+        var (bucket, feed, alice) = Engine(AliceSite, new CrdtSyncOptions { MaxChangesPerObject = 1 });
+
+        for (var i = 0; i < 5; i++)
+        {
+            feed.Write("Todos", "Title", $"item {i}");
+        }
+
+        await alice.PushAsync();
+        var before = bucket.Keys.Order(StringComparer.Ordinal).ToList();
+
+        await alice.CompactAsync();
+        var replacement = Assert.Single(bucket.Keys);
+
+        Assert.All(before, old =>
+            Assert.True(string.CompareOrdinal(replacement, old) >= 0,
+                $"'{replacement}' must sort at or after the '{old}' it replaced"));
+    }
+
+    [Fact]
+    public async Task A_peer_that_already_synced_loses_nothing()
+    {
+        var (bucket, feed, alice) = Engine(AliceSite, new CrdtSyncOptions { MaxChangesPerObject = 1 });
+        var bobFeed = new FakeChangeFeed(BobSite);
+        var bob = new CrdtSyncEngine(bucket, bobFeed);
+
+        for (var i = 0; i < 5; i++)
+        {
+            feed.Write("Todos", "Title", $"item {i}");
+        }
+
+        await alice.PushAsync();
+        await bob.SyncAsync();
+        var seenBefore = bobFeed.Log.Count;
+
+        await alice.CompactAsync();
+        feed.Write("Todos", "Title", "after compaction");
+        await alice.PushAsync();
+
+        await bob.SyncAsync();
+
+        // Bob keeps everything he had and picks up what came after.
+        Assert.True(bobFeed.Log.Count >= seenBefore);
+        Assert.Contains(bobFeed.Log, c => Equals(c.Value, "after compaction"));
+        foreach (var i in Enumerable.Range(0, 5))
+        {
+            Assert.Contains(bobFeed.Log, c => Equals(c.Value, $"item {i}"));
+        }
+    }
+
+    [Fact]
+    public async Task A_brand_new_peer_gets_the_whole_state_from_one_object()
+    {
+        // The payoff: a device joining a year-old family does not replay a year of syncs.
+        var (bucket, feed, alice) = Engine(AliceSite, new CrdtSyncOptions { MaxChangesPerObject = 1 });
+
+        for (var i = 0; i < 6; i++)
+        {
+            feed.Write("Todos", "Title", $"item {i}");
+        }
+
+        await alice.PushAsync();
+        await alice.CompactAsync();
+
+        var newcomerFeed = new FakeChangeFeed(BobSite);
+        var newcomer = new CrdtSyncEngine(bucket, newcomerFeed);
+        var status = await newcomer.SyncAsync();
+
+        Assert.Equal(6, status.Received);
+        Assert.Equal(1, bucket.Gets);
+    }
+
+    [Fact]
+    public async Task Compacting_twice_changes_nothing_the_second_time()
+    {
+        var (bucket, feed, alice) = Engine(AliceSite, new CrdtSyncOptions { MaxChangesPerObject = 1 });
+
+        for (var i = 0; i < 4; i++)
+        {
+            feed.Write("Todos", "Title", $"item {i}");
+        }
+
+        await alice.PushAsync();
+        await alice.CompactAsync();
+        var after = bucket.Keys.ToList();
+
+        Assert.Equal(0, await alice.CompactAsync());
+        Assert.Equal(after, bucket.Keys);
+    }
+
+    [Fact]
+    public async Task Compaction_leaves_another_replicas_prefix_alone()
+    {
+        // A replica only ever rewrites its own prefix — the same rule that removes write conflicts is
+        // what makes compaction a purely local decision, needing no coordination.
+        var bucket = new FakeObjectStore();
+        var aliceFeed = new FakeChangeFeed(AliceSite);
+        var alice = new CrdtSyncEngine(bucket, aliceFeed, null,
+            new CrdtSyncOptions { MaxChangesPerObject = 1, CompactAfterObjects = 0 });
+        var bobFeed = new FakeChangeFeed(BobSite);
+        var bob = new CrdtSyncEngine(bucket, bobFeed, null,
+            new CrdtSyncOptions { MaxChangesPerObject = 1, CompactAfterObjects = 0 });
+
+        for (var i = 0; i < 3; i++)
+        {
+            aliceFeed.Write("Todos", "Title", $"alice {i}");
+            bobFeed.Write("Todos", "Title", $"bob {i}");
+        }
+
+        await alice.PushAsync();
+        await bob.PushAsync();
+
+        var bobsKeys = bucket.Keys.Where(k => k.Contains(BobSite, StringComparison.Ordinal)).ToList();
+        await alice.CompactAsync();
+
+        Assert.Equal(bobsKeys, bucket.Keys.Where(k => k.Contains(BobSite, StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public async Task A_sync_compacts_once_the_prefix_grows_past_the_threshold()
+    {
+        var bucket = new FakeObjectStore();
+        var feed = new FakeChangeFeed(AliceSite);
+        var alice = new CrdtSyncEngine(bucket, feed, null,
+            new CrdtSyncOptions { MaxChangesPerObject = 1, CompactAfterObjects = 3 });
+
+        for (var i = 0; i < 5; i++)
+        {
+            feed.Write("Todos", "Title", $"item {i}");
+        }
+
+        await alice.SyncAsync();
+
+        Assert.Single(bucket.Keys);
+    }
+
+    [Fact]
+    public async Task Compaction_can_be_turned_off()
+    {
+        var bucket = new FakeObjectStore();
+        var feed = new FakeChangeFeed(AliceSite);
+        var alice = new CrdtSyncEngine(bucket, feed, null,
+            new CrdtSyncOptions { MaxChangesPerObject = 1, CompactAfterObjects = 0 });
+
+        for (var i = 0; i < 5; i++)
+        {
+            feed.Write("Todos", "Title", $"item {i}");
+        }
+
+        await alice.SyncAsync();
+
+        Assert.Equal(5, bucket.Keys.Count);
+    }
+
+    [Fact]
+    public async Task Publishing_resumes_correctly_after_compaction()
+    {
+        // The published watermark has to follow the replacement key, or the next push re-uploads
+        // everything the compaction just folded up.
+        var (bucket, feed, alice) = Engine(AliceSite, new CrdtSyncOptions { MaxChangesPerObject = 1 });
+
+        for (var i = 0; i < 4; i++)
+        {
+            feed.Write("Todos", "Title", $"item {i}");
+        }
+
+        await alice.PushAsync();
+        await alice.CompactAsync();
+
+        Assert.Equal(0, await alice.PushAsync());
+        Assert.Single(bucket.Keys);
+
+        feed.Write("Todos", "Title", "new one");
+        Assert.Equal(1, await alice.PushAsync());
+        Assert.Equal(2, bucket.Keys.Count);
+    }
+
+    [Fact]
+    public async Task A_single_object_is_left_alone()
+    {
+        var (bucket, feed, alice) = Engine(AliceSite, new CrdtSyncOptions());
+        feed.Write("Todos", "Title", "only one");
+        await alice.PushAsync();
+
+        Assert.Equal(0, await alice.CompactAsync());
+        Assert.Single(bucket.Keys);
+    }
+
+    private static (FakeObjectStore Bucket, FakeChangeFeed Feed, CrdtSyncEngine Engine) Engine(
+        string site, CrdtSyncOptions options)
+    {
+        // Compaction off by default in these, so the explicit CompactAsync calls are what is under test.
+        options.CompactAfterObjects = 0;
+        var bucket = new FakeObjectStore();
+        var feed = new FakeChangeFeed(site);
+        return (bucket, feed, new CrdtSyncEngine(bucket, feed, null, options));
+    }
+}

--- a/tests/Rask.SQLite.Crdt.Sync.Tests/RealReplicaSyncTests.cs
+++ b/tests/Rask.SQLite.Crdt.Sync.Tests/RealReplicaSyncTests.cs
@@ -159,9 +159,81 @@ public sealed class RealReplicaSyncTests : IDisposable
         Assert.Equal(0, (await bob.Engine.SyncAsync()).Received);
     }
 
+    [SkippableFact]
+    public async Task Compaction_costs_the_size_of_the_database_not_the_number_of_edits()
+    {
+        Skip.If(!Available(), SkipReason);
+
+        // The claim compaction rests on, and the one the fake feed cannot model: cr-sqlite's feed holds
+        // one entry per (row, column) with the value that won, so editing a field a hundred times leaves
+        // ONE entry. If it were a history log, folding a prefix into a single object would be pointless.
+        var bucket = new FakeObjectStore();
+        await using var alice = await NewReplicaAsync(bucket);
+
+        var id = Guid.NewGuid();
+        alice.Context.Todos.Add(new Todo { Id = id, Title = "v1" });
+        await alice.Context.SaveChangesAsync();
+
+        var afterInsert = (await new CrdtChangeFeed(alice.Context).ReadLocalChangesAsync()).Count;
+
+        for (var i = 2; i <= 40; i++)
+        {
+            alice.Context.ChangeTracker.Clear();
+            var todo = await alice.Context.Todos.SingleAsync(t => t.Id == id);
+            todo.Title = $"v{i}";
+            await alice.Context.SaveChangesAsync();
+        }
+
+        var afterEdits = await new CrdtChangeFeed(alice.Context).ReadLocalChangesAsync();
+
+        Assert.Equal(afterInsert, afterEdits.Count);
+        Assert.Equal("v40", Assert.Single(afterEdits, c => c.ColumnName == "Title").Value);
+    }
+
+    [SkippableFact]
+    public async Task A_new_device_reaches_the_right_state_from_a_compacted_prefix()
+    {
+        Skip.If(!Available(), SkipReason);
+
+        var bucket = new FakeObjectStore();
+        await using var alice = await NewReplicaAsync(bucket, new CrdtSyncOptions
+        {
+            MaxChangesPerObject = 1,
+            CompactAfterObjects = 0,
+        });
+
+        var kept = Guid.NewGuid();
+        var removed = Guid.NewGuid();
+
+        alice.Context.Todos.Add(new Todo { Id = kept, Title = "still here", Priority = 2 });
+        alice.Context.Todos.Add(new Todo { Id = removed, Title = "deleted later" });
+        await alice.Context.SaveChangesAsync();
+        await alice.Engine.PushAsync();
+
+        alice.Context.ChangeTracker.Clear();
+        alice.Context.Todos.Remove(await alice.Context.Todos.SingleAsync(t => t.Id == removed));
+        await alice.Context.SaveChangesAsync();
+        await alice.Engine.PushAsync();
+
+        Assert.True(bucket.Keys.Count > 1);
+        await alice.Engine.CompactAsync();
+        Assert.Single(bucket.Keys);
+
+        // A device that has never seen any of it: the surviving todo arrives, and the deleted one stays
+        // deleted — the tombstone has to survive compaction, or the row would come back from the dead.
+        await using var newcomer = await NewReplicaAsync(bucket);
+        Assert.Equal(CrdtSyncPhase.Synced, (await newcomer.Engine.SyncAsync()).Phase);
+
+        newcomer.Context.ChangeTracker.Clear();
+        var todos = await newcomer.Context.Todos.ToListAsync();
+
+        Assert.Equal("still here", Assert.Single(todos).Title);
+        Assert.Equal(2, todos[0].Priority);
+    }
+
     private static bool Available() => ExtensionPath is { Length: > 0 } p && File.Exists(p);
 
-    private async Task<Replica> NewReplicaAsync(FakeObjectStore bucket)
+    private async Task<Replica> NewReplicaAsync(FakeObjectStore bucket, CrdtSyncOptions? options = null)
     {
         var file = Path.Combine(Path.GetTempPath(), $"rask-crdt-sync-{Guid.NewGuid():N}.db");
         _files.Add(file);
@@ -181,7 +253,7 @@ public sealed class RealReplicaSyncTests : IDisposable
         await context.PromoteToCrrsAsync();
 
         var feed = new CrdtChangeFeed(context);
-        return new Replica(context, new CrdtSyncEngine(bucket, feed));
+        return new Replica(context, new CrdtSyncEngine(bucket, feed, null, options));
     }
 
     private sealed class Replica(TodoContext context, CrdtSyncEngine engine) : IAsyncDisposable


### PR DESCRIPTION
Without this a device's prefix accumulates an object per sync forever, and a device joining a year-old
family replays a year of them.

> **Stacked on #667** (→ #666 → #665). Retarget as those merge.

```csharp
var removed = await engine.CompactAsync();   // or automatically, past CompactAfterObjects (default 50)
```

## Why this is cheap — a property I checked rather than assumed

**cr-sqlite's change feed is current state, not history.** It holds one entry per (row, column) carrying
the value that won, so editing the same field forty times leaves *one* entry, and a deleted row collapses
to a single tombstone. Republishing everything therefore costs the size of the database rather than the
number of edits ever made.

Probed against the real extension before designing around it: 13 entries after an insert, still 13 after
five more edits, only the latest value present. Had it been an append-only log, folding a prefix into one
object would have been pointless and this would need a different design entirely.

## Why it needs no coordination

A replica only ever rewrites **its own prefix**. The rule that removes write conflicts is the same rule
that makes compaction a purely local decision — no lock, no lease, no agreement about when it is safe.

Three things keep it correct, each pinned by a test:

- **The replacement sorts at or after everything it replaces.** A peer resumes from the last key it read,
  so a replacement sorting earlier would never be fetched — and since it is the only object left, that
  peer would *silently stop receiving anything from this replica*. This is the property the whole design
  rests on, so it is asserted directly rather than implied by a round trip.
- **Re-reading state a peer already holds is harmless**, because applying a change twice does nothing.
  That is what lets the replacement cover everything rather than only what is new.
- **A peer reading an object as it is removed skips it** and finds the replacement; the engine already
  treats a vanished object as ordinary rather than an error.

The replacement is written *before* anything is deleted: a crash between the two leaves duplicate state
in the bucket, which is harmless, where the other order could leave a peer with neither.

## The empty case is deliberate

A replica whose local changes have all since been overwritten by peers — or whose rows were deleted, since
the tombstone carries the *deleter's* identity — contributes nothing. Its stale objects are removed and
nothing is written. The peers that now own those changes publish them, so nothing is lost.

## Testing

Verified against two real replicas, not only the fake feed:

- forty edits to one field leave the feed exactly the size it was after the insert;
- a brand-new device reaching a compacted prefix gets the surviving row **and stays free of the deleted
  one** — a tombstone that did not survive compaction would resurrect deleted rows on every new device,
  which is the failure mode worth guarding.

```
dotnet test tests/Rask.SQLite.Crdt.Sync.Tests                          # 43 passed, 4 skipped
RASK_CRSQLITE_PATH=… dotnet test tests/Rask.SQLite.Crdt.Sync.Tests     # 49 passed
```

One expectation of mine was wrong and the code was right: compacting 8 objects removes **7**, because the
replacement's key is the newest object's key and replaces it in place. Fixed the test, kept the
behaviour.

Local gates: `dotnet format` clean, `dotnet build -warnaserror` clean, 336 + 320 unit, 64 browser
journeys, 26 CLI build-gate.
