### PR TITLE
fix(docs): make tutorial chapter 2 compile, and add the gate that proves it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **Tutorial chapter 2 didn't compile if you typed it in.** Four defects, none visible to the snippet
+  parser: the `AppDbContext` step gave the `DbSet<Product>` line but not the `using` the slice needs
+  (the resulting error names `Product`, not the missing import); the list page linked to
+  `UpdateProduct` and `DeleteProduct`, which the chapter never provided; and the form used
+  `DataAnnotationsValidator` without saying it comes from its own package. The chapter now provides
+  both missing files and names the package, and chapter 3 gained the matching `using` for Orders.
+  `TutorialChapterBuildE2ETests` now scaffolds a project, types the chapter in, and builds it with
+  `-warnaserror` — reading the chapter itself, so an edited snippet is compiled rather than a copy.
+
 ### Changed
 - **`rask deploy logs -f` works.** `--follow` had no short name because `-f` was `--fields` CLI-wide,
   and the comment explaining that named the cost: `docker logs -f` muscle memory. `--fields` went with

--- a/docs/tutorial/02-first-feature.md
+++ b/docs/tutorial/02-first-feature.md
@@ -100,11 +100,18 @@ public sealed class ProductConfiguration : IEntityTypeConfiguration<Product>
 }
 ```
 
-Then add the set to `Features/Shared/AppDbContext.cs`:
+Then map it on the app's context. `AppDbContext` lives in `Features/Shared/`, so it needs the slice's
+namespace as well as the set — two lines in `Features/Shared/AppDbContext.cs`:
 
 ```csharp
-public DbSet<Product> Products => Set<Product>();
+using Shop.Features.Products;   // at the top of the file
 ```
+```csharp
+public DbSet<Product> Products => Set<Product>();   // inside the class
+```
+
+Forgetting the `using` is the one that bites, because the error names `Product` rather than the import:
+`The type or namespace name 'Product' could not be found`.
 
 ## 4. A command and its handler
 
@@ -182,15 +189,192 @@ public sealed class CreateProduct(IDispatcher dispatcher, Navigator navigator) :
 `Routes.ProductsPage()` is generated from the `[Route]` on the list page you're about to write — a typed
 URL, so renaming a route breaks the build instead of the link. See [routing](../routing.md).
 
+`DataAnnotationsValidator()` comes from its own package — the one thing on this page `rask new` doesn't
+already give you:
+
+```bash
+dotnet add package Rask.Validation.DataAnnotations
+```
+
 Note `OnMountAsync`, not a constructor or `OnInitialized`: a Rask component loads its data when it
 mounts. The [lifecycle](../lifecycle.md) guide has the full order.
 
-**`UpdateProduct.cs` and `DeleteProduct.cs` follow the same shape:** a record command, a handler that
-loads and mutates through `Product.Update` (or removes), and — for update — an edit page that loads the
-entity into a `ProductRequest` first. Write them by copying `CreateProduct.cs` and changing the verb, or
-read them in the [sample](https://github.com/pal-tamas/rask/tree/main/samples/Rask.Example.Shop/Features/Products).
+## 5. Edit and delete
 
-## 5. The list page
+Same shape, and the list page in the next step links to both — so write them now or it won't compile.
+
+`Features/Products/UpdateProduct.cs` adds a query (to load the row into the form) alongside the command:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Rask.Core.Routing;
+using Shop.Features.Shared;
+
+namespace Shop.Features.Products;
+
+public sealed record GetProductQuery(Guid Id) : IQuery<Product?>;
+
+public sealed class GetProductQueryHandler(IDbContextFactory<AppDbContext> dbContextFactory)
+    : IQueryHandler<GetProductQuery, Product?>
+{
+    public async Task<Product?> HandleAsync(GetProductQuery query, CancellationToken cancellationToken)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        return await db.Products.AsNoTracking().FirstOrDefaultAsync(x => x.Id == query.Id, cancellationToken);
+    }
+}
+
+public sealed record UpdateProductCommand(Guid Id, ProductRequest Request) : ICommand;
+
+public sealed class UpdateProductCommandHandler(IDbContextFactory<AppDbContext> dbContextFactory)
+    : ICommandHandler<UpdateProductCommand>
+{
+    public async Task HandleAsync(UpdateProductCommand command, CancellationToken cancellationToken)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var entity = await db.Products.FirstOrDefaultAsync(x => x.Id == command.Id, cancellationToken);
+        if (entity is null)
+        {
+            return;
+        }
+
+        entity.Update(command.Request.Name, command.Request.Price, command.Request.InStock);
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}
+
+[Route("/products/{id:guid}/edit")]
+public sealed class UpdateProduct(IDispatcher dispatcher, Navigator navigator) : Component
+{
+    private readonly ProductRequest _form = new();
+    private bool _loaded;
+    private bool _found;
+    private string? _error;
+
+    [RouteParam] public Guid Id { get; set; }
+
+    protected override Component? Head => Title()["Edit Product"];
+
+    protected override async Task OnPropsChangedAsync()
+    {
+        _loaded = false;
+        var entity = await dispatcher.DispatchAsync(new GetProductQuery(Id), CancellationToken);
+        _found = entity is not null;
+        if (entity is not null)
+        {
+            _form.Name = entity.Name;
+            _form.Price = entity.Price;
+            _form.InStock = entity.InStock;
+        }
+
+        _loaded = true;
+    }
+
+    private async Task SubmitAsync(ProductRequest form)
+    {
+        try
+        {
+            await dispatcher.DispatchAsync(new UpdateProductCommand(Id, form), CancellationToken);
+            navigator.NavigateTo(Routes.ProductsPage());
+        }
+        catch (Exception)
+        {
+            _error = "Something went wrong — please try again.";
+        }
+    }
+
+    protected override Component? Render()
+    {
+        if (!_loaded)
+        {
+            return Div()["Loading…"];
+        }
+
+        if (!_found)
+        {
+            return Div()["Product not found. ", NavLink(Routes.ProductsPage())["Back to the list"], "."];
+        }
+
+        return Div()[
+            Div()[
+                H1()["Edit Product"],
+                _error is null ? null : Div(Role: "alert")[_error],
+                Form(_form, OnValidSubmitAsync: SubmitAsync)[
+                    DataAnnotationsValidator(),
+                    Div()[
+                        Label("name")["Name"],
+                        Input(() => _form.Name, Id: "name")
+                    ],
+                    Div()[
+                        Label("price")["Price"],
+                        Input(() => _form.Price, Id: "price")
+                    ],
+                    Div()[
+                        Label("instock")["InStock"],
+                        Input(() => _form.InStock, Id: "instock")
+                    ],
+                    Div()[
+                        NavLink(Routes.ProductsPage())["Cancel"],
+                        Button("submit")["Save changes"]
+                    ]
+                ]
+            ]
+        ];
+    }
+}
+```
+
+`Features/Products/DeleteProduct.cs` is the command plus a small reusable button the list page drops
+next to each row:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Shop.Features.Shared;
+
+namespace Shop.Features.Products;
+
+public sealed record DeleteProductCommand(Guid Id) : ICommand;
+
+public sealed class DeleteProductCommandHandler(IDbContextFactory<AppDbContext> dbContextFactory)
+    : ICommandHandler<DeleteProductCommand>
+{
+    public async Task HandleAsync(DeleteProductCommand command, CancellationToken cancellationToken)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var entity = await db.Products.FirstOrDefaultAsync(x => x.Id == command.Id, cancellationToken);
+        if (entity is null)
+        {
+            return;
+        }
+
+        db.Products.Remove(entity);
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}
+
+// A reusable delete button: dispatches the delete command, then invokes OnDeleted so the caller
+// (the list page) can refresh.
+public sealed class DeleteProduct(IDispatcher dispatcher) : Component
+{
+    public Guid Id { get; set; }
+
+    public Func<Task>? OnDeleted { get; set; }
+
+    private async Task DeleteAsync()
+    {
+        await dispatcher.DispatchAsync(new DeleteProductCommand(Id), CancellationToken);
+        if (OnDeleted is not null)
+        {
+            await OnDeleted();
+        }
+    }
+
+    protected override Component? Render() =>
+        Button("button", OnClickAsync: DeleteAsync)["Delete"];
+}
+```
+
+## 6. The list page
 
 `Features/Products/ProductsPage.cs` — a query, its handler, and the routed page:
 
@@ -257,7 +441,7 @@ public sealed class ProductsPage(IDispatcher dispatcher) : Component
 }
 ```
 
-## 6. Register the services
+## 7. Register the services
 
 `Program.cs` needs three registrations (Chapter 1's `--all-batteries` already added them; if you
 scaffolded without it, add them next to your other `builder.Services…` lines):
@@ -279,7 +463,7 @@ builder.Services.AddDbContextFactory<AppDbContext>((sp, o) => o
   the app but honours a `ConnectionStrings:App` override, which is how a deploy points it at a persistent
   volume.
 
-## 7. Create the database
+## 8. Create the database
 
 The code is ready, but the SQLite file has no tables yet. EF Core **migrations** generate the schema from
 your entities. `rask db` wraps the EF tooling (installing `dotnet-ef` for you on first use):
@@ -293,7 +477,7 @@ rask db update                # apply it — creates app.db with a Products tabl
 against `app.db`. Every time you change an entity later, it's the same pair: `rask db add <Name>` then
 `rask db update`.
 
-## 8. Run it
+## 9. Run it
 
 ```bash
 rask dev

--- a/docs/tutorial/03-orders-and-auth.md
+++ b/docs/tutorial/03-orders-and-auth.md
@@ -47,11 +47,14 @@ files, and the list page. They're the chapter 2 files with `Product` swapped for
 change the type, or read them in the
 [sample](https://github.com/pal-tamas/rask/tree/main/samples/Rask.Example.Shop/Features/Orders).
 
-The one line that ties it to the existing database goes in `Features/Shared/AppDbContext.cs`, next to
-`Products`:
+What ties it to the existing database goes in `Features/Shared/AppDbContext.cs`, next to `Products` —
+the slice's namespace, and the set:
 
 ```csharp
-public DbSet<Order> Orders => Set<Order>();
+using Shop.Features.Orders;   // at the top, beside the Products one
+```
+```csharp
+public DbSet<Order> Orders => Set<Order>();   // inside the class
 ```
 
 That's the whole of "sharing a database": one context, one connection string, one migration history,

--- a/tests/Rask.Cli.Tests/CliBuildE2E.cs
+++ b/tests/Rask.Cli.Tests/CliBuildE2E.cs
@@ -30,7 +30,7 @@ internal static class CliBuildE2E
         "Rask.Server",                      // server template
         "Rask.Wasm",                        // wasm + wasm-hosted templates
         "Rask.Wasm.Hosting",                // wasm-hosted template
-        "Rask.Bootstrap",                   // every template, and `generate feature --bs`
+        "Rask.Bootstrap",                   // every template unless --no-bootstrap
         "Rask.Cqrs",                        // server template --cqrs, and every generated feature
         "Rask.Data",                        // every generated feature
         "Rask.SQLite",                      // --data + every generated feature (via Rask.SQLite.EntityFrameworkCore)
@@ -40,14 +40,14 @@ internal static class CliBuildE2E
         "Rask.Postgres",                    // --database postgres — UseRaskPostgres
         "Rask.SqlServer",                   // --database sqlserver — UseRaskSqlServer
         "Rask.WebPush",                     // --push — AddRaskWebPush + the subscription endpoints
-        "Rask.Outbox",                      // generate feature --outbox, and tutorial ch7
+        "Rask.Outbox",                      // tutorial ch.7
         "Rask.Jobs",                        // generate job, and tutorial ch4
         "Rask.Mail",                        // generate email, and tutorial ch5
         "Rask.Cache",                       // tutorial ch6 — AddRaskCache / ICache.GetOrCreateAsync
         "Rask.Logging",                     // --logs — AddRaskLogging, and the dashboard's History mode
         "Rask.Dashboard",                   // --ops — AddRaskDashboard + the /_ops pages
-        "Rask.Validation.DataAnnotations",  // generate feature --validation dataannotations
-        "Rask.Validation.FluentValidation", // generate feature --validation fluent
+        "Rask.Validation.DataAnnotations",  // tutorial ch.2's form validation
+        "Rask.Validation.FluentValidation", // the FluentValidation alternative
     ];
 
     // Packed once and shared across every case (packing the projects is the expensive part of these gates).

--- a/tests/Rask.Cli.Tests/TutorialChapterBuildE2ETests.cs
+++ b/tests/Rask.Cli.Tests/TutorialChapterBuildE2ETests.cs
@@ -1,0 +1,125 @@
+using System.Text.RegularExpressions;
+using Rask.Cli.Commands;
+using Rask.Cli.Scaffolding;
+
+namespace Rask.Cli.Tests;
+
+/// <summary>
+/// Types tutorial chapter 2 into a freshly scaffolded project and builds it — the question the snippet
+/// parser can't answer.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The chapter is the framework's teaching code now, and until this test existed nothing compiled it.
+/// Writing it found four defects that had shipped, none of which a parser could see: the
+/// <c>AppDbContext</c> instruction gave the <c>DbSet</c> line but not the <c>using</c> the slice needs;
+/// the list page linked to <c>UpdateProduct</c> and <c>DeleteProduct</c>, which the chapter never
+/// provided; and the form used <c>DataAnnotationsValidator</c> without saying it comes from its own
+/// package. A reader following the chapter exactly got four compiler errors.
+/// </para>
+/// <para>
+/// Opt-in with the rest of the build gates (<c>RASK_CLI_BUILD_E2E=1</c>) because it packs the framework
+/// and runs a real restore + build. It reads the chapter rather than a copy of it: a snippet edited in
+/// the docs is compiled here, which is the only arrangement that can't drift.
+/// </para>
+/// </remarks>
+public sealed partial class TutorialChapterBuildE2ETests
+{
+    [SkippableFact]
+    public async Task Chapter_2_builds_when_you_type_it_in()
+    {
+        Skip.IfNot(CliBuildE2E.Enabled, CliBuildE2E.SkipReason);
+
+        var chapter = File.ReadAllText(Path.Combine(TutorialDirectory(), "02-first-feature.md"));
+        var fences = CSharpFence().Matches(chapter).Select(m => m.Groups["code"].Value).ToArray();
+
+        string Fence(string contains) =>
+            fences.FirstOrDefault(f => f.Contains(contains, StringComparison.Ordinal))
+            ?? throw new InvalidOperationException(
+                $"Chapter 2 no longer contains a C# snippet with '{contains}'. If the chapter was "
+                + "restructured, update this test to match — don't delete the coverage.");
+
+        var (feed, version) = await CliBuildE2E.LocalFeed.Value;
+        var temp = Path.Combine(Path.GetTempPath(), "rask-tutorial-e2e", Guid.NewGuid().ToString("N"));
+        var projectDir = Path.Combine(temp, "Shop");
+
+        try
+        {
+            var fs = new SystemFileSystem();
+
+            // Chapter 1: rask new Shop --all-batteries.
+            var scaffold = ProjectGenerator.GenerateServer(
+                projectDir, "Shop", NewCommand.ToBatteries(["all-batteries"]), version);
+            foreach (var file in scaffold.Files)
+            {
+                fs.CreateDirectory(Path.GetDirectoryName(file.Path)!);
+                fs.WriteAllText(file.Path, file.Content);
+            }
+
+            // Chapter 2: every file it hands the reader.
+            var slice = Path.Combine(projectDir, "Features", "Products");
+            fs.CreateDirectory(slice);
+            Write(fs, slice, "Product.cs", Fence("class Product : Entity<Guid>"));
+            Write(fs, slice, "ProductRequest.cs", Fence("class ProductRequest"));
+            Write(fs, slice, "ProductConfiguration.cs", Fence("ProductConfiguration"));
+            Write(fs, slice, "UpdateProduct.cs", Fence("UpdateProductCommandHandler"));
+            Write(fs, slice, "DeleteProduct.cs", Fence("DeleteProductCommandHandler"));
+            Write(fs, slice, "ProductsPage.cs", Fence("class ProductsPage"));
+
+            // The chapter splits CreateProduct across two fences — "and the page that uses it, in the
+            // same file" — so they are joined the way a reader would join them.
+            Write(fs, slice, "CreateProduct.cs",
+                Fence("CreateProductCommandHandler").TrimEnd() + "\n\n" + Fence("[Route(\"/products/new\")]"));
+
+            // …and the two lines it says to add to the context.
+            var contextPath = Path.Combine(projectDir, "Features", "Shared", "AppDbContext.cs");
+            var context = Strip(Fence("using Shop.Features.Products;")) + "\n" + fs.ReadAllText(contextPath);
+            fs.WriteAllText(
+                contextPath,
+                OpeningBrace().Replace(context, "$1    " + Strip(Fence("DbSet<Product>")) + "\n\n", 1));
+
+            CliBuildE2E.WriteNuGetConfig(fs, projectDir, feed);
+
+            // The one package the chapter tells the reader to add by hand.
+            var csproj = Path.Combine(projectDir, "Shop.csproj");
+            var (added, addOutput) = await CliBuildE2E.RunDotnet(
+                $"add \"{csproj}\" package Rask.Validation.DataAnnotations --version {version}");
+            Assert.True(added == 0, $"Adding the validation package failed.{CliBuildE2E.Diagnostics(addOutput)}");
+
+            var (exit, output) = await CliBuildE2E.RunDotnet($"build \"{csproj}\" -warnaserror -m:1");
+            Assert.True(
+                exit == 0,
+                "Tutorial chapter 2 does not compile when typed in as written. Every snippet a reader "
+                + $"copies has to build.{CliBuildE2E.Diagnostics(output)}");
+        }
+        finally
+        {
+            CliBuildE2E.TryDeleteDirectory(temp);
+        }
+    }
+
+    /// <summary>A snippet line with its trailing "// at the top of the file" aside removed.</summary>
+    private static string Strip(string fence) => fence.Trim().Split("//")[0].Trim();
+
+    private static void Write(IFileSystem fs, string directory, string name, string code) =>
+        fs.WriteAllText(Path.Combine(directory, name), code);
+
+    private static string TutorialDirectory()
+    {
+        for (var dir = AppContext.BaseDirectory; dir is not null; dir = Path.GetDirectoryName(dir))
+        {
+            if (File.Exists(Path.Combine(dir, "Rask.slnx")))
+            {
+                return Path.Combine(dir, "docs", "tutorial");
+            }
+        }
+
+        throw new InvalidOperationException("Could not locate the repo root (Rask.slnx).");
+    }
+
+    [GeneratedRegex(@"```csharp\r?\n(?<code>.*?)```", RegexOptions.Singleline)]
+    private static partial Regex CSharpFence();
+
+    [GeneratedRegex(@"(\{\n)")]
+    private static partial Regex OpeningBrace();
+}


### PR DESCRIPTION
## Summary

I typed tutorial chapter 2 into a fresh `rask new` project and built it. **It did not compile.**

Four defects — and every one of them passed the snippet gate from #673, because syntax checking and override-name checking cannot see any of these:

| Defect | What the reader hits |
|---|---|
| The `AppDbContext` step gave the `DbSet<Product>` line but not the `using` | `error CS0246: The type or namespace name 'Product' could not be found` — an error that names the *type*, not the missing import |
| The list page linked to `Routes.UpdateProduct(...)` and dropped in a `DeleteProduct(...)` component, but the chapter never provided either file | `CS0117` + `CS0103`; the chapter said "follow the same shape, write them by copying", leaving a reader two files short of a build |
| `DataAnnotationsValidator()` needs `Rask.Validation.DataAnnotations`, which `rask new` does not add | `CS0103: The name 'DataAnnotationsValidator' does not exist` |

`AppDbContext` lives in `Features/Shared` and `Product` in `Features/Products` — the generator used to splice in both the `DbSet` and the `using`, and the rewrite in #672 kept one of them.

## The fix

Chapter 2 now provides `UpdateProduct.cs` and `DeleteProduct.cs` in full and names the package; chapter 3 gained the matching `using` for Orders.

## The gate is the point

`TutorialChapterBuildE2ETests` does exactly what I did by hand: scaffolds with `rask new --all-batteries`, writes every C# fence the chapter hands the reader, applies the two `AppDbContext` lines, adds the package the chapter names, and runs a real `-warnaserror` build.

It **reads the chapter rather than a copy of it**, so a snippet edited in the docs is the snippet compiled here — the only arrangement that can't drift. If the chapter is restructured so a fence goes missing, it fails with a message saying to update the test rather than silently covering nothing (the #673 lesson).

Opt-in with the other build gates (`RASK_CLI_BUILD_E2E=1`), ~34s.

## Testing

`dotnet format` ✓ · `CI=true dotnet build -warnaserror` ✓ · full local unit gate ✓ · **CLI build gate 27/27** ✓.

One note for honesty: an intermediate run of the build gate reported 4 unexplained failures while I had manual builds hammering the NuGet cache in parallel. Three subsequent clean runs are 27/27. I could not reproduce it, and I'd rather flag it than pretend it didn't happen — worth a second look if it recurs in CI.

Also corrected three comments in `CliBuildE2E` naming `generate feature` flags that no longer exist.
