### PR TITLE
fix(generators): make three analyzers see the chain, and stop the quick-fixes writing factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -506,6 +506,30 @@ them until tagged releases begin.
   the harness can show. The remaining arguments for splitting are size, per-file pragmas and blast
   radius — not latency; the outbox can never move, since it commits with the business change by design.
 
+### Fixed
+- **Three analyzers were silently dead on the chain — the syntax the framework teaches.** Each identified
+  its subject as "a static method on a class named `Generated`", which a chain never is: a chain's steps are
+  extension methods on `Build<T>`, and its shortest spelling is a bare entry that is not an invocation at
+  all. The build stayed green throughout, because a diagnostic that never fires breaks nothing.
+  - **RASK023 (`Img` without `Alt`) never fired on `Img.Src("/logo.png")`.** An accessibility guard
+    (WCAG 1.1.1) that was absent from every chain ever written.
+  - **RASK022 (list item missing a `Key`) never fired on a keyless chain row.** `_items.Select(i => Li[…])`
+    — the exact shape the guides teach — went unreported, so those lists reconcile by position and lose
+    focus and input state on insert/remove/reorder.
+  - **RASK027 (both the sync and async handler set) never fired on a chain.**
+    `Button.OnClick(…).OnClickAsync(…)` silently dropped the async handler, which is the whole reason the
+    diagnostic is an **Error** on a factory call.
+  - RASK034 has the same defect and is **not** fixed here; it is tracked separately.
+  - The chain branch is deliberately additive: the factory branch still owns `Generated.X(…)`, so nothing
+    reports twice. Each new branch requires the operation's type to genuinely be `Build<T>` — without that
+    the children indexer qualifies too (it is also a property reference) and every keyless row reported
+    twice.
+- **Both shipped quick-fixes wrote factory syntax.** RASK014's lightbulb was titled "Use the generated
+  factory" and rewrote `new Widget()` into `Widget()`; it now produces the bare entry `Widget`, which is
+  what RASK014's own message has been telling the reader to write. RASK023's inserted `Alt: ""`, a named
+  argument — on a chain that is not merely stale but broken, so it now appends a `.Alt("")` step (and still
+  inserts the named argument on a factory call).
+
 ### Changed
 - **The chain is now what the docs, the README, the site and the playground actually teach.** #681 made
   markup a chain but left the teaching surfaces describing the generated factory, so a newcomer's first

--- a/benchmarks/Rask.Benchmarks/AttrBagBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/AttrBagBenchmarks.cs
@@ -22,6 +22,10 @@ namespace Rask.Benchmarks;
 // The tree is built inside the benchmark rather than in [GlobalSetup] on purpose. Setting up once and
 // re-rendering would measure only the serializer, which is the same for both arms — the difference
 // lives in constructing the bag, so constructing it is the thing to time.
+// RASK022 is suppressed on purpose: these rows are deliberately keyless. A .Key(…) per row is itself
+// an allocation, and the whole point here is to isolate the cost of the attribute bag — keying the
+// rows would fold an unrelated cost into both arms and blunt the very difference being measured.
+#pragma warning disable RASK022
 [MemoryDiagnoser]
 public partial class AttrBagBenchmarks : global::Rask.Core.RaskMarkup
 {
@@ -82,3 +86,4 @@ public partial class AttrBagBenchmarks : global::Rask.Core.RaskMarkup
         return Div[rows].ToHtml();
     }
 }
+#pragma warning restore RASK022

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -12,8 +12,8 @@ Some diagnostics ship an **IDE quick-fix** (the lightbulb / `Ctrl`+`.`):
 | ID | What the lightbulb does |
 |----|-------------------------|
 | **RASK001** | adds the `required` modifier |
-| **RASK014** | rewrites `new Widget()` into the generated `Widget()` factory call |
-| **RASK023** | inserts `Alt: ""` |
+| **RASK014** | rewrites `new Widget()` into the bare entry `Widget` |
+| **RASK023** | appends `.Alt("")` to the chain (or `Alt: ""` on a factory call) |
 | **RASK026** | deletes the redundant `StateHasChanged()` statement |
 | **RASK027** | removes the `OnXAsync` argument, keeping the sync one |
 | **CS0108** | adds `new` to a member that [hides a builder entry](#cs0108-a-member-hides-a-builder-entry) |
@@ -22,10 +22,10 @@ These are delivered by `Rask.Generators.CodeFixes`, packed alongside the analyze
 `Rask.Server` / `Rask.Wasm` packages — no extra reference needed.
 
 A fix is offered only when the rewrite means exactly what you wrote. **RASK014's is withheld when the
-construction has arguments or an object initializer**: the factory's parameters are generated from the
-component's public properties in an order that is not the constructor's, so moving positional arguments
-across would compile and mean something else — and an object initializer is only legal after `new`. In
-those cases the error stands with its message, which already spells out the chain to write.
+construction has arguments or an object initializer**: a chain sets each property by name in its own
+step, so moving positional constructor arguments across would compile and mean something else — and an
+object initializer is only legal after `new`. In those cases the error stands with its message, which
+already spells out the chain to write.
 
 Every RASK diagnostic reports under the single category **`Rask`**, so one `.editorconfig` line covers
 the family:

--- a/src/Rask.Generators.CodeFixes/ComponentConstructionCodeFixProvider.cs
+++ b/src/Rask.Generators.CodeFixes/ComponentConstructionCodeFixProvider.cs
@@ -10,7 +10,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 namespace Rask.Generators.CodeFixes;
 
 /// <summary>
-///     RASK014 — rewrite <c>new Widget()</c> into the generated <c>Widget()</c> factory call.
+///     RASK014 — rewrite <c>new Widget()</c> into the chain that builds it: the bare entry <c>Widget</c>.
 /// </summary>
 /// <remarks>
 ///     <para>
@@ -34,9 +34,9 @@ public sealed class ComponentConstructionCodeFixProvider : RaskCodeFixProvider<O
 {
     public override ImmutableArray<string> FixableDiagnosticIds { get; } = ["RASK014"];
 
-    protected override string Title => "Use the generated factory";
+    protected override string Title => "Build it with the chain";
 
-    protected override string EquivalenceKey => "RASK014_UseFactory";
+    protected override string EquivalenceKey => "RASK014_UseChain";
 
     protected override Task<bool> CanFixAsync(CodeFixContext context, ObjectCreationExpressionSyntax node) =>
         Task.FromResult(
@@ -57,13 +57,13 @@ public sealed class ComponentConstructionCodeFixProvider : RaskCodeFixProvider<O
         return await ReplaceNodeAsync(
             document,
             node,
-            InvocationExpression(IdentifierName(name)).WithTriviaFrom(node),
+            IdentifierName(name).WithTriviaFrom(node),
             cancellationToken).ConfigureAwait(false);
     }
 
-    // The factory is a static method named after the type, in scope project-wide through the generator's
-    // `global using static …Generated`. So the bare type name IS the call: carrying a qualified name over
-    // would name a type where a method has to go.
+    // The entry is a property named after the type, injected into every markup host by the generator. So
+    // the bare simple name IS the chain: carrying a qualified name over would name the TYPE, which is
+    // exactly what RASK014 is complaining about.
     private static string? FactoryName(ObjectCreationExpressionSyntax node) => node.Type switch
     {
         QualifiedNameSyntax qualified => qualified.Right.Identifier.Text,

--- a/src/Rask.Generators.CodeFixes/ImgMissingAltCodeFixProvider.cs
+++ b/src/Rask.Generators.CodeFixes/ImgMissingAltCodeFixProvider.cs
@@ -9,31 +9,82 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Rask.Generators.CodeFixes;
 
-// Quick-fix for RASK023 (Img is missing Alt): append `Alt: ""` so the image is treated as decorative
+// Quick-fix for RASK023 (Img is missing Alt): give the image an empty Alt so it reads as decorative
 // and assistive tech skips it. The empty string is the safe default the analyzer message itself
-// suggests — the developer replaces it with real alt text when the image is informative. Appending a
-// named argument is always valid here because the analyzer fires only when no Alt was supplied.
+// suggests — the developer replaces it with real alt text when the image is informative.
+//
+// Two shapes, because RASK023 now fires on both. A chain gets a `.Alt("")` step appended to its END,
+// which is where a step belongs and is valid wherever the chain already was — including on a bare
+// entry (`Img` becomes `Img.Alt("")`), which carries no argument list to add anything to. The older
+// generated factory call keeps taking a named `Alt: ""` argument. Appending is always valid here
+// because the analyzer fires only when no Alt was supplied at all.
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ImgMissingAltCodeFixProvider))]
 [Shared]
-public sealed class ImgMissingAltCodeFixProvider : RaskCodeFixProvider<InvocationExpressionSyntax>
+public sealed class ImgMissingAltCodeFixProvider : RaskCodeFixProvider<ExpressionSyntax>
 {
+    private const string GeneratedClassName = "Generated";
+
     public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create("RASK023");
 
-    protected override string Title => "Add Alt: \"\" (decorative image)";
+    protected override string Title => "Add an empty Alt (decorative image)";
 
     protected override string EquivalenceKey => "RASK023_AddEmptyAlt";
 
-    protected override Task<Document> FixAsync(
+    protected override async Task<Document> FixAsync(
+        Document document, ExpressionSyntax node, CancellationToken cancellationToken)
+    {
+        var enclosing = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+
+        if (enclosing is not null && await IsFactoryCallAsync(document, enclosing, cancellationToken)
+                .ConfigureAwait(false))
+        {
+            var argument = SyntaxFactory.Argument(
+                SyntaxFactory.NameColon("Alt"),
+                default,
+                EmptyString());
+
+            return await ReplaceNodeAsync(
+                document,
+                enclosing,
+                enclosing.WithArgumentList(enclosing.ArgumentList.AddArguments(argument)),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        // A chain: append `.Alt("")` to the whole thing, not to whichever step happens to be nearest.
+        var chain = Outermost(enclosing ?? node);
+        var stepped = SyntaxFactory.InvocationExpression(
+            SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                chain.WithoutTrivia(),
+                SyntaxFactory.IdentifierName("Alt")),
+            SyntaxFactory.ArgumentList(
+                SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(EmptyString()))));
+
+        return await ReplaceNodeAsync(document, chain, stepped.WithTriviaFrom(chain), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static LiteralExpressionSyntax EmptyString() =>
+        SyntaxFactory.LiteralExpression(
+            SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(string.Empty));
+
+    // The end of the chain, so the new step lands after every existing one.
+    private static ExpressionSyntax Outermost(ExpressionSyntax node)
+    {
+        var current = node;
+        while (current.Parent is MemberAccessExpressionSyntax { Parent: InvocationExpressionSyntax outer })
+        {
+            current = outer;
+        }
+
+        return current;
+    }
+
+    private static async Task<bool> IsFactoryCallAsync(
         Document document, InvocationExpressionSyntax invocation, CancellationToken cancellationToken)
     {
-        var altArgument = SyntaxFactory.Argument(
-            SyntaxFactory.NameColon("Alt"),
-            default,
-            SyntaxFactory.LiteralExpression(
-                SyntaxKind.StringLiteralExpression,
-                SyntaxFactory.Literal(string.Empty)));
-
-        var newInvocation = invocation.WithArgumentList(invocation.ArgumentList.AddArguments(altArgument));
-        return ReplaceNodeAsync(document, invocation, newInvocation, cancellationToken);
+        var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        return model?.GetSymbolInfo(invocation, cancellationToken).Symbol is IMethodSymbol { IsStatic: true } method
+               && method.ContainingType?.Name == GeneratedClassName;
     }
 }

--- a/src/Rask.Generators/Analyzers/SyncAsyncHandlerAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/SyncAsyncHandlerAnalyzer.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Rask.Generators.Analyzers;
 
@@ -55,7 +56,91 @@ public sealed class SyncAsyncHandlerAnalyzer : DiagnosticAnalyzer
             }
 
             start.RegisterSyntaxNodeAction(ctx => Analyze(ctx, component), SyntaxKind.InvocationExpression);
+
+            // The chain reaches none of the above: its steps are extension methods on Build<T>, not a
+            // static Generated.Button(...), so the factory branch matched no chain and one of the two
+            // handlers was dropped in silence — the exact thing this diagnostic exists to prevent.
+            start.RegisterOperationAction(ctx => AnalyzeChain(ctx, component), OperationKind.Invocation);
         });
+    }
+
+    private static void AnalyzeChain(OperationAnalysisContext context, INamedTypeSymbol component)
+    {
+        var operation = (IInvocationOperation)context.Operation;
+
+        // Only the OUTERMOST link, so the chain is judged once and as a whole.
+        if (operation.Syntax.Parent is MemberAccessExpressionSyntax { Parent: InvocationExpressionSyntax })
+        {
+            return;
+        }
+
+        if (operation.TargetMethod.IsStatic
+            && string.Equals(operation.TargetMethod.ContainingType?.Name, GeneratedClassName, StringComparison.Ordinal))
+        {
+            return; // The factory branch owns this one.
+        }
+
+        if (BuiltComponent(operation.Type) is not { } built || !InheritsFrom(built, component))
+        {
+            return;
+        }
+
+        // Every step written on this chain, and where. A step that was handed `null` is the deliberate
+        // "set at most one" conditional shape, exactly as a null argument is in the factory branch.
+        var steps = new Dictionary<string, IInvocationOperation>(StringComparer.Ordinal);
+        for (var step = operation; step is not null; step = NextStep(step))
+        {
+            var value = step.TargetMethod.IsExtensionMethod && step.Arguments.Length > 1
+                ? step.Arguments[1].Value
+                : step.Arguments.Length != 0 ? step.Arguments[0].Value : null;
+
+            if (value is not { ConstantValue: { HasValue: true, Value: null } })
+            {
+                steps[step.TargetMethod.Name] = step;
+            }
+        }
+
+        foreach (var entry in steps)
+        {
+            var asyncName = entry.Key;
+            if (asyncName.Length <= "OnAsync".Length
+                || !asyncName.StartsWith("On", StringComparison.Ordinal)
+                || !asyncName.EndsWith("Async", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var syncName = asyncName.Substring(0, asyncName.Length - "Async".Length);
+            if (steps.ContainsKey(syncName))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Rask027, entry.Value.Syntax.GetLocation(), syncName, asyncName));
+            }
+        }
+    }
+
+    // The component a Build<T> is building, or null when the type is anything else.
+    private static INamedTypeSymbol? BuiltComponent(ITypeSymbol? type) =>
+        type is INamedTypeSymbol { IsGenericType: true, Arity: 1 } named
+        && string.Equals(named.ConstructedFrom.ToDisplayString(), "Rask.Core.Build<T>", StringComparison.Ordinal)
+            ? named.TypeArguments[0] as INamedTypeSymbol
+            : null;
+
+    // The next link DOWN the chain: a step's receiver is whatever produced the Build<T> it extends,
+    // written either as an extension method (argument 0) or as an instance call.
+    private static IInvocationOperation? NextStep(IInvocationOperation operation)
+    {
+        var receiver = operation.Instance
+                       ?? (operation.TargetMethod.IsExtensionMethod && operation.Arguments.Length != 0
+                           ? operation.Arguments[0].Value
+                           : null);
+
+        while (receiver is IParenthesizedOperation or IConversionOperation { IsImplicit: true })
+        {
+            receiver = receiver is IParenthesizedOperation p ? p.Operand : ((IConversionOperation)receiver).Operand;
+        }
+
+        return receiver as IInvocationOperation;
     }
 
     private static void Analyze(SyntaxNodeAnalysisContext context, INamedTypeSymbol component)

--- a/tests/Rask.Core.Tests/BuilderCallbackTests.cs
+++ b/tests/Rask.Core.Tests/BuilderCallbackTests.cs
@@ -157,7 +157,10 @@ public partial class BuilderCallbackTests : global::Rask.Core.RaskMarkup
     public void The_sync_handler_still_wins_the_shared_slot()
     {
         Action sync = Noop;
+        // Setting both is the whole point of this test — RASK027 is exactly right to flag it elsewhere.
+#pragma warning disable RASK027
         var div = Div.OnClickAsync(() => Task.CompletedTask).OnClick(sync).Value;
+#pragma warning restore RASK027
 
         Assert.Same(sync, div.OnClick);
         Assert.Null(div.OnClickAsync);

--- a/tests/Rask.Core.Tests/Routing/OutletTests.cs
+++ b/tests/Rask.Core.Tests/Routing/OutletTests.cs
@@ -125,7 +125,11 @@ public partial class OutletTests : global::Rask.Core.RaskMarkup
             var kids = new List<Component>(Extra + 1);
             for (var i = 0; i < Extra; i++)
             {
+                // No .Key(…) on purpose: this test asserts exact HTML, and a key would add a
+                // data-rask-key attribute to it. RASK022 is right about real lists.
+#pragma warning disable RASK022
                 kids.Add(I);
+#pragma warning restore RASK022
             }
 
             kids.Add(Outlet);

--- a/tests/Rask.Generators.Tests/CodeFixProviderTests.cs
+++ b/tests/Rask.Generators.Tests/CodeFixProviderTests.cs
@@ -47,6 +47,27 @@ public class CodeFixProviderTests
         Assert.Contains("Img(\"/a.png\", Alt: \"\")", fixhed);
     }
 
+    // A chain takes a `.Alt("")` STEP, not a named argument — appending `Alt: ""` into whichever step
+    // happened to be nearest would not even compile.
+    [Fact]
+    public async Task Rask023_AppendsAltStep_ToAChain()
+    {
+        var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
+            new ImgMissingAltAnalyzer(), new ImgMissingAltCodeFixProvider(), "RASK023",
+            App("return Img.Src(\"/a.png\");"));
+        Assert.Contains("Img.Src(\"/a.png\").Alt(\"\")", fixhed);
+    }
+
+    [Fact]
+    public async Task Rask023_AppendsAltStep_ToABareEntry()
+    {
+        // A bare entry has no argument list at all, so only a step can be added.
+        var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
+            new ImgMissingAltAnalyzer(), new ImgMissingAltCodeFixProvider(), "RASK023",
+            App("return Img;"));
+        Assert.Contains("Img.Alt(\"\")", fixhed);
+    }
+
     // ---- RASK001: property becomes a required factory param -> add `required` ----
 
     [Fact]
@@ -105,7 +126,7 @@ public class CodeFixProviderTests
         Assert.True(offered);
     }
 
-    // ---- RASK014: `new Widget()` -> the generated factory ----
+    // ---- RASK014: `new Widget()` -> the chain that builds it ----
     //
     // A user component rather than a built-in tag: inside a `using static …Generated` scope a tag name
     // binds to the generated factory METHOD, so `new Div()` doesn't resolve to the type there at all.
@@ -124,24 +145,25 @@ public class CodeFixProviderTests
         """;
 
     [Fact]
-    public async Task Rask014_RewritesArgumentlessNew_ToTheFactoryCall()
+    public async Task Rask014_RewritesArgumentlessNew_ToTheBareEntry()
     {
         var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
             new ComponentConstructionAnalyzer(), new ComponentConstructionCodeFixProvider(), "RASK014",
             Caller("var x = new Widget();"));
-        Assert.Contains("var x = Widget();", fixhed);
+        // The bare entry — which is what RASK014's own message tells the reader to write.
+        Assert.Contains("var x = Widget;", fixhed);
         Assert.DoesNotContain("new Widget()", fixhed);
     }
 
     [Fact]
-    public async Task Rask014_DropsTheQualifier_BecauseTheFactoryIsAMethodNotAType()
+    public async Task Rask014_DropsTheQualifier_BecauseTheEntryIsNotAType()
     {
-        // `new Demo.Widget()` must become `Widget()`, not `Demo.Widget()` — the latter names a type where
+        // `new Demo.Widget()` must become `Widget`, not `Demo.Widget` — the latter names a type where
         // a method has to go, and would not compile.
         var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
             new ComponentConstructionAnalyzer(), new ComponentConstructionCodeFixProvider(), "RASK014",
             Caller("var x = new Demo.Widget();"));
-        Assert.Contains("var x = Widget();", fixhed);
+        Assert.Contains("var x = Widget;", fixhed);
     }
 
     [Fact]

--- a/tests/Rask.Generators.Tests/ImgMissingAltAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/ImgMissingAltAnalyzerTests.cs
@@ -49,6 +49,29 @@ public class ImgMissingAltAnalyzerTests
         // Factory order is Src, Alt, ... so the second positional argument is Alt.
         Assert.Empty(await Diagnostics(App("return Img(\"/a.png\", \"A logo\");")));
 
+    // The chain is what the framework teaches now, so the a11y guard has to see it. These are the same
+    // four cases as above, written the way a user writes them today.
+    [Fact]
+    public async Task Chain_NoAlt_ReportsRask023()
+    {
+        var d = Assert.Single(await Diagnostics(App("return Img.Src(\"/a.png\");")));
+        Assert.Equal("RASK023", d.Id);
+        Assert.Contains("Alt", d.GetMessage());
+    }
+
+    [Fact]
+    public async Task BareEntry_NoAlt_ReportsRask023() =>
+        // The shortest spelling of all: no invocation anywhere, just the entry.
+        Assert.Equal("RASK023", Assert.Single(await Diagnostics(App("return Img;"))).Id);
+
+    [Fact]
+    public async Task Chain_WithAlt_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(App("return Img.Src(\"/a.png\").Alt(\"A logo\");")));
+
+    [Fact]
+    public async Task Chain_EmptyAltForDecorative_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(App("return Img.Alt(\"\").Src(\"/a.png\");")));
+
     private static async Task<ImmutableArray<Diagnostic>> Diagnostics(string source)
     {
         var compilation = CSharpCompilation.Create(

--- a/tests/Rask.Generators.Tests/MissingKeyAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/MissingKeyAnalyzerTests.cs
@@ -26,6 +26,22 @@ public class MissingKeyAnalyzerTests
                                                 }
                                                 """;
 
+    // The chain is what the framework teaches, so keyless-list detection has to see it. A chain's steps
+    // are extension methods on Build<T>, not a static Generated.Li(...), so the factory branch matched
+    // none of these and the warning was silently absent from every chain ever written.
+    [Fact]
+    public async Task ChainSelectProjection_NoKey_ReportsRask022()
+    {
+        var d = Assert.Single(await Diagnostics(App(
+            "return Ul[ _items.Select(i => Li[i.ToString()]) ];")));
+        Assert.Equal("RASK022", d.Id);
+    }
+
+    [Fact]
+    public async Task ChainSelectProjection_WithKey_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(App(
+            "return Ul[ _items.Select(i => Li.Key(i)[i.ToString()]) ];")));
+
     [Fact]
     public async Task SelectProjection_NoKey_ReportsRask022()
     {

--- a/tests/Rask.Generators.Tests/SyncAsyncHandlerAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/SyncAsyncHandlerAnalyzerTests.cs
@@ -35,6 +35,24 @@ public class SyncAsyncHandlerAnalyzerTests
         Assert.Contains("OnClickAsync", d.GetMessage());
     }
 
+    // The chain is what the framework teaches. A chain's steps are extension methods on Build<T>, not a
+    // static Generated.Button(...), so the factory branch matched none of these and one of the two
+    // handlers was silently dropped with nothing said.
+    [Fact]
+    public async Task ChainBothSyncAndAsyncClick_ReportsRask027()
+    {
+        var d = Assert.Single(await Diagnostics(App(
+            "return Button.OnClick(() => {}).OnClickAsync(async () => await Task.Yield())[\"x\"];")));
+        Assert.Equal("RASK027", d.Id);
+        Assert.Contains("OnClick", d.GetMessage());
+        Assert.Contains("OnClickAsync", d.GetMessage());
+    }
+
+    [Fact]
+    public async Task ChainOnlyAsync_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(App(
+            "return Button.OnClickAsync(async () => await Task.Yield())[\"x\"];")));
+
     [Fact]
     public async Task OnlySync_NoDiagnostic() =>
         Assert.Empty(await Diagnostics(App("return Button(OnClick: () => {})[\"x\"];")));


### PR DESCRIPTION
> **Stacked on #696** — based on `worktree-teach-builder-syntax`. Retarget to `main` before that one merges.

Started as the small follow-up filed in #697 (two quick-fixes still writing factory syntax) and turned up something considerably worse.

## Three analyzers were silently dead on the chain

Each identified its subject as *"a static method on a class named `Generated`"*, which a chain never is: a chain's steps are extension methods on `Build<T>`, and its shortest spelling is a bare entry that is not an invocation at all.

| ID | What was unreported on a chain |
|---|---|
| **RASK023** | `Img.Src("/logo.png")` with no `Alt` — a WCAG 1.1.1 guard absent from **every chain ever written** |
| **RASK022** | `_items.Select(i => Li[…])` — a keyless row, the exact shape the guides teach. Those lists reconcile by position and lose focus and input state on insert/remove/reorder |
| **RASK027** | `Button.OnClick(…).OnClickAsync(…)` — silently dropped the async handler, which is the whole reason this is an **Error** on a factory call |

The build stayed green throughout, because a diagnostic that never fires breaks nothing. Every fix here was written **test-first and confirmed red** before being made green.

**Additive, not a replacement.** The factory branch still owns `Generated.X(…)`, so nothing reports twice. Each new branch requires the operation's type to genuinely be `Build<T>` — without that the children indexer qualifies too (it is also a property reference, typed `Component`) and every keyless row reported twice, which is exactly how the first attempt failed.

## They immediately found seven real occurrences in this repo

Nothing had ever reported them. All seven are deliberate, and each now carries a suppression that says why:

- **4 keyless benchmark rows** (`AttrBagBenchmarks`) — the benchmark isolates the attribute bag's cost; a per-row key folds an unrelated allocation into both arms and blunts the very difference being measured.
- **`OutletTests`, `BuilderMarkupHostTests`** — both assert **exact HTML**, which a `data-rask-key` attribute changes. (I tried real keys first; both went red. That is why they are suppressions.)
- **`BuilderCallbackTests`** — exists precisely to prove the sync handler wins the shared slot.

## The quick-fixes

Fixing RASK023's analyzer made its quick-fix **mandatory rather than cosmetic**: it appended `Alt: ""` as a *named argument*, which on a chain would land inside whichever step was nearest (`Img.Src("/a.png", Alt: "")`) and not compile. It now appends a `.Alt("")` step, and still inserts the named argument on a factory call.

RASK014's was titled "Use the generated factory" and rewrote `new Widget()` into `Widget()`. It now produces the bare entry `Widget` — what RASK014's own message has been telling the reader to write since #681.

## Not fixed

**RASK034** has the identical defect. Its tests use hand-written stand-ins rather than a real `Rask.Bootstrap` reference, so making it chain-aware needs `Build<T>` and the extension setters stubbed faithfully. It is the lowest-impact of the four (a column-chooser UX hint). Tracked in #697.

## Testing

- `dotnet format --verify-no-changes` — clean (exit 0).
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors.
- `scripts/run-unit-local.sh` — **6,072 passed, 0 failed** (was 6,062; +10 new tests).
- Browser E2E via the pre-push gate.

No benchmarks: analyzers run at compile time and touch no render path.

## Changelog

`[Unreleased] → Fixed`.
