### PR TITLE
perf(core): memoise the route match, and stop two gate tests depending on machine load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -368,6 +368,32 @@ them until tagged releases begin.
   radius — not latency; the outbox can never move, since it commits with the business change by design.
 
 ### Fixed
+- **A routed frame no longer re-matches the route on every render.** `Router.Render()` runs on every
+  frame — it has to, because it publishes `ctx.Route` for the whole subtree and so cannot be
+  render-cached (#682) — and `RouteMatcher.TryMatch` allocates the chain list and the values dictionary
+  each time it is asked. It is a pure function of the flattened leaves and the path, neither of which
+  changes between renders except on navigation or a `Routes` reassignment, so the answer is now kept.
+  Same spirit as the `Routes` setter's existing reference cache, which already refuses to re-flatten the
+  same tree.
+
+  Measured (`RoutedRenderBenchmarks`, a two-level chain, 20 rows, steady-state re-render):
+
+  ```
+  | RoutedFrame                              Allocated
+  | before #682 (positional, but throwing)    3.86 KB
+  | after #682, matching every frame          4.18 KB
+  | with the match memoised                   3.96 KB
+  ```
+
+  So most of what #682 cost is back: **+0.10 KB rather than +0.32 KB** against the original. Wall clock
+  is inconclusive at this size (±0.4 us) so no claim is made about it. The remaining 0.10 KB is the
+  per-frame `RouteRenderState`, which is deliberately still fresh each frame — its `Cursor` is per-frame
+  walk state and its `Query` has to be read now, since `?page=2` moves without the path moving.
+
+  Two tests pin what a cache like this can get wrong: a query change on an unchanged path must still
+  reach the page, and replacing the routes must invalidate. The second one fails if the key is weakened
+  to the path alone. Closes #688.
+
 - **A dependency bump could fail the build of a project that has no scoped assets at all.** The
   scoped-asset bake refuses to write an empty bundle silently (#650) — but the check that decides whether
   "zero files" is a failure asked only whether *some* assembly had been skipped, on the reasoning that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -368,6 +368,26 @@ them until tagged releases begin.
   radius — not latency; the outbox can never move, since it commits with the business change by design.
 
 ### Fixed
+- **Two gate tests no longer depend on how busy the machine is.** The gates are the only place tests run
+  for this repo, so a flake here is a flake in the one thing standing between a change and `main` — and
+  worse, it trains people to re-run rather than read, which is how a real failure gets waved through.
+
+  `AsyncLifecycleRenderingTests` waited a fixed 50 ms for a **fire-and-forget** continuation and then
+  asserted it had happened. The thing being awaited is precisely the one that signals nothing (that is
+  what the test is *about*), so the number was a guess at thread-pool latency — and under a full gate
+  run, with many test projects at once, 50 ms is entirely ordinary. It now polls for the render to land
+  and keeps the sleep only where a test claims "and no more than this", because nothing but elapsed time
+  can evidence a render that did *not* happen. Closes #691.
+
+  `ShopExampleTests.SignInAsync` asserted only that the browser had left `/login`, and that turns out to
+  be too early on the **Server** host. Signing in there cannot set a cookie on a response that has
+  already been sent — the live session issues an `AuthInstruction` and the *client* performs the
+  navigation that commits it — so the URL moves off `/login` before the cookie exists, and the caller's
+  next navigation races that commit: it lands on an authorized page and is bounced straight back to
+  `/login` with sign-in apparently complete. Reproduced 2 runs in 3 once the mechanism was known. It now
+  waits for content that only an authorized principal renders, which is what every caller actually
+  depends on: 5 of 5 runs green after, and the whole Shop suite 11/11. Closes #692.
+
 - **A routed frame no longer re-matches the route on every render.** `Router.Render()` runs on every
   frame — it has to, because it publishes `ctx.Route` for the whole subtree and so cannot be
   render-cached (#682) — and `RouteMatcher.TryMatch` allocates the chain list and the values dictionary

--- a/src/Rask.Core/Routing/Router.cs
+++ b/src/Rask.Core/Routing/Router.cs
@@ -9,6 +9,22 @@ public sealed class Router : Component
     private IReadOnlyList<RouteLeaf> _leaves = Array.Empty<RouteLeaf>();
     private IReadOnlyList<Route>? _routes;
 
+    // The memoised match (#688). Render() runs on EVERY frame now — it has to, because it publishes
+    // ctx.Route for the whole subtree (see BypassRenderCache below) — and RouteMatcher.TryMatch allocates
+    // the chain list and the values dictionary each time it is asked. It is a pure function of the
+    // flattened leaves and the path, and neither changes between renders except on navigation or a
+    // `Routes` reassignment, so the answer is worth keeping. Same spirit as the `Routes` setter's
+    // reference cache just below, which already refuses to re-flatten the same tree.
+    //
+    // The results are safe to share across frames because nothing mutates them: RouteChainRenderer reads
+    // Chain by index and hands Values to PageBinder, which also only reads. The per-frame part of the
+    // state is RouteRenderState — its Cursor, and the Query, both of which are still taken fresh below.
+    private IReadOnlyList<RouteLeaf>? _matchedLeaves;
+    private string? _matchedPath;
+    private IReadOnlyList<Type>? _matchedChain;
+    private IReadOnlyDictionary<string, string?>? _matchedValues;
+    private bool _matched;
+
     public Router(RouteState state) => _state = state;
 
     // Settable from the auto-generated factory. A null assignment resolves to the
@@ -58,7 +74,18 @@ public sealed class Router : Component
 
     protected override Component? Render()
     {
-        if (!RouteMatcher.TryMatch(_leaves, _state.Path, out var chain, out var values))
+        var path = _state.Path;
+        if (!ReferenceEquals(_matchedLeaves, _leaves)
+            || !string.Equals(_matchedPath, path, StringComparison.Ordinal))
+        {
+            _matched = RouteMatcher.TryMatch(_leaves, path, out var chain, out var values);
+            _matchedLeaves = _leaves;
+            _matchedPath = path;
+            _matchedChain = chain;
+            _matchedValues = values;
+        }
+
+        if (!_matched)
         {
             return new Fragment();
         }
@@ -67,7 +94,10 @@ public sealed class Router : Component
                   ?? throw new InvalidOperationException(
                       "Router() must render under a Rask live root. Call this through MapRask<TApp>.");
 
-        ctx.Route = new RouteRenderState(_state.Path, chain, values, _state.Query);
+        // A fresh RouteRenderState per frame even on a memoised match: its Cursor is per-frame walk
+        // state, and the Query is read now rather than when the path last changed — `?page=2` moves
+        // without the path moving.
+        ctx.Route = new RouteRenderState(path, _matchedChain!, _matchedValues!, _state.Query);
         return RouteChainRenderer.RenderChainEntry(ctx);
     }
 }

--- a/tests/Rask.Core.Tests/Lifecycle/AsyncLifecycleRenderingTests.cs
+++ b/tests/Rask.Core.Tests/Lifecycle/AsyncLifecycleRenderingTests.cs
@@ -23,8 +23,8 @@ public class AsyncLifecycleRenderingTests
         await c.Step1.Task;
         await c.Step2.Task;
         await c.Done.Task;
-        // Drain pending continuations to allow Post→StateHasChanged dispatches to complete.
-        await Task.Delay(50);
+        // Wait for the Post→StateHasChanged dispatches to land, rather than guessing how long they take.
+        await WaitUntilAsync(() => handle.RequestRenderCount >= 2);
 
         Assert.True(handle.RequestRenderCount >= 2,
             $"expected progressive renders after awaits, got {handle.RequestRenderCount}");
@@ -52,6 +52,8 @@ public class AsyncLifecycleRenderingTests
         }
 
         await c.Done.Task;
+        await WaitUntilAsync(() => handle.RequestRenderCount >= 1);
+        // Settle: the claim is exactly one, and only elapsed time evidences the absence of a second.
         await Task.Delay(50);
 
         Assert.Equal(1, handle.RequestRenderCount);
@@ -75,6 +77,8 @@ public class AsyncLifecycleRenderingTests
         }
 
         await c.Done.Task;
+        await WaitUntilAsync(() => handle.RequestRenderCount >= 1);
+        // Settle: the claim is exactly one, and only elapsed time evidences the absence of a second.
         await Task.Delay(50);
 
         Assert.Equal(1, handle.RequestRenderCount);
@@ -115,7 +119,7 @@ public class AsyncLifecycleRenderingTests
         var beforeGate = handle.RequestPublishRenderCount;
 
         c.Gate.SetResult();
-        await Task.Delay(50);
+        await WaitUntilAsync(() => handle.RequestPublishRenderCount > beforeGate);
 
         Assert.True(handle.RequestPublishRenderCount > beforeGate,
             $"expected auto-rerender after OnRenderedAsync continuation; " +
@@ -290,6 +294,24 @@ public class AsyncLifecycleRenderingTests
         }
 
         protected override Component? Render() => this;
+    }
+
+    // Waits for a fire-and-forget continuation to land instead of guessing how long it takes. Fast on an
+    // idle machine and correct on a loaded one, which is where a fixed delay loses: the gate runs many
+    // test projects at once, and 50 ms of thread-pool latency is entirely ordinary. That is what made
+    // OnMountAsync_ConfigureAwaitFalse_StillFiresTerminalRender fail in a full gate run and pass in
+    // isolation (#691).
+    //
+    // Only ever for the POSITIVE half of an assertion. Where a test also claims "and no more than this",
+    // it keeps a short settle afterwards — nothing but elapsed time can evidence a render that did NOT
+    // happen, so the upper-bound tests below still sleep on purpose.
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (!condition() && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(5);
+        }
     }
 
     private sealed class RecordingHandle : IRenderHandle

--- a/tests/Rask.Core.Tests/Routing/RouterMatchMemoTests.cs
+++ b/tests/Rask.Core.Tests/Routing/RouterMatchMemoTests.cs
@@ -1,0 +1,88 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+using Rask.Core.Routing;
+
+#pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
+
+namespace Rask.Core.Tests.Routing;
+
+// #688. Router.Render() runs on EVERY frame — it has to, because it publishes ctx.Route for the whole
+// subtree — and RouteMatcher.TryMatch allocates the chain list and the values dictionary each time. The
+// match is a pure function of the flattened leaves and the path, so the answer is memoised.
+//
+// These pin the two things a cache like that can get wrong: the parts of the render that are NOT part of
+// the cache key have to stay live (the query moves without the path moving), and the key has to notice
+// when the routes themselves are replaced. Both were checked by construction and are now checked by a
+// test, because "it is a pure function" is a claim about code that can be edited later.
+public partial class RouterMatchMemoTests : global::Rask.Core.RaskMarkup
+{
+    [Fact]
+    public void A_query_change_on_the_same_path_still_reaches_the_page()
+    {
+        var (view, state, sp) = BuildView([Route<QueryPage>("/search")]);
+        state.Path = "/search";
+        state.Query = new QueryCollection(new Dictionary<string, StringValues> { ["term"] = "first" });
+
+        Assert.Equal("<span>first</span>", view.RenderAsLiveRoot(sp));
+
+        // Same path, different query — the memoised match must be reused AND the query must not be.
+        state.Query = new QueryCollection(new Dictionary<string, StringValues> { ["term"] = "second" });
+
+        Assert.Equal("<span>second</span>", view.RenderAsLiveRoot(sp));
+    }
+
+    [Fact]
+    public void Replacing_the_routes_invalidates_the_memoised_match()
+    {
+        // The Router is built by the chain, so the second render hands it a different Routes list. The
+        // path never changes, so only the leaves-reference half of the key can catch this.
+        var routes = new[] { Route<FirstPage>("/x") };
+        var state = new RouteState();
+        var services = new ServiceCollection();
+        services.AddSingleton(state);
+        var sp = services.BuildServiceProvider();
+        state.Path = "/x";
+
+        var current = routes;
+        // ReSharper disable once AccessToModifiedClosure — deliberately re-read on every render.
+        var view = new StubComponent(() => Router.Routes(current));
+
+        Assert.Equal("<i>first</i>", view.RenderAsLiveRoot(sp));
+
+        current = [Route<SecondPage>("/x")];
+
+        Assert.Equal("<b>second</b>", view.RenderAsLiveRoot(sp));
+    }
+
+    private static (StubComponent view, RouteState state, IServiceProvider sp) BuildView(
+        IReadOnlyList<Route> routes)
+    {
+        var state = new RouteState();
+        var services = new ServiceCollection();
+        services.AddSingleton(state);
+        var sp = services.BuildServiceProvider();
+        var view = new StubComponent(() => Router.Routes(routes));
+        return (view, state, sp);
+    }
+
+    [SkipFactory]
+    public sealed class QueryPage : Component
+    {
+        // Not named `Q`: that collides with the inherited <q> tag entry (CS0108).
+        [QueryParam] public string? Term { get; set; }
+
+        protected override Component? Render() => Span[Term ?? string.Empty];
+    }
+
+    [SkipFactory]
+    public sealed class FirstPage : Component
+    {
+        protected override Component? Render() => I["first"];
+    }
+
+    [SkipFactory]
+    public sealed class SecondPage : Component
+    {
+        protected override Component? Render() => B["second"];
+    }
+}

--- a/tests/Rask.Examples.E2E.Tests/ShopExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/ShopExampleTests.cs
@@ -252,6 +252,18 @@ public sealed class ShopExampleTests(ShopExampleAppFixture app, PlaywrightFixtur
         await _page.FillAsync("#password", "password");
         await _page.ClickAsync("button[type=submit]");
         await Assertions.Expect(_page).Not.ToHaveURLAsync(new Regex("/login"));
+
+        // …and then wait for the AUTHORIZED CONTENT, not just for the URL to change (#692). On the Server
+        // host, signing in cannot set a cookie on a response that has already been sent — the live session
+        // issues an AuthInstruction and the CLIENT performs the navigation that commits it. So the URL
+        // moves off /login before the cookie exists, and the next `GotoAsync` races that commit: the
+        // caller lands on an authorized page and is bounced straight back to /login, with sign-in
+        // apparently complete. Reproduced 2 runs in 3 in isolation.
+        //
+        // MemberContent renders only for an authorized principal, so its Sign-out button appearing is
+        // evidence the cookie round-trip finished — which is what every caller of this actually needs.
+        await Assertions.Expect(_page.Locator("button:has-text('Sign out')"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 15_000 });
     }
 
     private static async Task<string?> WaitForFileAsync(string directory, string pattern, TimeSpan timeout)


### PR DESCRIPTION
Closes #688, #691, #692. Two commits, kept separate because one touches Core and one touches only tests.

## `perf(core)`: memoise the route match — #688

`Router.Render()` runs on **every** frame — it has to, because it publishes `ctx.Route` for the whole subtree and so cannot be render-cached (#682) — and `RouteMatcher.TryMatch` allocates the chain list and the values dictionary each time. It is a pure function of the flattened leaves and the path, neither of which moves between renders except on navigation or a `Routes` reassignment.

```
| RoutedFrame                              Allocated
| before #682 (positional, but throwing)    3.86 KB
| after #682, matching every frame          4.18 KB
| with the match memoised                   3.96 KB
```

So most of what #682 cost is back: **+0.10 KB rather than +0.32 KB** against the original. Wall clock is inconclusive at this size (±0.4 µs) so no claim is made about it. The remaining 0.10 KB is the per-frame `RouteRenderState`, deliberately still fresh: its `Cursor` is per-frame walk state and its `Query` has to be read now, since `?page=2` moves without the path moving.

Two tests pin what a cache like this gets wrong — a query change on an unchanged path must still reach the page, and replacing the routes must invalidate. **Weaken the key to the path alone and the second one fails**, which is how it was checked.

## `test`: wait for the thing, not for 50 ms — #691, #692

The gates are the only place tests run for this repo, so a flake here is a flake in the one thing standing between a change and `main` — and worse, it trains people to re-run rather than read.

**#691.** `AsyncLifecycleRenderingTests` waited a fixed 50 ms for a **fire-and-forget** continuation and then asserted it had happened. The thing being awaited is precisely the one that signals nothing — that is what the test is *about* — so the number was a guess at thread-pool latency, and under a full gate run 50 ms is ordinary. It now polls. The sleep stays only where a test claims "and no more than this", because nothing but elapsed time can evidence a render that did *not* happen.

**#692 — diagnosed, not papered over.** `SignInAsync` asserted only that the browser had left `/login`, and on the **Server** host that is too early. Signing in there cannot set a cookie on a response that has already been sent: the live session issues an `AuthInstruction` and the **client** performs the navigation that commits it. So the URL moves off `/login` before the cookie exists, and the callers next navigation races that commit — it lands on an authorized page and is bounced back to `/login` with sign-in apparently complete.

Once the mechanism was known it reproduced **2 runs in 3** in isolation, which is what made it fixable. It now waits for content only an authorized principal renders: **5 of 5** green after, and the Shop suite 11/11.

An `APIRequest` probe was tried first and is **not** the fix — that request does not carry the sign-in cookie in this fixture, so it fails deterministically and cannot be evidence about what a page navigation will do. Recorded on #692 so nobody retries it.

## Testing

- `dotnet format --verify-no-changes` — clean.
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors.
- `scripts/run-unit-local.sh` — green.
- Full browser E2E — **64/64**.
- The flaky dashboard test specifically: 5/5, from 2-in-3 failing.
- CLI build gate + watch gate — green via pre-push.
- `RoutedRenderBenchmarks` as above.