### PR TITLE
fix(docs): reconcile tutorial chapter 7 with chapter 3, and fix the build gate's flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- **Tutorial chapter 7 contradicted chapter 3.** It told the reader to write `Create(string customer,
+  decimal total)` on an `Order` that chapter 3 gave `Total`/`ProductId`/`Placed` and no `Customer` —
+  the snippets came from a generator run with different fields, which the old `--force` regeneration
+  papered over. Chapter 7 now shows the revised `Order.cs` whole, with chapter 3's fields intact. The
+  build gate walks chapters 2 → 3 → 4 → 5 → 7.
+- **The CLI build gate's intermittent wasm-hosted failures were MSBuild node reuse
+  ([#650](https://github.com/pal-tamas/rask/issues/650)), not flakiness.** A worker node kept alive
+  from an earlier run had already loaded `Rask.Wasm.Tasks.dll` from that run's temp directory, so the
+  next run's publish silently baked nothing. `Directory.Build.rsp` sets `-nodeReuse:false` for in-repo
+  builds but these projects are generated outside it; the harness now sets `MSBUILDDISABLENODEREUSE=1`,
+  which the nested `dotnet publish` inherits. Three consecutive gate runs are now 27/27.
+
+### Fixed
 - **Tutorial chapter 4 didn't compile either.** The job handler used `IDbContextFactory<AppDbContext>`
   with no `using` and no namespace, so the file the chapter names failed with two `CS0246`s as soon as
   a reader filled the handler in. Chapter 5's email component gained the namespace every other file in

--- a/docs/tutorial/07-outbox-events.md
+++ b/docs/tutorial/07-outbox-events.md
@@ -27,29 +27,53 @@ public sealed record OrderUpdated(Guid Id) : IOutboxEvent;
 public sealed record OrderDeleted(Guid Id) : IOutboxEvent;
 ```
 
-**Raising them.** In `Order.cs`, announce the change from the same method that makes it, so an order can
-never be created without saying so:
+**Raising them.** Announce the change from the same method that makes it, so an order can never be
+created without saying so. Here is chapter 3's `Features/Orders/Order.cs` with the three `Raise` calls
+added — the whole file, so you can see where they go:
 
 ```csharp
-public static Order Create(string customer, decimal total)
-{
-    var entity = new Order(customer, total);
-    entity.Raise(new OrderCreated(entity.Id));
-    return entity;
-}
+namespace Shop.Features.Orders;
 
-public void Update(string customer, decimal total)
+public sealed class Order : Entity<Guid>
 {
-    this.Customer = customer;
-    this.Total = total;
-    Raise(new OrderUpdated(Id));
-}
+    private Order() { } // EF Core materialization
 
-public void RaiseDeleted() => Raise(new OrderDeleted(Id));
+    private Order(decimal total, Guid productId, DateTime placed)
+    {
+        Id = Guid.NewGuid();
+        this.Total = total;
+        this.ProductId = productId;
+        this.Placed = placed;
+    }
+
+    public decimal Total { get; private set; }
+
+    public Guid ProductId { get; private set; }
+
+    public DateTime Placed { get; private set; }
+
+    public static Order Create(decimal total, Guid productId, DateTime placed)
+    {
+        var entity = new Order(total, productId, placed);
+        entity.Raise(new OrderCreated(entity.Id));
+        return entity;
+    }
+
+    public void Update(decimal total, Guid productId, DateTime placed)
+    {
+        this.Total = total;
+        this.ProductId = productId;
+        this.Placed = placed;
+        Raise(new OrderUpdated(Id));
+    }
+
+    public void RaiseDeleted() => Raise(new OrderDeleted(Id));
+}
 ```
 
-`Raise` comes from `Entity<TId>`. The events sit on the entity until `SaveChanges`, which is what makes
-the next part atomic.
+`Create` changed from an expression body to a block so it can raise before returning; the fields are
+chapter 3's, untouched. `Raise` comes from `Entity<TId>`, and the events sit on the entity until
+`SaveChanges` — which is what makes the next part atomic.
 
 **Reacting.** `Features/Orders/OrderCreatedHandler.cs` — auto-registered by `AddRaskCqrs()`:
 

--- a/tests/Rask.Cli.Tests/CliBuildE2E.cs
+++ b/tests/Rask.Cli.Tests/CliBuildE2E.cs
@@ -198,6 +198,17 @@ internal static class CliBuildE2E
         };
         psi.Environment["CI"] = "true";
 
+        // Node reuse is what makes the wasm-hosted cases fail intermittently, and only ever on a repeated
+        // run (#650). A worker node kept alive from an earlier run has already loaded Rask.Wasm.Tasks.dll
+        // via Assembly.LoadFrom from *that* run's temp directory; the next run's publish reuses the node,
+        // the load of the same simple name from a new path throws, and the scoped-asset bake silently
+        // produces nothing — surfacing as "the bake did not run during this publish" rather than as
+        // anything to do with the template. The repo's Directory.Build.rsp sets this for in-repo builds,
+        // but these projects are generated into a temp directory outside it, so it has to be set here.
+        // An environment variable rather than -nodeReuse:false on the command line: the wasm-hosted build
+        // shells out to a nested `dotnet publish`, and the variable is inherited where a flag is not.
+        psi.Environment["MSBUILDDISABLENODEREUSE"] = "1";
+
         using var process = Process.Start(psi)!;
         var stdout = await process.StandardOutput.ReadToEndAsync();
         var stderr = await process.StandardError.ReadToEndAsync();

--- a/tests/Rask.Cli.Tests/TutorialChapterBuildE2ETests.cs
+++ b/tests/Rask.Cli.Tests/TutorialChapterBuildE2ETests.cs
@@ -18,10 +18,17 @@ namespace Rask.Cli.Tests;
 /// package. A reader following the chapter exactly got four compiler errors.
 /// </para>
 /// <para>
-/// Extending it to chapter 4 found a fifth: the job handler used <c>IDbContextFactory</c> and
-/// <c>AppDbContext</c> with no <c>using</c> and no namespace, so the file the chapter names did not
-/// compile. The chapters build on each other — chapter 4's handler reads <c>db.Orders</c>, which only
-/// exists after chapter 3 — so they are walked cumulatively rather than in isolation.
+/// Extending it found more of the same. Chapter 4's job handler used <c>IDbContextFactory</c> and
+/// <c>AppDbContext</c> with no <c>using</c> and no namespace. Chapter 7 told the reader to give
+/// <c>Order</c> a <c>Customer</c> field it never had — its snippets came from a generator run with
+/// different fields than chapter 3 used, which the old <c>--force</c> regeneration papered over and a
+/// reader patching by hand cannot.
+/// </para>
+/// <para>
+/// The chapters build on each other — chapter 4's handler reads <c>db.Orders</c>, which only exists
+/// after chapter 3; chapter 7 rewrites the <c>Order</c> chapter 3 wrote — so they are walked
+/// cumulatively rather than in isolation. Chapter 6 is absent because its accessor snippet is elided
+/// (<c>…</c>), leaving no complete file to write.
 /// </para>
 /// <para>
 /// Opt-in with the rest of the build gates (<c>RASK_CLI_BUILD_E2E=1</c>) because it packs the framework
@@ -39,6 +46,8 @@ public sealed partial class TutorialChapterBuildE2ETests
         var ch2 = Fences("02-first-feature.md");
         var ch3 = Fences("03-orders-and-auth.md");
         var ch4 = Fences("04-background-jobs.md");
+        var ch5 = Fences("05-email.md");
+        var ch7 = Fences("07-outbox-events.md");
 
         string Fence(string contains) => Pick(ch2, contains, "2");
 
@@ -114,6 +123,21 @@ public sealed partial class TutorialChapterBuildE2ETests
                 + jobHandler[jobHandler.IndexOf("public sealed class", StringComparison.Ordinal)..]);
 
             await Build(csproj, "chapter 4");
+
+            // --- Chapter 5: the email body, a plain component ---
+            Write(fs, shared, "OrderReceipt.cs", Pick(ch5, "Thanks for your order!", "5"));
+
+            await Build(csproj, "chapter 5");
+
+            // --- Chapter 7: domain events through the outbox ---
+            // The chapter shows the revised Order.cs whole rather than as a patch, which is both what a
+            // reader needs (the Raise calls have to go somewhere specific) and what lets this walk apply
+            // it — a fragment could not replace the file chapter 3 wrote.
+            Write(fs, orders, "OrderEvents.cs", Pick(ch7, "record OrderCreated", "7"));
+            Write(fs, orders, "Order.cs", Pick(ch7, "entity.Raise(new OrderCreated", "7"));
+            Write(fs, orders, "OrderCreatedHandler.cs", Pick(ch7, "INotificationHandler<OrderCreated>", "7"));
+
+            await Build(csproj, "chapter 7");
         }
         finally
         {


### PR DESCRIPTION
## Summary

Two findings from extending the chapter walk to 5 and 7. The second one corrects something I got wrong twice.

## Chapter 7 contradicted chapter 3

It told the reader to write:

```csharp
public static Order Create(string customer, decimal total)
{
    ...
    this.Customer = customer;
```

on an `Order` that **chapter 3 gave `Total`, `ProductId` and `Placed`** — and no `Customer` at all.

The snippets came from a generator run using different fields than chapter 3's. The old `--force` regeneration rewrote the whole slice, so the mismatch never surfaced; a reader patching by hand gets a compile error.

Chapter 7 now shows the revised `Order.cs` **whole**, with chapter 3's fields untouched and the three `Raise` calls in place. That also makes it something the walk can apply — a fragment can't replace the file chapter 3 wrote, which is exactly why chapter 7 was uncoverable before.

The gate now walks **ch2 → ch3 → ch4 → ch5 → ch7**. Chapter 6 stays out: its accessor snippet is elided with `…`, so there is no complete file to write.

## The build gate's flake was #650, not cache contention

I called it "unexplained" in #675 and "probably cache contention between overlapping runs" in #676. **Both were wrong**, and I only found out by capturing the log instead of re-running until it went green.

The four wasm-hosted cases fail because the scoped-asset bake silently produces nothing:

```
error : Rask: the scoped-asset bake did not run during this publish and
bin/Debug/net10.0-browser/publish/wwwroot/_rask/a is empty
```

That is [#650](https://github.com/pal-tamas/rask/issues/650). A worker node kept alive from an earlier run has already loaded `Rask.Wasm.Tasks.dll` via `Assembly.LoadFrom` from *that* run's temp directory; the next run's publish reuses the node, the load of the same simple name from a new path throws, and the bake does nothing. **That is precisely why it only ever appeared on a repeated run** — the detail I had been treating as noise was the whole diagnosis.

`Directory.Build.rsp` already sets `-nodeReuse:false`, but these projects are generated into a temp directory outside the repo, so it never applied. `RunDotnet` now sets `MSBUILDDISABLENODEREUSE=1` — an environment variable rather than a command-line flag, because the wasm-hosted build shells out to a nested `dotnet publish` that inherits the variable and would not inherit the flag.

## Testing

Verified against the thing that used to break it: **three consecutive gate runs, 27/27 each.** Before this, the second back-to-back run failed all four wasm-hosted cases.

`dotnet format` ✓ · `CI=true dotnet build -warnaserror` ✓ · full local unit gate ✓ · CLI build gate 27/27 ×3 ✓.
