### PR TITLE
fix(wasm): stop an unrelated assembly failing the bake for a project with no scoped assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,6 +310,23 @@ them until tagged releases begin.
   `Handler`).
 
 ### Fixed
+- **A dependency bump could fail the build of a project that has no scoped assets at all.** The
+  scoped-asset bake refuses to write an empty bundle silently (#650) — but the check that decides whether
+  "zero files" is a failure asked only whether *some* assembly had been skipped, on the reasoning that
+  "zero written plus a skip is never a legitimate no-scoped-assets project". That reasoning was wrong, and
+  the skip need not be an assembly that could ever hold a scoped asset.
+
+  Bumping the `Microsoft.Extensions` family was enough to prove it: the app then carries a
+  `Microsoft.Extensions.DependencyModel` newer than the one MSBuild already has loaded, `Assembly.LoadFrom`
+  throws on identity, and `Rask.Example.Wasm.Jobs` — which genuinely has no scoped assets — failed a build
+  that was entirely correct, with an error blaming node reuse.
+
+  The check now also requires that the registry was **never read**, which is what actually distinguishes
+  the two: if `Rask.Core` loaded and the registry was read, "zero files" is an answer rather than a
+  failure, and `FailOnEmpty` still speaks for the projects that assert they should have produced some. The
+  decision is extracted as `BakeScopedAssetsTask.IsNodeReuseBakeFailure` and pinned by a table test — it
+  is three booleans that had already been wrong once in a way no build caught.
+
 - **`rask new` scaffolded projects that could not compile, and every in-repo gate said they were fine.**
   `RaskBuilderSurface` — the switch that emits the chain entries — defaulted to **false**, and the repo
   turned it on only in its own `Directory.Build.props`. So the solution build, the 5,956-test unit gate,

--- a/src/Rask.Wasm.Tasks/BakeScopedAssetsTask.cs
+++ b/src/Rask.Wasm.Tasks/BakeScopedAssetsTask.cs
@@ -105,17 +105,26 @@ public sealed class BakeScopedAssetsTask : Task
             Log.LogMessage(MessageImportance.High,
                 $"Rask asset bake: wrote {written} file(s) under '{Path.Combine(BundleDir, "_rask", "a")}'.");
 
-            // The bake produced nothing AND we skipped an assembly because this process had already loaded
-            // one by that name. That combination is never a legitimate "this project has no scoped assets":
-            // it is the MSBuild node-reuse race (#650), where LoadFrom throws on a reused worker and the
-            // bake quietly bakes an empty bundle. Measured at roughly one publish in three, and silent —
+            // The bake produced nothing, we skipped an assembly because this process had already loaded one
+            // by that name, AND the registry itself was never read. That combination is the MSBuild
+            // node-reuse race (#650): LoadFrom throws on a reused worker, the registry is never reached, and
+            // the bake quietly writes an empty bundle. Measured at roughly one publish in three, and silent —
             // the app then boots with every /_rask/a/ URL 404ing, which reads as a broken app rather than a
             // broken build. Failing here is what stops that shipping.
             //
-            // Deliberately conditioned on written == 0 as well as the skip: a bake that still produced its
-            // files despite skipping something is not known to be wrong, and failing it would turn a real
-            // fix into a new source of false build breaks.
-            if (written == 0 && _skippedAlreadyLoaded.Count > 0)
+            // !registryResolved is load-bearing, and was missing. Without it this fires on a project that
+            // legitimately has NO scoped assets (Rask.Example.Wasm.Jobs is one) the moment ANY assembly is
+            // skipped — and the skip need not be one that could ever hold a scoped asset. A Microsoft
+            // .Extensions bump was enough: the app then carries a DependencyModel newer than the one MSBuild
+            // already has loaded, LoadFrom throws on identity, and a build that was entirely correct failed
+            // on an assembly that cannot contain a registration. If the registry WAS read, "zero files" is
+            // an answer, not a failure — and the FailOnEmpty check below is what speaks for the projects
+            // that assert they should have produced some.
+            //
+            // Still conditioned on written == 0: a bake that produced its files despite skipping something
+            // is not known to be wrong, and failing it would turn a real fix into a new source of false
+            // build breaks.
+            if (IsNodeReuseBakeFailure(written, _skippedAlreadyLoaded.Count, registryResolved))
             {
                 Log.LogError(
                     "Rask asset bake: zero /_rask/a/ files were written because " +
@@ -147,6 +156,19 @@ public sealed class BakeScopedAssetsTask : Task
             return true;
         }
     }
+
+    /// <summary>
+    ///     Whether an empty bake is the MSBuild node-reuse race (#650) rather than a project that simply
+    ///     has no scoped assets.
+    /// </summary>
+    /// <remarks>
+    ///     Extracted so the decision can be pinned by a test. It is three booleans and it has already been
+    ///     wrong once, in a way no build caught: without <paramref name="registryResolved" /> it fired on any
+    ///     project with no scoped assets the moment ANY assembly was skipped, including one that could never
+    ///     hold a registration. A Microsoft.Extensions version bump was enough to trigger it.
+    /// </remarks>
+    internal static bool IsNodeReuseBakeFailure(int written, int skippedAlreadyLoaded, bool registryResolved)
+        => written == 0 && skippedAlreadyLoaded > 0 && !registryResolved;
 
     private int BakeFromAssemblies(out bool registryResolved)
     {

--- a/src/Rask.Wasm.Tasks/Rask.Wasm.Tasks.csproj
+++ b/src/Rask.Wasm.Tasks/Rask.Wasm.Tasks.csproj
@@ -46,4 +46,8 @@
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(MSBuildThisFileDirectory)..\Rask.Wasm\build\" SkipUnchangedFiles="true"/>
   </Target>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Rask.Wasm.Tasks.Tests"/>
+  </ItemGroup>
+
 </Project>

--- a/tests/Rask.Wasm.Tasks.Tests/BakeScopedAssetsTaskTests.cs
+++ b/tests/Rask.Wasm.Tasks.Tests/BakeScopedAssetsTaskTests.cs
@@ -199,6 +199,22 @@ public sealed class BakeScopedAssetsTaskTests : IDisposable
         Assert.Equal(first, second);
     }
 
+    // The #650 guard, pinned as the three-input decision it is. It was wrong in exactly one of these
+    // rows — a project with no scoped assets, where an unrelated assembly failed to load — and nothing
+    // caught it until a Microsoft.Extensions bump made an unrelated assembly fail to load. That row is
+    // the second one.
+    [Theory]
+    // written, skipped, registryResolved, expected
+    [InlineData(0, 1, false, true)]   // the real #650: registry never read, nothing baked -> fail
+    [InlineData(0, 1, true, false)]   // registry READ and this project has no scoped assets -> fine
+    [InlineData(0, 0, false, false)]  // nothing skipped: not this failure mode
+    [InlineData(3, 1, false, false)]  // files were written despite a skip: not known to be wrong
+    [InlineData(3, 0, true, false)]   // the ordinary happy path
+    public void IsNodeReuseBakeFailure_OnlyWhenTheRegistryWasNeverRead(
+        int written, int skipped, bool registryResolved, bool expected) =>
+        Assert.Equal(expected,
+            BakeScopedAssetsTask.IsNodeReuseBakeFailure(written, skipped, registryResolved));
+
     /// <summary>
     ///     Minimal IBuildEngine stub for task tests. The bake task only calls Log.*; all
     ///     messages are captured into <see cref="Messages" /> for assertions that care


### PR DESCRIPTION
Found while merging the dependency bumps: **#678 could not be merged**, and the reason turned out to have nothing to do with the dependency.

## What happens

The scoped-asset bake refuses to write an empty bundle silently (#650). The check deciding whether "zero files" is a failure asked only whether *some* assembly had been skipped, carrying this reasoning in a comment:

> That combination is never a legitimate "this project has no scoped assets".

It is. `samples/Rask.Example.Wasm.Jobs` genuinely has no scoped assets, so `written == 0` is the correct answer for it — and the skipped assembly does not have to be one that could ever hold a scoped asset.

Bumping the `Microsoft.Extensions` family to 10.0.11 (#678) is enough to trigger it. The app then carries a `Microsoft.Extensions.DependencyModel` newer than the one MSBuild already has loaded, `Assembly.LoadFrom` throws on identity, `_skippedAlreadyLoaded` gains an entry, and a build that is entirely correct fails with an error blaming node reuse.

Isolated by bisecting the three open dependabot PRs: #679 and #680 build clean, #678 alone reproduces it, and `main`’s versions build clean.

## The fix

The check now also requires that the registry was **never read**. That is what actually separates the two cases:

- registry never read + nothing baked + something skipped → the real #650 race, still fails the build.
- registry read, project simply has no scoped assets → an answer, not a failure.

`FailOnEmpty` still speaks for the projects that assert they should have produced some, so nothing is lost on the standalone-WASM path.

The decision is extracted as `BakeScopedAssetsTask.IsNodeReuseBakeFailure` and pinned by a table test over all five rows. It is three booleans that had already been wrong once in a way no build caught; the row that was wrong is now the row that fails if anyone relaxes the condition again.

## What this does NOT do

**It does not close #650 or #660.** The underlying `Assembly.LoadFrom` conflict is still there and `-nodeReuse:false` is still the workaround in `scripts/run-e2e-local.sh`. This fixes a false positive in the guard that #650 added, nothing more.

Also recorded on #650: **`TaskFactory="TaskHostFactory"` does not fix the underlying conflict.** It was the obvious next candidate after byte-loading and a bare `AssemblyLoadContext` were ruled out, and it fails identically — verified after `dotnet build-server shutdown` plus killing every MSBuild process, so it was not a stale task host either. That also casts doubt on the "node reuse" framing in the error message, since the conflict reproduces in a freshly started process.

The real fix remains: have the generator emit the scoped-asset registry as a file next to the assembly and have the task read that, removing the reflection and the load conflict together.

## Testing

- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors.
- `scripts/run-unit-local.sh` — green.
- With this fix applied, the #678 package bump builds clean; without it, it fails.