### PR TITLE
fix(docs): make tutorial chapter 4 compile, and walk the gate through chapters 3 and 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- **Tutorial chapter 4 didn't compile either.** The job handler used `IDbContextFactory<AppDbContext>`
+  with no `using` and no namespace, so the file the chapter names failed with two `CS0246`s as soon as
+  a reader filled the handler in. Chapter 5's email component gained the namespace every other file in
+  the tutorial declares. The build gate now walks chapters 2 → 3 → 4 cumulatively — they depend on each
+  other (chapter 4's handler reads the `Orders` set chapter 3 adds), so isolation would have missed it.
+
+### Fixed
 - **Tutorial chapter 2 didn't compile if you typed it in.** Four defects, none visible to the snippet
   parser: the `AppDbContext` step gave the `DbSet<Product>` line but not the `using` the slice needs
   (the resulting error names `Product`, not the missing import); the list page linked to

--- a/docs/tutorial/04-background-jobs.md
+++ b/docs/tutorial/04-background-jobs.md
@@ -13,6 +13,8 @@ same `app.db`.
 Create `Features/Shared/SendOrderReceipt.cs` — a job record and its handler:
 
 ```csharp
+namespace Shop.Features.Shared;
+
 public sealed record SendOrderReceipt : IJob;
 
 public sealed class SendOrderReceiptHandler : ICommandHandler<SendOrderReceipt>
@@ -35,6 +37,8 @@ public sealed record SendOrderReceipt(Guid OrderId) : IJob;
 Fill in the handler with whatever the work is (we'll make it send an email in the next chapter):
 
 ```csharp
+using Microsoft.EntityFrameworkCore;   // for IDbContextFactory
+
 public sealed class SendOrderReceiptHandler(IDbContextFactory<AppDbContext> dbFactory)
     : ICommandHandler<SendOrderReceipt>
 {

--- a/docs/tutorial/05-email.md
+++ b/docs/tutorial/05-email.md
@@ -12,6 +12,8 @@ email in C# with the same `Div()`/`H1()` you already know, no templating languag
 Create `Features/Shared/OrderReceipt.cs` — a component whose `Render()` is the email body:
 
 ```csharp
+namespace Shop.Features.Shared;
+
 public sealed class OrderReceipt : Component
 {
     protected override Component? Render() =>

--- a/tests/Rask.Cli.Tests/TutorialChapterBuildE2ETests.cs
+++ b/tests/Rask.Cli.Tests/TutorialChapterBuildE2ETests.cs
@@ -5,8 +5,8 @@ using Rask.Cli.Scaffolding;
 namespace Rask.Cli.Tests;
 
 /// <summary>
-/// Types tutorial chapter 2 into a freshly scaffolded project and builds it — the question the snippet
-/// parser can't answer.
+/// Walks the tutorial the way a reader does — scaffold, then chapter 2, 3, 4 in order — building after
+/// each. The question the snippet parser can't answer.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -18,26 +18,29 @@ namespace Rask.Cli.Tests;
 /// package. A reader following the chapter exactly got four compiler errors.
 /// </para>
 /// <para>
+/// Extending it to chapter 4 found a fifth: the job handler used <c>IDbContextFactory</c> and
+/// <c>AppDbContext</c> with no <c>using</c> and no namespace, so the file the chapter names did not
+/// compile. The chapters build on each other — chapter 4's handler reads <c>db.Orders</c>, which only
+/// exists after chapter 3 — so they are walked cumulatively rather than in isolation.
+/// </para>
+/// <para>
 /// Opt-in with the rest of the build gates (<c>RASK_CLI_BUILD_E2E=1</c>) because it packs the framework
-/// and runs a real restore + build. It reads the chapter rather than a copy of it: a snippet edited in
-/// the docs is compiled here, which is the only arrangement that can't drift.
+/// and runs a real restore + build. It reads the chapters rather than copies of them: a snippet edited
+/// in the docs is compiled here, which is the only arrangement that can't drift.
 /// </para>
 /// </remarks>
 public sealed partial class TutorialChapterBuildE2ETests
 {
     [SkippableFact]
-    public async Task Chapter_2_builds_when_you_type_it_in()
+    public async Task The_tutorial_builds_when_you_type_it_in()
     {
         Skip.IfNot(CliBuildE2E.Enabled, CliBuildE2E.SkipReason);
 
-        var chapter = File.ReadAllText(Path.Combine(TutorialDirectory(), "02-first-feature.md"));
-        var fences = CSharpFence().Matches(chapter).Select(m => m.Groups["code"].Value).ToArray();
+        var ch2 = Fences("02-first-feature.md");
+        var ch3 = Fences("03-orders-and-auth.md");
+        var ch4 = Fences("04-background-jobs.md");
 
-        string Fence(string contains) =>
-            fences.FirstOrDefault(f => f.Contains(contains, StringComparison.Ordinal))
-            ?? throw new InvalidOperationException(
-                $"Chapter 2 no longer contains a C# snippet with '{contains}'. If the chapter was "
-                + "restructured, update this test to match — don't delete the coverage.");
+        string Fence(string contains) => Pick(ch2, contains, "2");
 
         var (feed, version) = await CliBuildE2E.LocalFeed.Value;
         var temp = Path.Combine(Path.GetTempPath(), "rask-tutorial-e2e", Guid.NewGuid().ToString("N"));
@@ -86,17 +89,62 @@ public sealed partial class TutorialChapterBuildE2ETests
                 $"add \"{csproj}\" package Rask.Validation.DataAnnotations --version {version}");
             Assert.True(added == 0, $"Adding the validation package failed.{CliBuildE2E.Diagnostics(addOutput)}");
 
-            var (exit, output) = await CliBuildE2E.RunDotnet($"build \"{csproj}\" -warnaserror -m:1");
-            Assert.True(
-                exit == 0,
-                "Tutorial chapter 2 does not compile when typed in as written. Every snippet a reader "
-                + $"copies has to build.{CliBuildE2E.Diagnostics(output)}");
+            await Build(csproj, "chapter 2");
+
+            // --- Chapter 3: a second slice on the same database ---
+            var orders = Path.Combine(projectDir, "Features", "Orders");
+            fs.CreateDirectory(orders);
+            Write(fs, orders, "Order.cs", Pick(ch3, "class Order : Entity<Guid>", "3"));
+
+            context = Strip(Pick(ch3, "using Shop.Features.Orders;", "3")) + "\n" + fs.ReadAllText(contextPath);
+            fs.WriteAllText(
+                contextPath,
+                OpeningBrace().Replace(context, "$1    " + Strip(Pick(ch3, "DbSet<Order>", "3")) + "\n\n", 1));
+
+            await Build(csproj, "chapter 3");
+
+            // --- Chapter 4: a durable job, whose handler reads the Orders set chapter 3 added ---
+            var jobHandler = Pick(ch4, "SendOrderReceiptHandler(IDbContextFactory", "4");
+            var shared = Path.Combine(projectDir, "Features", "Shared");
+            Write(
+                fs, shared, "SendOrderReceipt.cs",
+                jobHandler[..jobHandler.IndexOf("public sealed class", StringComparison.Ordinal)].Trim()
+                + "\n\nnamespace Shop.Features.Shared;\n\n"
+                + Pick(ch4, "record SendOrderReceipt(Guid OrderId)", "4").Trim() + "\n\n"
+                + jobHandler[jobHandler.IndexOf("public sealed class", StringComparison.Ordinal)..]);
+
+            await Build(csproj, "chapter 4");
         }
         finally
         {
             CliBuildE2E.TryDeleteDirectory(temp);
         }
     }
+
+    private static async Task Build(string csproj, string chapter)
+    {
+        var (exit, output) = await CliBuildE2E.RunDotnet($"build \"{csproj}\" -warnaserror -m:1");
+        Assert.True(
+            exit == 0,
+            $"Tutorial {chapter} does not compile when typed in as written. Every snippet a reader "
+            + $"copies has to build.{CliBuildE2E.Diagnostics(output)}");
+    }
+
+    private static string[] Fences(string chapter) =>
+        CSharpFence()
+            .Matches(File.ReadAllText(Path.Combine(TutorialDirectory(), chapter)))
+            .Select(m => m.Groups["code"].Value)
+            .ToArray();
+
+    /// <summary>
+    /// The chapter's snippet containing <paramref name="contains"/>. Throws rather than returning null so
+    /// a restructured chapter fails loudly instead of silently covering nothing.
+    /// </summary>
+    private static string Pick(string[] fences, string contains, string chapter) =>
+        fences.FirstOrDefault(f => f.Contains(contains, StringComparison.Ordinal))
+        ?? throw new InvalidOperationException(
+            $"Chapter {chapter} no longer contains a C# snippet with '{contains}'. If the chapter was "
+            + "restructured, update this test to match — don't delete the coverage.");
 
     /// <summary>A snippet line with its trailing "// at the top of the file" aside removed.</summary>
     private static string Strip(string fence) => fence.Trim().Split("//")[0].Trim();


### PR DESCRIPTION
## Summary

#675 built chapter 2 and found four defects. Chapter 3 uses the same *"copy the previous chapter's files and change the type"* phrasing that caused one of them, so I walked the rest the same way: scaffold, apply each chapter in order, build after each.

**Chapter 3 builds.** Its deferred files are never referenced, unlike chapter 2's list page — so the same phrasing was harmless there.

**Chapter 4 does not.** The job handler snippet uses `IDbContextFactory<AppDbContext>` with no `using` and no namespace, so `Features/Shared/SendOrderReceipt.cs` — the file the chapter names — fails the moment a reader fills the handler in:

```
error CS0246: The type or namespace name 'IDbContextFactory<>' could not be found
error CS0246: The type or namespace name 'AppDbContext' could not be found
```

It now declares the namespace its location implies and carries the EF `using`.

Chapter 5's email component gained the same namespace. It *compiled* without one — the type just landed in the global namespace — but every other file in the tutorial declares one, and a reader copying it into `Features/Shared` has no reason to expect otherwise.

## Why the walk is cumulative

The chapters depend on each other: chapter 4's handler reads `db.Orders`, which only exists once chapter 3 adds the `DbSet`. Testing each chapter against a fresh project would have missed that entirely — so the gate scaffolds once and applies 2 → 3 → 4 in order, building after each so a failure names the chapter.

## Still uncovered

Chapters 5–7 remain syntax-checked only. 5 and 6 I verified by hand here (both build); 7 patches an existing file rather than adding one, which the current harness can't express. Worth doing, not done.

## Testing

`dotnet format` ✓ · `CI=true dotnet build -warnaserror` ✓ · full local unit gate ✓ · **CLI build gate 27/27** ✓.

### The flake from #675, characterised

I said there I couldn't reproduce it. I can now say what it is: the four `Generated_wasm_hosted_solution_builds` cases, and it only appears when the gate is run **back-to-back several times** — a single clean run is 27/27, confirmed repeatedly, including the final one for this PR. It looks like cache contention between overlapping runs rather than anything in the template. Still not reproducible on demand, so still worth a second look if CI ever shows it.
