### PR TITLE
refactor(cli): clear what the generate removal left behind, and free -f

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Changed
+- **`rask deploy logs -f` works.** `--follow` had no short name because `-f` was `--fields` CLI-wide,
+  and the comment explaining that named the cost: `docker logs -f` muscle memory. `--fields` went with
+  `rask generate`, so the letter is free and the tail of a log now reads the way every other tool
+  spells it. A test already enforces one meaning per short name across the CLI, which is what makes
+  reclaiming a freed letter safe rather than a guess.
+
+### Removed
+- **Dead code the `rask generate` removal left behind.** Eight properties on `ScaffoldResult` (the
+  DbContext splice points, the `Program.cs` registrations, the sibling test-project wiring), the
+  `TestProjectWiring` record, `Identifiers.Capitalize`, and `Scaffold.IsInside` with its private
+  path-comparison helper. Nothing warns about an unused property on an internal record, so they would
+  have sat there looking like part of the design.
+- **Stale references to `rask generate` in the CLI itself.** The scaffolded welcome page told every new
+  project to run three commands that no longer exist, `rask new`'s next steps printed a fourth, and the
+  generated `Program.cs` and `AppDbContext` carried comments describing a generator. They now point at
+  the tutorial.
+
 ### Added
 - **The tutorial's C# snippets are now checked by a test.** Since the code moved out of `rask generate`
   and into the guides, nothing compiled it — a snippet could rot into something that never builds and

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -26,7 +26,7 @@ rask deploy --host root@box --domain shop.example.com   # bare box → live HTTP
 rask deploy                           # redeploy (host/domain remembered), zero-downtime
 rask deploy --github-actions          # write .github/workflows/deploy.yml
 rask deploy status                    # what's running, and on which color
-rask deploy logs --follow             # tail the deployed app
+rask deploy logs -f                  # tail the deployed app (--follow)
 rask deploy rollback                  # put the previous image back
 
 # tab completion

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -49,10 +49,11 @@ them:
 | `-o` | `--output` |
 | `-n` | `--name` |
 | `-t` | `--template` |
+| `-f` | `--follow` |
 | `-y` | `--yes` |
 
 A few options have no short name on purpose, because the letter belongs to something else: `rask dev
---open`, `rask deploy logs --follow`.
+--open` (`-o` is `--output`).
 
 `--force` means *overwrite files* (`rask new`). Skipping a destructive confirmation is
 `--yes` (`rask db drop`, `rask db restore`) — a different word, because it is a different power.

--- a/samples/Rask.Example.Shop/Features/Home/HomePage.cs
+++ b/samples/Rask.Example.Shop/Features/Home/HomePage.cs
@@ -12,12 +12,11 @@ public sealed class HomePage : Component
             BsCard(Class: "shadow-sm")[
                 BsCardBody()[
                     BsCardTitle()["Hello, Rask! 👋"],
-                    BsCardText(Class: "text-body-secondary")["Your app is ready. Scaffold the rest with the rask CLI:"],
+                    BsCardText(Class: "text-body-secondary")["Your app is ready. What to do next:"],
                     Ul(Class: "mb-3")[
-                        Li()[Code()["rask generate feature Product Name:string Price:decimal"], " — a full CRUD slice (entity, pages, tests)"],
-                        Li()[Code()["rask generate page About"], " — a routed page"],
-                        Li()[Code()["rask generate component Card"], " — a reusable component"],
-                        Li()[Code()["rask dev"], " — run with hot reload"]
+                        Li()[Code()["rask dev"], " — run with hot reload"],
+                        Li()[Code()["rask db add Init"], " then ", Code()["rask db update"], " — create the database"],
+                        Li()[A(Href: "https://github.com/pal-tamas/rask/blob/main/docs/tutorial/02-first-feature.md")["Build your first feature"], " — entity, pages and CQRS handlers, step by step"]
                     ],
                     P(Class: "mb-0 small text-body-secondary")[
                         "Edit this page in ",

--- a/src/Rask.Cli/ArgumentSchema.cs
+++ b/src/Rask.Cli/ArgumentSchema.cs
@@ -106,7 +106,7 @@ internal sealed class ArgumentSchema
 
     /// <summary>
     /// Declare a subcommand. <paramref name="aliases"/> resolve to the same verb, so <c>rask g f</c> and
-    /// <c>rask generate feature</c> take one path and both are documented.
+    /// <c>rask db backup</c> take one path and both are documented.
     /// </summary>
     public ArgumentSchema Verb(string name, string description, params string[] aliases)
     {

--- a/src/Rask.Cli/Commands/DbCommand.cs
+++ b/src/Rask.Cli/Commands/DbCommand.cs
@@ -311,9 +311,9 @@ internal sealed partial class DbCommand(IConsole console, IFileSystem fileSystem
     }
 
     // The EF Core tools need the startup project to reference Microsoft.EntityFrameworkCore.Design;
-    // without it `dotnet ef` fails with a terse message. Projects from `rask generate feature` already
+    // without it `dotnet ef` fails with a terse message. Projects scaffolded with `--data` already
     // include it, but a hand-built one (or a demo that uses EnsureCreated) may not — so add it for the
-    // user (like `rask generate` does for the packages it needs, and like the dotnet-ef tool install
+    // user (like the dotnet-ef tool install
     // above). `dotnet add package` restores too, so the subsequent `dotnet ef` build picks it up. This
     // never blocks: if we can't confidently read the startup project's csproj we stay quiet rather than
     // touch a setup we can't see (e.g. the ref comes from imported props), and a failed add still lets

--- a/src/Rask.Cli/Commands/DeployCommand.cs
+++ b/src/Rask.Cli/Commands/DeployCommand.cs
@@ -129,11 +129,11 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
             .Flag("dry-run", description: "Print the docker commands that would run without changing anything.")
             .WithJson()
             .Option("tail", valueHint: "n", description: "Log lines to show (logs only; default: 100, 'all' for everything).")
-            // No short name. '-f' is --fields CLI-wide: `rask generate feature` is the command people
-            // run most and --fields is its primary input, where `deploy logs --follow` is occasional and
-            // four more characters. `docker logs -f` muscle memory is the cost, and it is the smaller
-            // one — a short that means two things is what #601 is about.
-            .Flag("follow", description: "Stream new log lines until interrupted (logs only).")
+            // '-f' was --fields CLI-wide while `rask generate` existed, so this went without a short and
+            // paid the `docker logs -f` muscle-memory cost. That command is gone and the letter is free,
+            // so the tail of a log reads the way every other tool spells it. CliApplicationTests keeps
+            // one meaning per short, which is what makes reclaiming a freed letter safe.
+            .Flag("follow", 'f', description: "Stream new log lines until interrupted (logs only).")
             .Flag("setup-host", group: SetupGroup, description: "Prepare the host without asking (installs Docker, creates the deploy user, firewall, SSH hardening).")
             .Flag("no-setup-host", group: SetupGroup, description: "Never change the host; fail with instructions if it isn't ready.")
             .Option("deploy-user", valueHint: "name", group: SetupGroup, description: "Non-root login to create and deploy as when given a root host (default: deploy).")

--- a/src/Rask.Cli/Commands/DoctorCommand.cs
+++ b/src/Rask.Cli/Commands/DoctorCommand.cs
@@ -168,7 +168,7 @@ internal sealed class DoctorCommand(
             : new DoctorCheck("rask dev", DoctorStatus.Ok, $"{target.Name} ({target.Kind})", null));
 
         // The version this CLI would pin into a new project, so a mismatch with what the project already
-        // references is visible before `rask generate` adds a package that disagrees with the rest.
+        // references is visible before a package is added that disagrees with the rest.
         checks.Add(new DoctorCheck(
             "rask packages", DoctorStatus.Ok, NewCommand.ResolvePackageVersion(CliMetadata.Version), null));
 

--- a/src/Rask.Cli/Commands/NewCommand.cs
+++ b/src/Rask.Cli/Commands/NewCommand.cs
@@ -75,7 +75,7 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
             .Flag("auth", description: "Add cookie authentication (login + members pages).")
             .Flag("pwa", description: "Add a PWA manifest, icon, and offline page.")
             .Flag("cqrs", description: "Wire up Rask.Cqrs (server template only).")
-            .Flag("data", description: "Pre-wire a database + EF Core: an AppDbContext that `rask generate feature` attaches to (server only). See --database.")
+            .Flag("data", description: "Pre-wire a database + EF Core: an AppDbContext your features map through (server only). See --database.")
             .Flag("docker", description: "Add a Dockerfile and .dockerignore for container deploys.")
             .Flag("no-restore", description: "Don't run dotnet restore after scaffolding (for offline use).")
             .Flag("no-git", description: "Don't initialize a git repository (one is created with an initial commit by default).")
@@ -549,7 +549,7 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
         var version = ResolvePackageVersion(CliMetadata.Version);
         var result = build(targetDirectory, version);
 
-        // --dry-run previews the plan without touching disk or restoring — same spirit as `rask generate --dry-run`.
+        // --dry-run previews the plan without touching disk or restoring.
         if (dryRun)
         {
             WriteHeading($"Would create {template.DisplayName} '{name}':");

--- a/src/Rask.Cli/Scaffolding/Identifiers.cs
+++ b/src/Rask.Cli/Scaffolding/Identifiers.cs
@@ -31,21 +31,6 @@ internal static class Identifiers
     public static bool IsValidNamespaceName(string value) =>
         !string.IsNullOrEmpty(value) && value.Split('.').All(IsValidTypeName);
 
-    /// <summary>
-    /// <paramref name="value"/> with its first character upper-cased — the whole of the PascalCase
-    /// convention that a scaffolder can apply without guessing.
-    /// </summary>
-    /// <remarks>
-    /// Deliberately only the first character. Splitting <c>my_thing</c> or <c>myThing</c> into words would
-    /// be guessing at intent, and a scaffolder that renames more than the user can predict is worse than
-    /// one that renames nothing. <c>product</c> → <c>Product</c>; <c>AppDbContext</c> and <c>_internal</c>
-    /// are already fine and come back unchanged.
-    /// </remarks>
-    public static string Capitalize(string value) =>
-        string.IsNullOrEmpty(value) || !char.IsLower(value[0])
-            ? value
-            : char.ToUpperInvariant(value[0]) + value[1..];
-
     /// <summary>True if <paramref name="value"/> is a valid, non-keyword C# identifier (a usable type name).</summary>
     public static bool IsValidTypeName(string value)
     {

--- a/src/Rask.Cli/Scaffolding/ProjectContext.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectContext.cs
@@ -34,7 +34,7 @@ internal sealed partial class ProjectContext(
     /// </summary>
     /// <remarks>
     /// Detected, not configured: the provider was already decided by <c>rask new --database</c>, and a
-    /// second source of truth is a second thing to get out of sync — a <c>rask generate feature</c> that
+    /// second source of truth is a second thing to get out of sync — a command that
     /// emitted SQLite wiring into a PostgreSQL app would not fail until runtime.
     /// </remarks>
     public DatabaseProvider Provider { get; } = provider;

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.Native.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.Native.cs
@@ -384,8 +384,7 @@ internal static partial class ProjectGenerator
                     H1(Style: "font-size:1.5rem;margin:0 0 .5rem")["Hello, Rask! 👋"],
                     P(Style: "margin:0 0 1rem;color:#374151")["Your native app is ready. Scaffold the rest with the rask CLI:"],
                     Ul(Style: "margin:0 0 1rem;padding-left:1.1rem;line-height:1.75;color:#374151")[
-                        Li()[Code()["rask generate page About"], " — a routed page"],
-                        Li()[Code()["rask generate component Card"], " — a reusable component"]
+                        Li()[A(Href: "https://github.com/pal-tamas/rask/blob/main/docs/tutorial/00-overview.md")["The tutorial"], " — pages, components and features, step by step"]
                     ],
                     P(Style: "margin:0;font-size:.9rem;color:#6b7280")[
                         "Edit this page in ",

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.Server.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.Server.cs
@@ -326,8 +326,8 @@ internal static partial class ProjectGenerator
                 // UseSqlite that also applies the production pragmas (WAL, busy_timeout, foreign_keys). The
                 // connection string defaults to a local app.db but honours a ConnectionStrings:App override —
                 // `rask deploy` sets that to a path on a mounted volume so the DB survives redeploys.
-                // `rask generate feature X …` adds its DbSet to AppDbContext (it attaches to the app's context);
-                // `rask db add <Name>` / `rask db update` create and apply the migration.
+                // Add a `DbSet<T>` to AppDbContext per entity, then `rask db add <Name>` / `rask db update`
+                // to create and apply the migration.
                 __ADDRASKDATA__
                 var connectionString = builder.Configuration.GetConnectionString("App") ?? "__CONNECTIONSTRING__";
                 __ADDRASKOUTBOX__builder.Services.AddDbContextFactory<AppDbContext>((sp, o) => o
@@ -367,8 +367,8 @@ internal static partial class ProjectGenerator
                 // retrying. Set the real connection string via ConnectionStrings:App — in production pass it as
                 // an environment variable, e.g. `rask deploy --env "ConnectionStrings__App=..."`, so it never
                 // lands in source control.
-                // `rask generate feature X …` adds its DbSet to AppDbContext (it attaches to the app's context);
-                // `rask db add <Name>` / `rask db update` create and apply the migration.
+                // Add a `DbSet<T>` to AppDbContext per entity, then `rask db add <Name>` / `rask db update`
+                // to create and apply the migration.
                 __ADDRASKDATA__
                 var connectionString = builder.Configuration.GetConnectionString("App") ?? "__CONNECTIONSTRING__";
                 __ADDRASKOUTBOX__builder.Services.AddDbContextFactory<AppDbContext>((sp, o) => o
@@ -728,7 +728,6 @@ internal static partial class ProjectGenerator
         steps.Append("  cd ").Append(name).Append('\n');
         if (batteries.Data)
         {
-            steps.Append("  rask generate feature Post Title:string Body:string\n");
             steps.Append("  rask db add Init    # create the first migration\n");
             steps.Append(batteries.Database.IsFileBased
                 ? "  rask db update      # apply it to app.db\n"
@@ -763,9 +762,9 @@ internal static partial class ProjectGenerator
 
     // ---- --data template files ----
 
-    // An empty database ready for features. `rask generate feature …` finds this context and inserts a DbSet;
-    // ApplyRaskConventions + ApplyConfigurationsFromAssembly pick up each feature's generated entity config,
-    // so the context needs no per-entity edits beyond its DbSet line.
+    // An empty database ready for features. Add one `DbSet<T>` per entity; ApplyRaskConventions +
+    // ApplyConfigurationsFromAssembly pick up each feature's IEntityTypeConfiguration automatically, so the
+    // context needs no per-entity edits beyond that line.
     private static string AppDbContextCs(ServerBatteries batteries)
     {
         var usings = new StringBuilder("using Microsoft.EntityFrameworkCore;\nusing Rask.Data;\n");

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.Shared.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.Shared.cs
@@ -138,12 +138,11 @@ internal static partial class ProjectGenerator
                     BsCard(Class: "shadow-sm")[
                         BsCardBody()[
                             BsCardTitle()["Hello, Rask! 👋"],
-                            BsCardText(Class: "text-body-secondary")["Your app is ready. Scaffold the rest with the rask CLI:"],
+                            BsCardText(Class: "text-body-secondary")["Your app is ready. What to do next:"],
                             Ul(Class: "mb-3")[
-                                Li()[Code()["rask generate feature Product Name:string Price:decimal"], " — a full CRUD slice (entity, pages, tests)"],
-                                Li()[Code()["rask generate page About"], " — a routed page"],
-                                Li()[Code()["rask generate component Card"], " — a reusable component"],
-                                Li()[Code()["rask dev"], " — run with hot reload"]
+                                Li()[Code()["rask dev"], " — run with hot reload"],
+                                Li()[Code()["rask db add Init"], " then ", Code()["rask db update"], " — create the database"],
+                                Li()[A(Href: "https://github.com/pal-tamas/rask/blob/main/docs/tutorial/02-first-feature.md")["Build your first feature"], " — entity, pages and CQRS handlers, step by step"]
                             ],
                             P(Class: "mb-0 small text-body-secondary")[
                                 "Edit this page in ",
@@ -176,12 +175,11 @@ internal static partial class ProjectGenerator
                 Main()[
                     Div(Class: "card")[
                         H1()["Hello, Rask! 👋"],
-                        P()["Your app is ready. Scaffold the rest with the rask CLI:"],
+                        P()["Your app is ready. What to do next:"],
                         Ul()[
-                            Li()[Code()["rask generate feature Product Name:string Price:decimal"], " — a full CRUD slice (entity, pages, tests)"],
-                            Li()[Code()["rask generate page About"], " — a routed page"],
-                            Li()[Code()["rask generate component Card"], " — a reusable component"],
-                            Li()[Code()["rask dev"], " — run with hot reload"]
+                            Li()[Code()["rask dev"], " — run with hot reload"],
+                            Li()[Code()["rask db add Init"], " then ", Code()["rask db update"], " — create the database"],
+                            Li()[A(Href: "https://github.com/pal-tamas/rask/blob/main/docs/tutorial/02-first-feature.md")["Build your first feature"], " — entity, pages and CQRS handlers, step by step"]
                         ],
                         P(Class: "small")[
                             "Edit this page in ",

--- a/src/Rask.Cli/Scaffolding/Scaffold.cs
+++ b/src/Rask.Cli/Scaffolding/Scaffold.cs
@@ -21,27 +21,6 @@ internal static class Scaffold
         return Path.Combine(parts);
     }
 
-
-    /// <summary>
-    /// Is <paramref name="target"/> inside <paramref name="baseDirectory"/>?
-    ///
-    /// <para>Used by <c>rask generate</c>, whose <c>--output</c> names a folder <em>within the project</em>
-    /// — the namespace is derived from that folder's path, so a directory outside it can't produce a
-    /// coherent one. Before this, <c>--output ../../..</c> wrote files outside the project and quietly fell
-    /// back to the root namespace instead of failing. (<c>rask new --output</c> is different: naming a
-    /// directory anywhere is the whole point, so it doesn't use this.)</para>
-    /// </summary>
-    public static bool IsInside(string baseDirectory, string target)
-    {
-        var root = Path.TrimEndingDirectorySeparator(Path.GetFullPath(baseDirectory));
-        var full = Path.TrimEndingDirectorySeparator(Path.GetFullPath(target));
-        return full.Equals(root, PathComparison)
-            || full.StartsWith(root + Path.DirectorySeparatorChar, PathComparison);
-    }
-
-    /// <summary>Paths compare case-insensitively where the filesystem does.</summary>
-    private static StringComparison PathComparison =>
-        OperatingSystem.IsLinux() ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
     /// <summary>
     /// The default folder segments for a cross-cutting artifact (component/job/email): its own feature slice
     /// <c>Features/&lt;Feature&gt;</c> when <c>--feature</c> names one, otherwise the shared bucket

--- a/src/Rask.Cli/Scaffolding/ScaffoldResult.cs
+++ b/src/Rask.Cli/Scaffolding/ScaffoldResult.cs
@@ -2,76 +2,26 @@ namespace Rask.Cli.Scaffolding;
 
 /// <summary>
 /// What a generator produced: the <see cref="Files"/> to write, optional <see cref="Notes"/> to print
-/// afterwards (e.g. a feature's "register the DbContext / run a migration" next steps), and the NuGet
-/// <see cref="Packages"/> the output needs — the command adds them to the project automatically.
+/// afterwards (e.g. a template's "run a migration" next steps), and the NuGet <see cref="Packages"/> the
+/// output needs — the command adds them to the project automatically.
 /// </summary>
+/// <remarks>
+/// This carried eight more members when <c>rask generate</c> existed: the DbContext splice points, the
+/// <c>Program.cs</c> registrations, and the sibling test project a <c>--tests</c> run wired up. They went
+/// with the command that produced them. Nothing warns about an unused property on an internal record, so
+/// they would have sat here looking like part of the design.
+/// </remarks>
 internal sealed record ScaffoldResult(IReadOnlyList<ScaffoldFile> Files, string? Notes = null)
 {
     /// <summary>Packages the generated code references, added to the project via <c>dotnet add package</c>.</summary>
     public IReadOnlyList<string> Packages { get; init; } = [];
 
     /// <summary>
-    /// Files written only when they don't already exist (never overwritten, even with <c>--force</c>) — e.g. a
-    /// sibling test project's <c>.csproj</c> and <c>GlobalUsings.cs</c>, which the first <c>--tests</c> run
-    /// creates and later runs reuse.
-    /// </summary>
-    public IReadOnlyList<ScaffoldFile> CreateIfAbsent { get; init; } = [];
-
-    /// <summary>
-    /// A sibling test project to wire up when its <c>.csproj</c> is first created: its path, the packages it
-    /// needs (<c>dotnet add package</c>), and a reference back to the app. <c>null</c> when the run has no tests.
-    /// </summary>
-    public TestProjectWiring? TestProject { get; init; }
-
-    /// <summary>
-    /// <c>using</c> namespaces the <see cref="ProgramRegistrations"/> need. The command adds any that are
-    /// missing to <c>Program.cs</c> when it wires the registrations in. Empty for generators that don't
-    /// register services.
-    /// </summary>
-    public IReadOnlyList<string> ProgramUsings { get; init; } = [];
-
-    /// <summary>
-    /// Service-registration statements the command inserts into <c>Program.cs</c> after the scaffold is
-    /// written (idempotently — a statement already present is left alone). Each entry may span multiple
-    /// lines. When <c>Program.cs</c> can't be found or understood, they're printed as a manual fallback.
-    /// </summary>
-    public IReadOnlyList<string> ProgramRegistrations { get; init; } = [];
-
-    /// <summary>
-    /// For an <c>--context</c> run: the <c>DbSet</c> property lines to add to the user's existing DbContext so
-    /// the new entities are mapped. Empty when the run generates its own context (the sets are baked in there).
-    /// </summary>
-    public IReadOnlyList<string> ContextDbSets { get; init; } = [];
-
-    /// <summary>For an <c>--context</c> run: namespaces the added <see cref="ContextDbSets"/> reference, so the
-    /// command can add any missing <c>using</c> to the context file.</summary>
-    public IReadOnlyList<string> ContextUsings { get; init; } = [];
-
-    /// <summary>
-    /// Statements to insert into the target DbContext's <c>OnModelCreating</c> (after the Rask conventions
-    /// call) — e.g. <c>modelBuilder.AddRaskMail();</c> to map the mail table. Idempotent; a line already
-    /// present is left alone. Requires <see cref="ContextFilePath"/>; printed as a fallback when the context
-    /// can't be edited.
-    /// </summary>
-    public IReadOnlyList<string> ContextModelLines { get; init; } = [];
-
-    /// <summary>
-    /// For an <c>--context</c> run: the resolved path of the file declaring that DbContext, so the command can
-    /// insert the <see cref="ContextDbSets"/>. <c>null</c> when the class couldn't be located in the project.
-    /// </summary>
-    public string? ContextFilePath { get; init; }
-
-    /// <summary>
     /// The project/solution the command should restore (and guard against overwriting), relative to the target
     /// directory. <c>null</c> means the single-project default (<c>{name}.csproj</c> at the target root). A
-    /// multi-project template (e.g. <c>wasm-hosted</c>) sets this to its <c>{name}.sln</c>, which has no root csproj.
+    /// multi-project template (e.g. <c>wasm-hosted</c>) sets this to its <c>{name}.slnx</c>, which has no root csproj.
     /// </summary>
     public string? RestoreTarget { get; init; }
 
     public static ScaffoldResult Single(ScaffoldFile file) => new([file]);
 }
-
-/// <summary>A sibling <c>&lt;Project&gt;.Tests</c> project the command wires up on first creation.</summary>
-/// <param name="ProjectPath">Absolute path of the test project's <c>.csproj</c>.</param>
-/// <param name="Packages">Packages to add to it (test SDK, xUnit, and EF SQLite for persistence tests).</param>
-internal sealed record TestProjectWiring(string ProjectPath, IReadOnlyList<string> Packages);


### PR DESCRIPTION
## Summary

Follow-up to #672. Removing a command leaves two kinds of debris, and **neither one fails a build** — so both were found by looking rather than by the compiler.

### Dead code

Eight properties on `ScaffoldResult` (the DbContext splice points, the `Program.cs` registrations, the sibling test-project wiring), the `TestProjectWiring` record, `Identifiers.Capitalize`, and `Scaffold.IsInside` with its private path-comparison helper.

Nothing warns about an unused property on an internal record, so they sat there looking like part of the design. Removing `IsInside` then orphaned `PathComparison` in turn — which is how this compounds if you only delete what the compiler complains about.

Found by counting references to every member of the scaffolding types from outside its own file.

### Stale instructions — the ones users actually read

| Where | What it said |
|---|---|
| **Every scaffolded project's welcome page** | run `rask generate feature` / `generate page` / `generate component` |
| **`rask new`'s next steps** | `rask generate feature Post Title:string Body:string` |
| **`rask new --help`** | `--data` — "an AppDbContext that `rask generate feature` attaches to" |
| **Generated `Program.cs` + `AppDbContext`** | comments describing what the generator would do |

All now point at the tutorial. Found by probing the built CLI for output mentioning a departed command, rather than grepping the source and hoping — the welcome page only surfaced because the probe read what a *new project* shows its author.

### One thing the removal unlocked

`rask deploy logs --follow` had no short name because `-f` was `--fields` CLI-wide, and the comment explaining it named the cost outright: `docker logs -f` muscle memory. `--fields` is gone, so `-f` is free and the letter goes where everyone already reaches for it.

`CliApplicationTests.A_short_name_means_the_same_option_on_every_command` enforces one meaning per short across the CLI, which is what makes reclaiming a freed letter safe rather than a guess.

## The guard that caught me

`ShopProvenanceTests` failed on the welcome-page edit: the committed sample has to match what `rask new` writes, and I'd changed the generator without moving the sample. Exactly what it's for — the sample moved with it.

## Testing

`dotnet format` ✓ · `CI=true dotnet build -warnaserror` ✓ · full local unit gate ✓ · CLI build gate 26/26 ✓ · smoke 30/30 ✓.

Re-probed the built CLI afterwards: no output mentions a removed command except the error messages that quote the user's own input back (`Unknown command 'generate'`), which is correct.
