### PR TITLE
fix(core): identify a keyed child by its key, not by its position among its siblings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **A keyed row's own state followed its POSITION, not its item.** A child's identity inside its parent
+  was its ordinal among entry-built siblings, and `Key` took no part — the parent's child map never read
+  it. `Key` was only ever the diff codec's identity (`data-rask-key`), one layer above. So inserting an
+  item at the top of a keyed list handed every later row the *next* row's instance: private fields, an
+  edit buffer, an open/closed toggle, a subscription taken in `OnMount` — all of it moved with the slot
+  rather than with the item. That is exactly the bug `Key` exists to prevent, happening one layer below
+  where `Key` was being consulted. Older than the chain surface; `main` behaved identically.
+
+  A keyed child is now identified by its key. `GetOrCreateChild` stops recycling by ordinal for any type
+  its parent has keyed — it has to, because a key that is new this frame must get a FRESH instance rather
+  than whichever item used to sit at that position — and the `Key` step claims the instance the key owns.
+
+  **`Key` must now open a component's chain**, and that is enforced: **RASK046**. Claiming an instance
+  discards the one the entry built, so a step written before `Key` lands on the discarded one and is
+  silently lost. To make that expressible, `Key` is available before the required steps too — a component
+  with required properties can settle its identity first (`BsToast.Key(id).Id(…).Message(…)`), which the
+  chain previously had no way to say.
+
+  **Elements are exempt**, and not as a carve-out: an element is re-specified in full every render — what
+  its chain does not name, the deferred reset puts back — so its instance carries nothing and is never
+  claimed. `Div.Class("row").Key(i)` is unchanged, which is the spelling used in its hundreds.
+
+  RASK046 found **nine** live instances of the trap while this was being written — in `Rask.Bootstrap`,
+  `Rask.Dashboard`, the samples and the benchmarks. `BsToaster` and the toast demos are the clearest:
+  a toast list that changed shape rendered the *previous* frame's message and title.
+
+  **What it costs, measured** (`LiveRenderRoundTripBenchmarks`, 100 keyed components reshuffled every
+  iteration):
+
+  ```
+  | RenderKeyedList100_ShuffledEachIteration   Mean       Allocated
+  | position identity (and losing state)       85.64 us    92.21 KB
+  | key identity                               83.82 us    96.20 KB
+  |                                            within noise  +4.0 KB (+4.3%)
+  ```
+
+  The allocation is inherent rather than incidental, and worth naming: a type its parent has keyed can no
+  longer be recycled by ordinal, so each keyed row is constructed and then discarded when the key claims
+  an earlier instance — about 40 bytes a row. Wall clock is unchanged within the error bars, so no claim
+  is made about it. The ELEMENT path is untouched and stays at exact allocation parity with the factory
+  (`BuilderSurfaceBenchmarks`: 19.7 KB on both arms).
+
+  The obvious way to reclaim it is to defer construction until the key has been seen, which needs
+  `Build<T>` to carry an unmaterialised child — a wider change to the struct that every generated setter
+  takes. Left for later rather than folded in here.
+
 ### Added
 - **A WebRTC signaling relay — `ISignaling` (client) and the new `Rask.Signaling` package (server).**
   `IWebRtc` deliberately doesn't pick a signaling channel; this is the channel for apps that don't already

--- a/benchmarks/Rask.Benchmarks/Infrastructure/LoadPage.cs
+++ b/benchmarks/Rask.Benchmarks/Infrastructure/LoadPage.cs
@@ -33,7 +33,7 @@ public sealed partial class LoadPage(LoadPageOptions options) : Component
         var rows = new List<Component>(options.RowCount);
         for (var i = 0; i < options.RowCount; i++)
         {
-            rows.Add(FootprintRow.Index(i).Key(i));
+            rows.Add(FootprintRow.Key(i).Index(i));
         }
 
         return Div.Class("container").Id("root")[

--- a/benchmarks/Rask.Benchmarks/LiveRenderRoundTripBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/LiveRenderRoundTripBenchmarks.cs
@@ -71,7 +71,7 @@ public partial class LiveRenderRoundTripBenchmarks : global::Rask.Core.RaskMarku
         var rows = new List<Component>(20);
         for (var i = 0; i < 20; i++)
         {
-            rows.Add(RowItem.Index(i).Key(i));
+            rows.Add(RowItem.Key(i).Index(i));
         }
 
         return [

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -32,6 +32,23 @@ Div.Class("card")[
 > diff codec reports a one-time `data-rask-key="…"` error (via the diagnostics seam) when it detects
 > a duplicate — treat it as a bug to fix, not noise.
 
+> **For a component, `Key` also decides which instance is reused — so name it FIRST.**
+> A keyed component is identified by its key rather than by its position among its siblings, which
+> is what keeps the state it holds *itself* — a private field, an edit buffer, an open/closed
+> toggle, a subscription taken in `OnMount` — with the item rather than with the slot when the list
+> changes shape. Settling that identity hands back the instance the key owns, so a step written
+> before `Key` is applied to one that is about to be discarded. **RASK046** reports it:
+>
+> ```csharp
+> TodoRow.Key(item.Id).Item(item)   // ✓ identity first
+> TodoRow.Item(item).Key(item.Id)   // ✗ RASK046 — Item is written to the discarded instance
+> ```
+>
+> `Key` is available before a component's *required* steps too, so a row with required properties
+> can still settle its identity first. **Elements are exempt** — an element is re-specified in full
+> every render, so its instance carries nothing and `Li.Key(i.Id)[…]` or `Div.Class("row").Key(i)`
+> both read exactly as before.
+
 A `[...]` collection expression renders its items with **no wrapping element** — use it for a list
 of siblings. For the conditional "render nothing" branch, return `null` (a `null` child renders
 nothing):

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -81,6 +81,7 @@ dotnet_analyzer_diagnostic.category-Rask.severity = warning
 | [RASK043](#rask043) | Warning | Component factory is not imported in a type that has no builder entries |
 | [RASK044](#rask044) | Warning | Builder chain sets the same property twice |
 | [RASK045](#rask045) | Warning | Component built by a chain is assigned to afterwards |
+| [RASK046](#rask046) | Warning | Key must open a component's chain |
 
 ---
 
@@ -971,3 +972,34 @@ settable properties, and nothing in the type system is left to forbid the write.
 **Fix:** move the assignment into the chain — every property a chain can reach has a step of the same
 name. Suppress with `#pragma warning disable RASK045` / `.editorconfig`
 (`dotnet_diagnostic.RASK045.severity = none`) where a component genuinely has to be completed later.
+
+---
+
+## RASK046
+**Key must open a component's chain** · Warning
+
+A keyed child is identified by its **key** rather than by its position among its siblings, so that the
+state a row holds itself — a private field, an edit buffer, an `OnMount` subscription — moves with the
+item rather than with the slot when the list changes shape. Settling that identity means handing back
+the instance the key owns and discarding the one the entry just built, so any step written **before**
+`Key` is applied to a component that is about to be thrown away:
+
+```csharp
+TodoRow.Item(item).Key(item.Id)   // ✗ RASK046 — Item is written to the instance Key then discards
+TodoRow.Key(item.Id).Item(item)   // ✓ identity first, then everything else
+```
+
+It compiles and it renders. The value goes missing only once the list changes shape — an insert at the
+top, a reorder — which is the worst possible time to discover it.
+
+**Elements are exempt, and that is not a carve-out.** An element is re-specified in full on every
+render: whatever its chain does not name, the deferred reset puts back. Its instance therefore carries
+nothing, it is never claimed, and its DOM identity comes from `data-rask-key` in the diff codec rather
+than from the parent's child map. So the common spelling stays exactly as it reads:
+
+```csharp
+Div.Class("row").Key(index)[cells]   // ✓ an element is never claimed
+```
+
+**Fix:** move `.Key(…)` to the front of the chain. See [composition → keys](composition.md#children--fragments)
+and the reconciliation note in [the live-rendering codec](architecture/live-rendering-codec.md).

--- a/samples/Rask.Example.Shared/Features/Callback/RatingStars.cs
+++ b/samples/Rask.Example.Shared/Features/Callback/RatingStars.cs
@@ -13,10 +13,10 @@ public sealed partial class RatingStars : Component
     protected override Component? Render() =>
         Div.Class("d-inline-flex gap-1")[
             Enumerable.Range(1, 5).Select(i => (Component)BsButton
+                .Key(i)
                 .Class("btn-link p-0 fs-3 lh-1 text-decoration-none")
                 .Style(i <= Value ? "color:#ffc107" : "color:#ced4da")
-                .OnClick(() => OnRate?.Invoke(i))
-                .Key(i)[
+                .OnClick(() => OnRate?.Invoke(i))[
                 i <= Value ? "★" : "☆"
             ])
         ];

--- a/samples/Rask.Example.Shared/Features/Gantt/GanttDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Gantt/GanttDemo.cs
@@ -38,11 +38,11 @@ public sealed partial class GanttDemo : Component
                 BsButtonGroup.Size(BsSize.Sm)[
                     Enum.GetValues<GanttViewMode>().Select(mode =>
                         BsButton
+                            .Key(mode.ToString())
                             .Color(BsColor.Secondary)
                             .Outline(_viewMode != mode)
                             .Active(_viewMode == mode)
-                            .OnClick(() => _viewMode = mode)
-                            .Key(mode.ToString())[ViewModeLabel(mode)])
+                            .OnClick(() => _viewMode = mode)[ViewModeLabel(mode)])
                 ],
                 // Add/remove push a new task list at the library — the prop-change path.
                 BsButton.Color(BsColor.Primary).Size(BsSize.Sm).Outline(true).OnClick(AddTask)[

--- a/samples/Rask.Example.Shared/Features/Toast/ToastDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Toast/ToastDemo.cs
@@ -114,6 +114,7 @@ public sealed partial class ToastDemo : Component
                     : null,
                 Div.Class($"toast-container position-absolute {_placement} p-3")[
                     toasts.Select(t => (Component)BsToast
+                        .Key(t.Id.ToString())
                         .Id(t.Id)
                         .Message(t.Message)
                         .Title(t.Title)
@@ -121,8 +122,7 @@ public sealed partial class ToastDemo : Component
                         .Icon(t.Icon)
                         .Timestamp("just now")
                         .AutoHideMs(_autoHide ? 5000 : null)
-                        .OnClose(RemoveToast)
-                        .Key(t.Id.ToString()))
+                        .OnClose(RemoveToast))
                 ]
             ]
         ];

--- a/samples/Rask.Example.Shared/Features/Toaster/ToasterDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Toaster/ToasterDemo.cs
@@ -30,11 +30,11 @@ public sealed partial class ToasterDemo(IToaster toast) : Component
                     .Template((messages, dismiss) =>
                     Div[
                         messages.Select(m => (Component)BsAlert
+                            .Key(m.Id.ToString())
                             .Color(ToColor(m.Level))
                             .Dismissible(true)
                             .OnClose(() => dismiss(m.Id))
-                            .Class("d-flex align-items-center")
-                            .Key(m.Id.ToString())[
+                            .Class("d-flex align-items-center")[
                             m.Title is { } title ? Strong.Class("me-1")[$"{title}:"] : null,
                             m.Message])
                     ])

--- a/samples/Rask.Example.Shared/Shared/GuideCards.cs
+++ b/samples/Rask.Example.Shared/Shared/GuideCards.cs
@@ -34,7 +34,7 @@ public sealed partial class GuideCards : Component
     }
 
     private static Component Card(GuideEntry g) =>
-        BsCol.Md(6).Lg(4).Key(g.Slug)[
+        BsCol.Key(g.Slug).Md(6).Lg(4)[
             NavLink.Href(Features.Routes.GuidePage(g.Slug)).ActiveClass("").Class("text-decoration-none")[
                 BsCard.Class(Bs.Join(Sizing.H(100), Border.None, Shadow.Sm, "feature-card"))[
                     BsCardBody.Class("p-4")[

--- a/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
+++ b/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
@@ -244,10 +244,10 @@ public sealed partial class ShowcaseLayout(RouteState route, IEnumerable<Showcas
                         }
 
                         return (Component)BsNavItem
+                            .Key(i.Path)
                             .Href(i.Path)
                             .Match(match)
                             .ActiveMatch(i.MatchPrefix is null ? null : NavLinkMatch.Prefix)
-                            .Key(i.Path)
                             .Class("side-nav-link")[
                             I.Class($"bi {i.Icon} me-2"),
                             Span[i.Label]

--- a/src/Rask.Bootstrap/BsMultiSelect.cs
+++ b/src/Rask.Bootstrap/BsMultiSelect.cs
@@ -159,7 +159,7 @@ public sealed partial class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollec
             foreach (var item in selected!)
             {
                 var captured = item;
-                box.Add(BsBadge.Color(BsColor.Primary).Class("d-inline-flex align-items-center").Key(i)[
+                box.Add(BsBadge.Key(i).Color(BsColor.Primary).Class("d-inline-flex align-items-center")[
                     LabelOf(captured),
                     BsCloseButton
                         .White(true)

--- a/src/Rask.Bootstrap/BsToaster.cs
+++ b/src/Rask.Bootstrap/BsToaster.cs
@@ -28,15 +28,18 @@ public sealed partial class BsToaster : Component
         ToastOutlet
             .Template((messages, dismiss) =>
             Div.Class($"toast-container position-fixed {Placement} p-3")[
+                // Key opens the chain (RASK046): it decides WHICH toast instance is being built, so every
+                // step after it lands on that one. Written last, a toast list that changed shape kept the
+                // instance the key claimed and quietly dropped this frame's message, title and level.
                 messages.Select(m => (Component)BsToast
+                    .Key(m.Id.ToString())
                     .Id(m.Id)
                     .Message(m.Message)
                     .Title(m.Title)
                     .Color(ToColor(m.Level))
                     .Icon(ToIcon(m.Level))
                     .AutoHideMs(AutoHideMs)
-                    .OnClose(id => dismiss(id))
-                    .Key(m.Id.ToString()))
+                    .OnClose(id => dismiss(id)))
             ]);
 
     private static BsColor ToColor(ToastLevel level) => level switch

--- a/src/Rask.Core/Builder/BuilderRuntime.cs
+++ b/src/Rask.Core/Builder/BuilderRuntime.cs
@@ -135,6 +135,73 @@ public static partial class BuilderRuntime
         }
     }
 
+    /// <summary>
+    ///     Settles a keyed child's identity: hands back the instance this key owns, which may not be the
+    ///     one the entry just built.
+    /// </summary>
+    /// <remarks>
+    ///     The <c>Key</c> chain step routes through here so a keyed child is identified by its KEY rather
+    ///     than by its position among its siblings (#685). The parent is found the same way
+    ///     <see cref="Written" /> finds its slot — a backwards scan that matches on the top of the stack in
+    ///     every chain, because the step runs immediately after the entry that pushed it.
+    ///     <para>
+    ///         When the key claims an earlier instance, the slot's target is repointed at it: the deferred
+    ///         reset, the pending-bit bookkeeping and the lifecycle notification all run off that slot when
+    ///         the parent's <c>Render()</c> returns, and every one of them must land on the component that
+    ///         is actually being rendered here rather than on the one position happened to produce.
+    ///     </para>
+    /// </remarks>
+    public static T ClaimKey<T>(T target, object? key) where T : Component
+    {
+        // A null key is the absence of one — Key(null) must not turn a positional child into a keyed one.
+        if (key is null)
+        {
+            return target;
+        }
+
+        // ELEMENTS keep positional identity, deliberately. An element is fully re-specified by its chain
+        // on every render — whatever the chain does not name, the deferred reset puts back — so which
+        // instance it gets carries nothing, and its DOM identity comes from `data-rask-key` in the diff
+        // codec rather than from here. A COMPONENT is the opposite: its private fields, its OnMount
+        // subscription and anything else it holds itself are exactly what position was losing (#685).
+        //
+        // This is also what keeps the ordering rule off the common call site. Claiming an instance
+        // discards the one the entry built, along with any step written before Key — so Key has to open
+        // the chain for it to be sound. Elements are where `Div.Class(…).Key(i)` is written in their
+        // hundreds, and none of them needs claiming.
+        if (target is Element)
+        {
+            return target;
+        }
+
+        var slots = _slots;
+        if (slots is null)
+        {
+            return target;
+        }
+
+        for (var i = slots.Count - 1; i >= 0; i--)
+        {
+            var slot = slots[i];
+            if (!ReferenceEquals(slot.Target, target))
+            {
+                continue;
+            }
+
+            var chosen = slot.Parent.ClaimKeyedChild(target, key);
+            if (!ReferenceEquals(chosen, target))
+            {
+                slots[i] = slot with { Target = chosen };
+            }
+
+            return chosen;
+        }
+
+        // No slot: the receiver came from a FACTORY rather than an entry (both surfaces compile side by
+        // side), and the factory owns that component's identity itself. Leave it alone.
+        return target;
+    }
+
     /// <summary>The prop bits still pending on <paramref name="target" />, for tests and diagnostics.</summary>
     internal static ulong Pending(Component target)
     {

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -905,6 +905,15 @@ public abstract partial class Component : RaskMarkup
             _live.Children.Clear();
         }
 
+        // The keyed map rotates on exactly the same discipline, and only for a parent that keys a child
+        // at all — otherwise both stay null and this is two null checks (#685).
+        if (_live?.KeyedChildren is not null)
+        {
+            _live.PreviousKeyedChildren ??= new Dictionary<(Type, object), Component>();
+            (_live.PreviousKeyedChildren, _live.KeyedChildren) = (_live.KeyedChildren, _live.PreviousKeyedChildren);
+            _live.KeyedChildren.Clear();
+        }
+
         Live.ChildPositions = 0;
 
         // HtmlSerializer wraps every user-component serialization in an EnterParentScope so
@@ -1292,14 +1301,73 @@ public abstract partial class Component : RaskMarkup
             (child.GetType(), AdoptedChildPosition)] = child;
     }
 
+    /// <summary>
+    ///     Settles which instance a keyed child actually is, replacing the one position handed us.
+    /// </summary>
+    /// <remarks>
+    ///     Called by the <c>Key</c> chain step, on the PARENT, immediately after the entry that built
+    ///     <paramref name="provisional" />. `Key` has always been the diff codec's reconciliation identity
+    ///     (<c>data-rask-key</c>); until #685 it was not the parent's, so a keyed row's own state — private
+    ///     fields, an <c>OnMount</c> subscription — followed its POSITION instead of its item.
+    ///     <para>
+    ///         The instance the entry handed over is a fresh one (<see cref="GetOrCreateChild{T}" /> stops
+    ///         recycling by ordinal once a type is keyed), so claiming an earlier instance discards it.
+    ///         That is the cost of correctness here and it is confined to keyed children: an unkeyed tree
+    ///         never reaches this method.
+    ///     </para>
+    /// </remarks>
+    internal T ClaimKeyedChild<T>(T provisional, object key) where T : Component
+    {
+        // From now on this parent identifies T by key rather than by position — see LiveState.KeyedTypes.
+        (Live.KeyedTypes ??= new HashSet<Type>()).Add(typeof(T));
+
+        var mapKey = (typeof(T), key);
+        var chosen = provisional;
+        if (Live.PreviousKeyedChildren is not null
+            && Live.PreviousKeyedChildren.TryGetValue(mapKey, out var prev)
+            && prev is T kept
+            && !ReferenceEquals(kept, provisional))
+        {
+            chosen = kept;
+            // Same reason GetOrCreateChild clears on reuse: children arrive via the `[...]` indexer after
+            // the chain, and a childless render must not inherit the last one's subtree.
+            chosen.Children = null;
+            chosen.RenderHandle ??= provisional.RenderHandle;
+        }
+
+        (Live.KeyedChildren ??= new Dictionary<(Type, object), Component>())[mapKey] = chosen;
+
+        // Re-file this frame's positional slot onto whichever instance the key settled on, so the
+        // alive-set walk sees the child that is actually rendered here.
+        if (Live.Children is not null && Live.LastChildSlot.Type == typeof(T))
+        {
+            Live.Children[Live.LastChildSlot] = chosen;
+        }
+
+        return chosen;
+    }
+
     internal T GetOrCreateChild<T>(
         Func<IServiceProvider, T> factory,
         IServiceProvider? services,
         IRenderHandle? handle) where T : Component
     {
         var key = (typeof(T), Live.ChildPositions++);
+        Live.LastChildSlot = key;
         T instance;
-        if (Live.PreviousChildren is not null && Live.PreviousChildren.TryGetValue(key, out var prev) && prev is T t)
+        // A type this parent identifies by Key is NOT identified by position (#685): recycling the
+        // instance that happens to sit at this ordinal would hand a brand-new key whichever item used
+        // to be here, state and all. Create, and let the Key step that follows claim the right one.
+        if (Live.KeyedTypes is not null && Live.KeyedTypes.Contains(typeof(T)))
+        {
+            instance = factory(services!);
+            if (instance is Forms.IFormControl newControl)
+            {
+                Forms.BindingConsumerRegistry.Record(newControl, this);
+            }
+        }
+        else if (Live.PreviousChildren is not null && Live.PreviousChildren.TryGetValue(key, out var prev) &&
+                 prev is T t)
         {
             instance = t;
             // The factory re-applies every factory-param property each render, but Children is
@@ -2465,6 +2533,24 @@ public abstract partial class Component : RaskMarkup
         public Dictionary<(Type, int), Component>? PreviousChildren;
         public bool PropsDirty;
         public bool StateDirty;
+
+        // Keyed child identity (#685). Three more null references on a parent that never keys a child,
+        // and the maps are allocated only by one that does — a keyed list is a small fraction of the
+        // nodes on a page, so this does not pay the per-node cost the note on Cached describes.
+        //
+        // KeyedTypes is deliberately CUMULATIVE rather than per-frame: once a parent has identified a
+        // child type by key, that type stops being identified by ordinal for the rest of the parent's
+        // life. It has to. A key that is new this frame must get a FRESH instance, and the ordinal path
+        // would hand it a recycled one belonging to whichever item used to sit at that position — which
+        // is the very bug being fixed, moved one step along.
+        public HashSet<Type>? KeyedTypes;
+        public Dictionary<(Type, object), Component>? KeyedChildren;
+        public Dictionary<(Type, object), Component>? PreviousKeyedChildren;
+
+        // The slot the last entry filed a child under, so the Key step that follows it can re-file onto
+        // whichever instance the key actually claims. Safe to keep as one field because Key is required
+        // to be the FIRST step of its chain (RASK046) — nothing can be built in between.
+        public (Type Type, int Ordinal) LastChildSlot;
 
         // Builder surface. Two more bools rather than a wider record: LiveState is allocated per node
         // on a mounted page, and these two land in the padding the six above already leave behind — so

--- a/src/Rask.Dashboard/Pages/LogsPage.cs
+++ b/src/Rask.Dashboard/Pages/LogsPage.cs
@@ -354,7 +354,7 @@ public sealed partial class LogsPage(
             ? null
             : Div.Class("d-flex flex-wrap gap-1 mt-1")[
                 scopes.Select(s =>
-                    BsBadge.Color(BsColor.Secondary).Class("fw-normal font-monospace").Key(s.Key)[
+                    BsBadge.Key(s.Key).Color(BsColor.Secondary).Class("fw-normal font-monospace")[
                         $"{s.Key}={s.Value}"
                     ])
             ];

--- a/src/Rask.Generators/Analyzers/KeyOpensChainAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/KeyOpensChainAnalyzer.cs
@@ -1,0 +1,140 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Rask.Generators.Analyzers;
+
+/// <summary>
+///     RASK046 — <c>Key</c> must be the first step of a COMPONENT's chain.
+///     <para>
+///         Since #685 a keyed child is identified by its key rather than by its position among its
+///         siblings, which is what stops a keyed row's own state — private fields, an <c>OnMount</c>
+///         subscription — following its POSITION when an item is inserted above it. Settling that identity
+///         means handing back the instance the key owns and discarding the one the entry just built, so a
+///         step written BEFORE <c>Key</c> lands on the discarded instance and is silently lost.
+///     </para>
+///     <para>
+///         Elements are exempt and that is not a carve-out: an element is fully re-specified by its chain
+///         every render (whatever the chain does not name, the deferred reset puts back), so it is never
+///         claimed and nothing can be lost. <c>Div.Class("row").Key(i)</c> stays exactly as it reads.
+///     </para>
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class KeyOpensChainAnalyzer : DiagnosticAnalyzer
+{
+    private const string ComponentFullName = "Rask.Core.Component";
+    private const string ElementFullName = "Rask.Core.Element";
+
+    private static readonly DiagnosticDescriptor Rask046 = new(
+        "RASK046",
+        "Key must open a component's chain",
+        "'Key' comes after '{0}' on this chain. Key decides WHICH instance is being built, so '{0}' is written to the "
+        + "instance the key then discards — move '.Key(…)' to the front of the chain.",
+        DiagnosticHelp.Category,
+        DiagnosticSeverity.Warning,
+        true,
+        description: "A keyed child is identified by its key rather than by its position among its siblings, so that "
+                     + "the state a row holds itself moves with the item rather than with the slot. Settling that "
+                     + "identity hands back the instance the key owns and discards the one the entry built — so any "
+                     + "step written before Key is applied to a component that is about to be thrown away. It "
+                     + "compiles and it renders; the value simply goes missing, and only when the list changes shape. "
+                     + "Elements are exempt: they are re-specified in full every render and are never claimed.",
+        helpLinkUri: DiagnosticHelp.Link("RASK046"));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(Rask046);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterCompilationStartAction(static start =>
+        {
+            var component = start.Compilation.GetTypeByMetadataName(ComponentFullName);
+            if (component is null)
+            {
+                return;
+            }
+
+            var element = start.Compilation.GetTypeByMetadataName(ElementFullName);
+            start.RegisterOperationAction(ctx => Analyze(ctx, component, element), OperationKind.Invocation);
+        });
+    }
+
+    private static void Analyze(
+        OperationAnalysisContext context,
+        INamedTypeSymbol component,
+        INamedTypeSymbol? element)
+    {
+        var operation = (IInvocationOperation)context.Operation;
+        if (operation.TargetMethod.Name != "Key")
+        {
+            return;
+        }
+
+        // What is being built. The setter's receiver is Build<T>, so T is the component the chain owns.
+        var built = BuiltType(operation);
+        if (built is null || !DerivesFrom(built, component))
+        {
+            return;
+        }
+
+        // An element is never claimed, so nothing before its Key can be lost — see the type doc.
+        if (element is not null && DerivesFrom(built, element))
+        {
+            return;
+        }
+
+        // The step immediately below this one. An entry is a PROPERTY, not an invocation, so a chain that
+        // opens with Key has no invocation underneath it and is exactly what this wants to see.
+        if (Receiver(operation) is not IInvocationOperation previous)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rask046, operation.Syntax.GetLocation(), previous.TargetMethod.Name));
+    }
+
+    // The T of the Build<T> this call hands back.
+    private static ITypeSymbol? BuiltType(IInvocationOperation operation) =>
+        operation.TargetMethod.ReturnType is INamedTypeSymbol { IsGenericType: true, TypeArguments.Length: 1 } build
+            ? build.TypeArguments[0]
+            : null;
+
+    // The next link DOWN the chain, matching DuplicateChainCallAnalyzer: a setter's receiver is whatever
+    // produced it, written as an extension (argument 0) or as an instance call.
+    private static IOperation? Receiver(IInvocationOperation operation)
+    {
+        var receiver = operation.Instance
+                       ?? (operation.TargetMethod.IsExtensionMethod && operation.Arguments.Length != 0
+                           ? operation.Arguments[0].Value
+                           : null);
+
+        return Unwrap(receiver);
+    }
+
+    private static IOperation? Unwrap(IOperation? operation)
+    {
+        while (operation is IParenthesizedOperation or IConversionOperation { IsImplicit: true })
+        {
+            operation = operation is IParenthesizedOperation p ? p.Operand : ((IConversionOperation)operation).Operand;
+        }
+
+        return operation;
+    }
+
+    private static bool DerivesFrom(ITypeSymbol? type, INamedTypeSymbol target)
+    {
+        for (var t = type; t is not null; t = t.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(t.OriginalDefinition, target))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -920,6 +920,31 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         EmitDocComment(sb, summary, "    ");
         var setterName = name;
 
+        // Key is not an ordinary assignment: it decides WHICH instance the chain is building (#685).
+        // Before this, a child's identity inside its parent was its ordinal among entry-built siblings
+        // and Key took no part, so inserting an item at the top of a keyed list handed every later row
+        // the next row's instance — the state-follows-position bug Key exists to prevent, one layer
+        // below where Key was being consulted. ClaimKey hands back the instance this key owns, which is
+        // why this step returns a NEW chain rather than the one it was given.
+        //
+        // It also makes Key an opening step in practice: any setter written before it would land on the
+        // instance the key is about to discard. RASK046 reports that at the call site.
+        if (generic && string.Equals(name, "Key", StringComparison.Ordinal))
+        {
+            sb.Append("    ").Append(visibility).Append(" static ")
+                .Append(BuildOf("T")).Append(" Key<T>(this ").Append(BuildOf("T")).Append(" __b, ")
+                .Append(typeFqn).Append(" value) where T : ").Append(receiver);
+            sb.Append(" { var __c = global::Rask.Core.BuilderRuntime.ClaimKey(__b.Value, value); ");
+            if (pendingBit >= 0)
+            {
+                sb.Append("global::Rask.Core.BuilderRuntime.Written(__c, ")
+                    .Append(MaskLiteral(new[] { pendingBit })).Append("); ");
+            }
+
+            sb.Append("__c.Key = value; return new ").Append(BuildOf("T")).AppendLine("(__c); }");
+            return;
+        }
+
         // `wrap` is the AutoCallback decision, and it is per property: an Element's
         // handlers go to the DOM unwrapped (owner resolution already re-renders, and wrapping would
         // allocate per render), a non-Element component's event callbacks are wrapped, and a form
@@ -1326,6 +1351,30 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         sb.Append(pad).Append(visibility).Append(" readonly struct ").Append(SeedName(c)).AppendLine();
         sb.Append(pad).AppendLine("{");
 
+        // Key has to be able to come FIRST — before the required steps, not merely before the optional
+        // ones (#685, RASK046). It decides WHICH instance the chain is building, so a required property
+        // written ahead of it lands on the instance the key then discards: `BsToast.Id(…).Message(…)
+        // .Key(…)` was silently rendering the previous frame's message whenever the list changed shape.
+        //
+        // The seed itself holds no component — the first step constructs one — so this step constructs,
+        // claims, and hands back the state that still awaits everything. The required steps then assign
+        // onto the instance the key settled on, which is the whole point.
+        //
+        // Only for a non-generic component: a generic one has type arguments still to be pinned by its
+        // opening, so there is no state type to name here yet. Those keep Key on the finished chain.
+        var seedCarriesKey = required.Count > 0 && c.TypeParameters.Length == 0;
+        if (seedCarriesKey)
+        {
+            sb.Append(pad).AppendLine("    private readonly object? _key;");
+            sb.Append(pad).AppendLine();
+            sb.Append(pad).Append("    internal ").Append(SeedName(c)).AppendLine("(object? key) => _key = key;");
+            sb.Append(pad).AppendLine();
+            sb.Append(pad).AppendLine(
+                "    /// <summary>Sets the reconciliation identity. Name it FIRST — see RASK046.</summary>");
+            sb.Append(pad).Append("    public ").Append(SeedName(c)).AppendLine(" Key(object? key) => new(key);");
+            sb.Append(pad).AppendLine();
+        }
+
         EmitExplicitTypeOpening(sb, c, pad + "    ", assemblyName, runtimePrefix, required);
 
         foreach (var opening in openings)
@@ -1338,7 +1387,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
                 {
                     EmitBuildingStep(
                         sb, c, pad + "    ", assemblyName, runtimePrefix, first, [],
-                        new HashSet<string>(StringComparer.Ordinal) { first.PropertyName });
+                        new HashSet<string>(StringComparer.Ordinal) { first.PropertyName }, seedCarriesKey);
                 }
 
                 continue;
@@ -1358,7 +1407,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
 
             EmitBuildingStep(
                 sb, c, pad + "    ", assemblyName, runtimePrefix, opening[0], [],
-                SatisfiedBy(c, opening));
+                SatisfiedBy(c, opening), seedCarriesKey);
         }
 
         sb.Append(pad).AppendLine("}");
@@ -1405,6 +1454,24 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             sb.Append(pad).AppendLine();
             sb.Append(pad).Append("    private ").Append(c.FullyQualifiedName)
                 .AppendLine(" Component { get; }");
+
+            // Key is offered here, not only on the finished chain, because it has to be able to come
+            // FIRST (#685, RASK046): it decides which instance is being built, so anything written before
+            // it lands on the one the key discards. A component with required steps would otherwise have
+            // no way to satisfy both rules — `BsToast.Id(…).Message(…).Key(…)` is precisely the shape that
+            // was silently losing its props. Returns the same state, so it composes anywhere in the
+            // required sequence and changes nothing about what is still outstanding.
+            sb.Append(pad).AppendLine();
+            sb.Append(pad).AppendLine(
+                "    /// <summary>Sets the reconciliation identity. Name it FIRST — see RASK046.</summary>");
+            sb.Append(pad).Append("    public ").Append(StateName(c, state)).Append(c.TypeParameters)
+                .AppendLine(" Key(object? key)");
+            sb.Append(pad).AppendLine("    {");
+            sb.Append(pad).AppendLine(
+                "        var __c = global::Rask.Core.BuilderRuntime.ClaimKey(Component, key);");
+            sb.Append(pad).AppendLine("        __c.Key = key;");
+            sb.Append(pad).AppendLine("        return new(__c);");
+            sb.Append(pad).AppendLine("    }");
 
             foreach (var step in required.Where(r => !state.Contains(r.PropertyName)))
             {
@@ -1565,7 +1632,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
     private static void EmitBuildingStep(
         StringBuilder sb, Candidate c, string pad, string assemblyName, string runtimePrefix,
         EntryInference step, IReadOnlyList<(EntryInference Pin, string Value)> carried,
-        HashSet<string> satisfied)
+        HashSet<string> satisfied, bool carriesKey = false)
     {
         var required = RequiredSteps(c);
         var done = satisfied.Count == required.Count;
@@ -1590,6 +1657,16 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             .Append(c.FullyQualifiedName).Append(">(");
         EmitResetArguments(sb, c, assemblyName, c.TypeParameters);
         sb.AppendLine(");");
+
+        // The key the seed was carrying, applied BEFORE any property is assigned — which is the whole
+        // reason the seed carries it (#685, RASK046). Claiming settles which instance the chain is
+        // building, so every pin below lands on that one rather than on an instance about to be
+        // discarded. A default seed carries null, and a null key claims nothing.
+        if (carriesKey)
+        {
+            sb.Append(pad).AppendLine("    __c = global::Rask.Core.BuilderRuntime.ClaimKey(__c, _key);");
+            sb.Append(pad).AppendLine("    if (_key is not null) { __c.Key = _key; }");
+        }
 
         foreach (var (pin, value) in carried)
         {

--- a/tests/Rask.Core.Tests/Live/KeyedChildIdentityTests.cs
+++ b/tests/Rask.Core.Tests/Live/KeyedChildIdentityTests.cs
@@ -1,0 +1,100 @@
+#pragma warning disable RASK014 // the test owns the root it re-renders; there is no parent to build it
+
+namespace Rask.Core.Tests.Live;
+
+// #685. A child's identity inside its parent is its ORDINAL among entry-built children, and `Key` does
+// not participate — the parent's child map never reads it. So inserting an item at the top of a keyed
+// list hands every later row the NEXT row's instance: private fields, OnMount subscriptions and any
+// state the row holds itself move with the position rather than with the item. That is precisely the
+// state-follows-position bug `Key` exists to prevent, one layer below where `Key` is consulted.
+//
+// The rows are built through the chain ENTRY, which is the only way to reach GetOrCreateChild at all —
+// constructing one with `new` bypasses the machinery entirely and would prove nothing. The entry is
+// named through its host (`RaskEntriesRask_Core_Tests`) rather than by simple name, because a type in
+// scope beats an injected entry of the same name (the #684 family).
+public class KeyedChildIdentityTests
+{
+    [Fact]
+    public void InsertingAtTheTop_KeepsEachKeyedRowsOwnInstance()
+    {
+        KeyedRow.MountCount = 0;
+        var list = new KeyedList();
+        list.Ids.AddRange([1, 2, 3]);
+
+        // Each row records which instance it is the first time it mounts, so the rendered text is
+        // "<item id>:<instance number>" — a row that got re-created shows a NEW instance number.
+        Assert.Equal(Rows((1, 1), (2, 2), (3, 3)), list.RenderAsLiveRoot());
+
+        list.Ids.Insert(0, 0);
+
+        // Only item 0 is new, so only it may mount (as instance #4). Items 1-3 must still be the very
+        // instances that mounted above — they are the same items, merely one position lower.
+        Assert.Equal(Rows((0, 4), (1, 1), (2, 2), (3, 3)), list.RenderAsLiveRoot());
+    }
+
+    [Fact]
+    public void RemovingFromTheTop_KeepsEachKeyedRowsOwnInstance()
+    {
+        KeyedRow.MountCount = 0;
+        var list = new KeyedList();
+        list.Ids.AddRange([1, 2, 3]);
+
+        Assert.Equal(Rows((1, 1), (2, 2), (3, 3)), list.RenderAsLiveRoot());
+
+        list.Ids.RemoveAt(0);
+
+        // Nothing new mounts: 2 and 3 are the same items and keep the instances they had.
+        Assert.Equal(Rows((2, 2), (3, 3)), list.RenderAsLiveRoot());
+    }
+
+    [Fact]
+    public void ReorderingKeyedRows_MovesTheInstanceWithTheItem()
+    {
+        KeyedRow.MountCount = 0;
+        var list = new KeyedList();
+        list.Ids.AddRange([1, 2, 3]);
+
+        Assert.Equal(Rows((1, 1), (2, 2), (3, 3)), list.RenderAsLiveRoot());
+
+        list.Ids.Reverse();
+
+        // A reorder is the same three items in a different order — no row may re-mount.
+        Assert.Equal(Rows((3, 3), (2, 2), (1, 1)), list.RenderAsLiveRoot());
+    }
+
+    // The Key step also emits data-rask-key, so spell the expected HTML once here and keep the
+    // assertions about which INSTANCE each item is holding.
+    private static string Rows(params (int Id, int Instance)[] rows) =>
+        "<div>"
+        + string.Concat(rows.Select(r => $"<i data-rask-key=\"{r.Id}\">{r.Id}:{r.Instance}</i>"))
+        + "</div>";
+}
+
+/// <summary>Renders one entry-built, keyed row per id.</summary>
+public sealed partial class KeyedList : Component
+{
+    public List<int> Ids { get; } = [];
+
+    protected override Component? Render() =>
+        // Key opens the chain — it decides which instance is being built (RASK046). The pending-required
+        // state carries a Key step of its own for exactly this, so a row with required props can still
+        // settle its identity before anything is written to it.
+        Div[Ids.Select(id => (Component)global::RaskEntriesRask_Core_Tests.KeyedRow.Key(id).Id(id))];
+}
+
+/// <summary>
+///     Holds state of its own — the instance number it was handed when it first mounted. If the parent
+///     re-creates it, that number changes, which is exactly what the assertions read.
+/// </summary>
+public sealed partial class KeyedRow : Component
+{
+    internal static int MountCount;
+
+    private int _instance;
+
+    public required int Id { get; set; }
+
+    protected override void OnMount() => _instance = ++MountCount;
+
+    protected override Component? Render() => I[$"{Id}:{_instance}"];
+}

--- a/tests/Rask.Generators.Tests/KeyOpensChainAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/KeyOpensChainAnalyzerTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Rask.Generators.Analyzers;
+using Xunit;
+
+namespace Rask.Generators.Tests;
+
+/// <summary>
+///     RASK046 — Key has to open a COMPONENT's chain. Since #685 a keyed child is identified by its key
+///     rather than by its position, which means settling that identity hands back the instance the key
+///     owns and discards the one the entry built. A step written before Key is applied to the discarded
+///     one: it compiles, it renders, and the value simply goes missing — and only once the list changes
+///     shape, which is the worst time to find out.
+/// </summary>
+public class KeyOpensChainAnalyzerTests
+{
+    private const string Component = """
+        namespace Demo
+        {
+            public sealed partial class Row : Rask.Core.Component
+            {
+                public string? Title { get; set; }
+            }
+        }
+        """;
+
+    [Fact]
+    public async Task A_component_chain_that_sets_a_property_before_Key_is_reported()
+    {
+        var d = Assert.Single(await AnalyzeAsync("""
+            namespace Demo
+            {
+                public sealed partial class Page : Rask.Core.Component
+                {
+                    protected override Rask.Core.Component? Render() => Row.Title("a").Key(1);
+                }
+            }
+            """));
+
+        Assert.Equal("RASK046", d.Id);
+        // Names the step that would be lost, so the fix needs no re-reading of the chain.
+        Assert.Contains("'Title'", d.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_component_chain_that_opens_with_Key_is_clean()
+    {
+        Assert.Empty(await AnalyzeAsync("""
+            namespace Demo
+            {
+                public sealed partial class Page : Rask.Core.Component
+                {
+                    protected override Rask.Core.Component? Render() => Row.Key(1).Title("a");
+                }
+            }
+            """));
+    }
+
+    // The exemption that keeps this off the common call site. An element is re-specified in full every
+    // render — whatever its chain does not name, the deferred reset puts back — so it is never claimed
+    // and nothing written before its Key can be lost. `Div.Class("row").Key(i)` is written in its
+    // hundreds across the samples and must stay exactly as it reads.
+    [Fact]
+    public async Task An_element_chain_with_Key_last_is_clean()
+    {
+        Assert.Empty(await AnalyzeAsync("""
+            namespace Demo
+            {
+                public sealed partial class Page : Rask.Core.Component
+                {
+                    protected override Rask.Core.Component? Render() => Div.Class("row").Key(1);
+                }
+            }
+            """));
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string page)
+    {
+        var run = BuilderGeneratorHarness.Run(Component + "\n" + page);
+        var trees = run.Sources
+            .Select(s => s.SourceText.ToString())
+            .Prepend(Component + "\n" + page)
+            .Select(s => CSharpSyntaxTree.ParseText(s, new CSharpParseOptions(LanguageVersion.Latest)));
+
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            trees,
+            GeneratorDriverFixture.BuildReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+        var all = await compilation
+            .WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(new KeyOpensChainAnalyzer()))
+            .GetAnalyzerDiagnosticsAsync();
+
+        return [.. all.Where(d => d.Id == "RASK046")];
+    }
+}


### PR DESCRIPTION
Fixes #685.

## What was wrong

A child's identity inside its parent was its **ordinal** among entry-built siblings, and `Key` took no part in it — the parent's child map never read it. `Key` was only ever the diff codec's identity (`data-rask-key`), one layer above.

So inserting an item at the top of a keyed list handed every later row the **next** row's instance. Private fields, an edit buffer, an open/closed toggle, a subscription taken in `OnMount` — all of it moved with the slot rather than with the item. That is exactly the bug `Key` exists to prevent, happening one layer below where `Key` was being consulted. Older than the chain surface; `main` behaved identically.

Reproduced by three tests that build their rows through the chain **entry**, which is the only way to reach `GetOrCreateChild` at all — `new`-ing a row bypasses the machinery and proves nothing. On the previous behaviour every one of them fails, and the shape of the failure is the bug stated plainly:

| Case | Key | Showed instance | Should be |
| --- | --- | --- | --- |
| insert at top | `0` (brand new) | 1 | 4 |
| remove from top | `2` | 1 | 2 |
| reorder | `3` | 1 | 3 |

Every row was holding the instance belonging to whatever sat at its position.

## The fix

`GetOrCreateChild` stops recycling by ordinal for any type its parent has keyed, and the `Key` step claims the instance the key owns. The first half is not optional: a key that is new this frame must get a **fresh** instance, and the ordinal path would hand it whichever item used to sit at that position — the same bug, moved one step along.

## `Key` must now open a component's chain

Claiming an instance discards the one the entry built, along with anything already written to it. That is enforced two ways:

- **RASK046** reports a step written before `Key`, naming the step that would be lost.
- The generator now offers `Key` **before the required steps**, so a component with required properties can settle its identity first — `BsToast.Key(id).Id(…).Message(…)`. The chain previously had no way to say that.

**Elements are exempt, and not as a carve-out.** An element is re-specified in full every render — whatever its chain does not name, the deferred reset puts back — so its instance carries nothing and is never claimed. `Div.Class("row").Key(i)` is unchanged, which is the spelling used in its hundreds.

## RASK046 found nine live instances of the trap

In `Rask.Bootstrap`, `Rask.Dashboard`, the samples and the benchmarks — all fixed here. `BsToaster` and the two toast demos are the clearest: **a toast list that changed shape rendered the previous frame's message and title.** Those were shipping.

## What it costs, measured

`LiveRenderRoundTripBenchmarks`, 100 keyed components reshuffled every iteration:

```
| RenderKeyedList100_ShuffledEachIteration   Mean       Allocated
| position identity (and losing state)       85.64 us    92.21 KB
| key identity                               83.82 us    96.20 KB
|                                            within noise  +4.0 KB (+4.3%)
```

The allocation is inherent rather than incidental: a keyed type can no longer be recycled by ordinal, so each row is constructed and then discarded when the key claims an earlier instance — about 40 bytes a row. Wall clock is unchanged within the error bars, so no claim is made about it.

The **element** path is untouched and stays at exact allocation parity with the factory (`BuilderSurfaceBenchmarks`: 19.7 KB on both arms). Reclaiming the 4 KB needs `Build<T>` to carry an unmaterialised child — a wider change to the struct every generated setter takes — so it is left for later rather than folded in here.

## Testing

- `dotnet format --verify-no-changes` — clean.
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors.
- `scripts/run-unit-local.sh` — green, **6,055** tests.
- `scripts/run-e2e-local.sh` — **64/64**.
- `scripts/run-cli-build-e2e.sh` + the watch gate — green via pre-push.
- Benchmarks as above.