### PR TITLE
fix(build): stop a second build in the same session failing on the scoped-asset bake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- **A second build in the same session no longer fails on the scoped-asset bake.** MSBuild keeps its
+  worker nodes alive between invocations, and the bake is not safe across them: it loads bundle
+  assemblies with `Assembly.LoadFrom`, so a node that already loaded one of that simple name from
+  *another* project's output throws and the bake produces an empty bundle
+  ([#650](https://github.com/pal-tamas/rask/issues/650)). Since the guard added in #652 that is a build
+  error rather than a silently 404-ing app — correct, but it means publishing two different WASM samples
+  in a row **breaks the second one**, and an ordinary `dotnet build` after a publish can break too. A
+  repository-level `Directory.Build.rsp` now passes `-nodeReuse:false`, so every build starts from fresh
+  workers and the collision cannot arise. Measured cost on this repo: a no-op incremental build of
+  `Rask.Core` goes 0.68s → 0.89s.
+  Explicitly a **mitigation, not the fix** — consumers building their own apps are unaffected by the
+  response file. The fix needs a load context that intercepts *dependency* resolution rather than only
+  top-level loads; `Assembly.Load(byte[])` and a bare `AssemblyLoadContext` both look like they work and
+  do not, because `AssemblyResolve` is last-chance and the pre-loaded copy wins, splitting the registry
+  the bake reads from the one the registrations write to. Diagnosis recorded on #650.
 - **`rask generate job` in the Server half of a `wasm-hosted` solution treated it as a browser app.**
   Browser detection matched `Rask.Wasm` as a substring, and the Server project references
   **`Rask.Wasm.Hosting`** — so the one project a background job actually belongs in got the browser

--- a/Directory.Build.rsp
+++ b/Directory.Build.rsp
@@ -1,0 +1,18 @@
+# MSBuild reads this response file for every build started from the repository root, so these options
+# apply to `dotnet build` / `test` / `publish` / `pack` without anyone having to remember them.
+#
+# -nodeReuse:false — MSBuild keeps its worker nodes alive between invocations, and the scoped-asset bake
+# is not safe across them: the task loads bundle assemblies with Assembly.LoadFrom, so a node that
+# already loaded one of that simple name from ANOTHER project's output throws FileLoadException and the
+# bake produces an empty bundle (#650). Since #652 that is a build error rather than a silently broken
+# app, which means an ordinary second build in the same session FAILS — publish two different WASM
+# samples in a row and the second one breaks.
+#
+# This is a mitigation, not the fix. The fix has to give the bake a load context that intercepts
+# DEPENDENCY resolution, not just top-level loads, and that needs Rask.Wasm.Tasks multi-targeted off
+# netstandard2.0 (which exists so full-framework MSBuild in Visual Studio can load it). Tracked in #650;
+# remove this line when that lands.
+#
+# Cost, measured on this repo: a no-op incremental build of Rask.Core goes 0.68s → 0.89s, since every
+# invocation pays worker startup. Worth roughly a fifth of a second to not have the build fail.
+-nodeReuse:false

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -48,6 +48,14 @@ Every change passes this gate before a PR (the `rask-ship` skill):
    (`--filter FullyQualifiedName~ATests`) while iterating. The build runs in parallel by default —
    don't add `-m:1` (the former WASM copy-race workaround is fixed at the source in
    `Rask.Wasm.Hosting.targets`).
+
+   `Directory.Build.rsp` turns **MSBuild node reuse off** for every build started from the repository
+   root. That is deliberate and load-bearing: the scoped-asset bake is not safe across reused workers
+   ([#650](https://github.com/pal-tamas/rask/issues/650)), so with reuse on, publishing two different
+   WASM samples in a row fails the second one. It costs about a fifth of a second per incremental
+   build. If you are working on `Rask.Wasm.Tasks` itself, note that a reused node also pins the **task**
+   assembly — run `dotnet build-server shutdown` before judging any change to it, or you are measuring
+   the previous build's DLL.
 4. **Benchmarks** — any render/live-runtime hot-path change runs `benchmarks/Rask.Benchmarks`
    before/after and quotes the `Allocated` delta in the PR.
 5. **Docs & examples** — user-facing changes update a `samples/` app, the relevant `docs/*.md`,


### PR DESCRIPTION
Publishing two different WASM samples in a row currently **breaks the second one**, and an ordinary
solution build after a publish can break too. A repository-level `Directory.Build.rsp` passing
`-nodeReuse:false` removes that.

Independent of the CRDT stack (#665–#668) — branches off `main`, touches three files.

## Why the build fails today

MSBuild keeps its worker nodes alive between invocations. The scoped-asset bake loads bundle assemblies
with `Assembly.LoadFrom`, so a node that already loaded one of that simple name from *another* project's
output throws `FileLoadException`, skips it, and produces an empty bundle
([#650](https://github.com/pal-tamas/rask/issues/650)). Since the guard added in #652 that is a build
**error** rather than a silently 404-ing app — the right trade, but it turns a latent bug into a visible
one, and the visible one is a failing build.

## Verified against the reproduction, not against green runs

Repeated green runs have misled three times on this bug, so the check is the deterministic repro: warm
the pool, then publish two **different** WASM bundles (same assembly names, different paths — one project
published twice never fails, because `LoadFrom` just returns the cached assembly).

| | guard fires | `Rask.Example.Site` bakes |
|---|---|---|
| before | every publish | **0 files** — despite a real `App.js` |
| after | never | **1 file** |

`dotnet build Rask.slnx -warnaserror` now also succeeds in parallel **without** `-m:1`, which the repo
had adopted by habit.

## Cost, measured

A no-op incremental build of `Rask.Core`: **0.68s → 0.89s** (average of 3, cold pool each side), since
every invocation now pays worker startup. About a fifth of a second to not have the build fail.

Scoped to this repository — a consumer building their own app never reads this response file.

## This is a mitigation, and here is what was ruled out

Two cheap fixes **look** like they work and are wrong. `Assembly.Load(byte[])` passes the MSBuild
reproduction 3/3 — and breaks four tests in `tests/Rask.Wasm.Tasks.Tests` with `Expected 2 / Actual 0`,
the exact symptom being fixed.

`AppDomain.AssemblyResolve` is **last-chance**: the default context binds a freshly-loaded assembly's
dependencies to an **already-loaded** matching assembly before the hook is consulted. So
`Rask.Example.Shared`'s `RefreshAll` writes into the pre-loaded `Rask.Core`'s registry while the task
reads the newly-loaded one — split registry, zero assets. The same mechanism explains why a bare
`AssemblyLoadContext` "still gave 0 assets" in an earlier attempt: returning `null` from `Load()` falls
back to Default. It was never a load-order bug.

A real fix must intercept **dependency** resolution — a full `AssemblyLoadContext.Load()` override
(needs `Rask.Wasm.Tasks` multi-targeted off `netstandard2.0`, which exists so full-framework MSBuild in
Visual Studio can load the task) or an out-of-process bake. Full diagnosis posted on #650 so that work
doesn't start from zero.

## Also documented

`docs/development-workflow.md` now explains why the response file is there, and the trap that a reused
node pins the **task** assembly too — so an edit to `Rask.Wasm.Tasks` is invisible until
`dotnet build-server shutdown`. That is how the byte-loading attempt first appeared to change nothing.

Local gates: `dotnet format` clean, `dotnet build -warnaserror` clean, 336 + 320 unit, 60 browser
journeys.
