### PR TITLE
fix(build): pack the readme every package ships, so nightly stops failing

### DIFF
--- a/src/Rask.Cache/Rask.Cache.csproj
+++ b/src/Rask.Cache/Rask.Cache.csproj
@@ -17,7 +17,8 @@
        overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.Cli/Rask.Cli.csproj
+++ b/src/Rask.Cli/Rask.Cli.csproj
@@ -25,7 +25,8 @@
        overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.Cqrs/Rask.Cqrs.csproj
+++ b/src/Rask.Cqrs/Rask.Cqrs.csproj
@@ -18,7 +18,8 @@
        overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.Dashboard/Rask.Dashboard.csproj
+++ b/src/Rask.Dashboard/Rask.Dashboard.csproj
@@ -18,7 +18,8 @@
        overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.Data/Rask.Data.csproj
+++ b/src/Rask.Data/Rask.Data.csproj
@@ -17,7 +17,8 @@
        overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.Jobs/Rask.Jobs.csproj
+++ b/src/Rask.Jobs/Rask.Jobs.csproj
@@ -17,7 +17,8 @@
        overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.Logging/Rask.Logging.csproj
+++ b/src/Rask.Logging/Rask.Logging.csproj
@@ -17,7 +17,8 @@
        overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.Mail/Rask.Mail.csproj
+++ b/src/Rask.Mail/Rask.Mail.csproj
@@ -17,7 +17,8 @@
        overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.ObjectStore/Rask.ObjectStore.csproj
+++ b/src/Rask.ObjectStore/Rask.ObjectStore.csproj
@@ -18,7 +18,8 @@
   <!-- Ship a package-specific README instead of the shared framework overview. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.Outbox/Rask.Outbox.csproj
+++ b/src/Rask.Outbox/Rask.Outbox.csproj
@@ -17,7 +17,8 @@
        overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.Postgres/Rask.Postgres.csproj
+++ b/src/Rask.Postgres/Rask.Postgres.csproj
@@ -17,7 +17,8 @@
        overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.SQLite.Browser/Rask.SQLite.Browser.csproj
+++ b/src/Rask.SQLite.Browser/Rask.SQLite.Browser.csproj
@@ -30,7 +30,8 @@
   <!-- Package-specific README instead of the shared framework overview Directory.Build.props packs. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.SQLite.Crdt.Sync/Rask.SQLite.Crdt.Sync.csproj
+++ b/src/Rask.SQLite.Crdt.Sync/Rask.SQLite.Crdt.Sync.csproj
@@ -14,7 +14,8 @@
 
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.SQLite.Crdt/Rask.SQLite.Crdt.csproj
+++ b/src/Rask.SQLite.Crdt/Rask.SQLite.Crdt.csproj
@@ -14,7 +14,8 @@
 
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.SQLite.EntityFrameworkCore/Rask.SQLite.EntityFrameworkCore.csproj
+++ b/src/Rask.SQLite.EntityFrameworkCore/Rask.SQLite.EntityFrameworkCore.csproj
@@ -17,7 +17,8 @@
        overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.SQLite.Litestream/Rask.SQLite.Litestream.csproj
+++ b/src/Rask.SQLite.Litestream/Rask.SQLite.Litestream.csproj
@@ -18,7 +18,8 @@
        overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.SQLite.Snapshots/Rask.SQLite.Snapshots.csproj
+++ b/src/Rask.SQLite.Snapshots/Rask.SQLite.Snapshots.csproj
@@ -17,7 +17,8 @@
        overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.SQLite/Rask.SQLite.csproj
+++ b/src/Rask.SQLite/Rask.SQLite.csproj
@@ -18,7 +18,8 @@
        overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.SqlServer/Rask.SqlServer.csproj
+++ b/src/Rask.SqlServer/Rask.SqlServer.csproj
@@ -17,7 +17,8 @@
        overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.Sync.Client/Rask.Sync.Client.csproj
+++ b/src/Rask.Sync.Client/Rask.Sync.Client.csproj
@@ -15,7 +15,8 @@
 
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.Sync/Rask.Sync.csproj
+++ b/src/Rask.Sync/Rask.Sync.csproj
@@ -17,7 +17,8 @@
 
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.Testing/Rask.Testing.csproj
+++ b/src/Rask.Testing/Rask.Testing.csproj
@@ -16,7 +16,8 @@
        that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.WebPush/Rask.WebPush.csproj
+++ b/src/Rask.WebPush/Rask.WebPush.csproj
@@ -18,7 +18,8 @@
        overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
-    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+    <None Remove="NUGET.md" />
+    <None Include="NUGET.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Rask.Generators.Tests/PackageDependencyTests.cs
+++ b/tests/Rask.Generators.Tests/PackageDependencyTests.cs
@@ -138,6 +138,35 @@ public class PackageDependencyTests
             : declared;
     }
 
+    // A package that ships its OWN NUGET.md must Include it, never Update it.
+    //
+    // The regression this pins: `<None Update="NUGET.md" Pack="true" …>` relies on the file already being in
+    // the None collection, which it only is in the INNER (per-TargetFramework) build — the SDK's default item
+    // globs do not run in the outer build. Pack runs on the outer build, so for a MULTI-TARGETED project the
+    // Update matched nothing, while the neighbouring `<None Remove="..\..\NUGET.md" />` still stripped the
+    // repo-root readme Directory.Build.props contributes. The package came out with no readme at all and pack
+    // failed with NU5039 — which broke every nightly publish, silently, because a plain `dotnet build` never
+    // touches the outer-build pack path.
+    //
+    // Include is correct for single- and multi-targeted projects alike, so the rule is uniform rather than
+    // "Update is fine until you add a second TFM".
+    [Fact]
+    public void A_package_with_its_own_readme_includes_it_rather_than_updating_it()
+    {
+        var offenders = SourceProjects()
+            .Where(p => IsPackable(p.Value))
+            .Where(p => File.ReadAllText(p.Value).Contains("<None Update=\"NUGET.md\"", StringComparison.Ordinal))
+            .Select(p => p.Key)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(
+            offenders.Length == 0,
+            "These projects Update NUGET.md instead of Including it, so their package ships without a readme "
+            + "and pack fails with NU5039 on a multi-targeted project:"
+            + Environment.NewLine + "  " + string.Join(Environment.NewLine + "  ", offenders));
+    }
+
     // Every project under src/, packable or not, keyed by its file name. Both invariants above need the whole set:
     // one to tell a reference to an unpackable project from a reference to a shipped one, the other to pick the
     // packable ones out.


### PR DESCRIPTION
Every nightly publish since #662 has failed with NU5039 ("the readme file 'NUGET.md' does not exist in
the package"), so no prerelease has reached nuget.org since. Rask.Sync, Rask.Sync.Client and
Rask.ObjectStore cannot be packed at all today.

A package that ships its OWN NUGET.md declared it as `<None Update="NUGET.md" Pack="true" …>`. Update
only sets metadata on an item that already exists, and the file is only in the None collection in the
INNER, per-TargetFramework build -- the SDK's default item globs do not run in the outer build. Pack
runs on the OUTER build. So for a MULTI-TARGETED project the Update matched nothing, while the
neighbouring `<None Remove="..\..\NUGET.md" />` still stripped the repo-root readme that
Directory.Build.props contributes. The package ended up with no readme at all, and pack refused it.

Single-target packages were unaffected, which is why this survived: Rask.Cqrs packs cleanly with the
identical wiring. The three that broke are exactly the ones that multi-target net10.0;net10.0-browser.
Nothing else notices, because a plain `dotnet build` never touches the outer-build pack path -- the only
thing that exercises it is packing, which nothing did locally.

Include rather than Update, preceded by a Remove so the inner build's glob copy does not duplicate it.
That form is correct for single- and multi-targeted projects alike, so it is applied to all 23 packages
that ship their own readme rather than only the three that are failing -- otherwise the next package to
gain a second TargetFramework loses its readme silently, which is precisely how this arrived.

Verified by packing EVERY packable project and asserting each nupkg actually contains NUGET.md: 23
packed, 0 failures, 0 without a readme. Guarded by a test in PackageDependencyTests, which reads the
csproj XML rather than packing, so it is instant; reverting one project to Update turns it red and names
it.

Found by adding Rask.ObjectStore to the CLI build gate's local feed, which packs what it needs -- the
gate started failing on a defect that had nothing to do with the change.
