### PR TITLE
fix(generators): three more analyzers were blind to the chain, found by auditing the rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -519,7 +519,12 @@ them until tagged releases begin.
   - **RASK027 (both the sync and async handler set) never fired on a chain.**
     `Button.OnClick(…).OnClickAsync(…)` silently dropped the async handler, which is the whole reason the
     diagnostic is an **Error** on a factory call.
-  - RASK034 has the same defect and is **not** fixed here; it is tracked separately.
+  - **RASK034 (a `BsDataGrid` column with no `Field`) never fired on a chain either.** The column
+    chooser addresses a column by the token read off `Field`, so a column without one can never be
+    shown, hidden or reordered — it sits pinned with no menu row, silently, which is exactly the
+    failure this diagnostic exists to catch. Verified against the real `Rask.Bootstrap` types rather
+    than the test's stand-ins: removing a `Field` from a sample's grid makes it fire on the offending
+    column and nothing else.
   - The chain branch is deliberately additive: the factory branch still owns `Generated.X(…)`, so nothing
     reports twice. Each new branch requires the operation's type to genuinely be `Build<T>` — without that
     the children indexer qualifies too (it is also a property reference) and every keyless row reported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -506,6 +506,30 @@ them until tagged releases begin.
   the harness can show. The remaining arguments for splitting are size, per-file pragmas and blast
   radius — not latency; the outbox can never move, since it commits with the business change by design.
 
+### Fixed
+- **Three analyzers were silently dead on the chain — the syntax the framework teaches.** Each identified
+  its subject as "a static method on a class named `Generated`", which a chain never is: a chain's steps are
+  extension methods on `Build<T>`, and its shortest spelling is a bare entry that is not an invocation at
+  all. The build stayed green throughout, because a diagnostic that never fires breaks nothing.
+  - **RASK023 (`Img` without `Alt`) never fired on `Img.Src("/logo.png")`.** An accessibility guard
+    (WCAG 1.1.1) that was absent from every chain ever written.
+  - **RASK022 (list item missing a `Key`) never fired on a keyless chain row.** `_items.Select(i => Li[…])`
+    — the exact shape the guides teach — went unreported, so those lists reconcile by position and lose
+    focus and input state on insert/remove/reorder.
+  - **RASK027 (both the sync and async handler set) never fired on a chain.**
+    `Button.OnClick(…).OnClickAsync(…)` silently dropped the async handler, which is the whole reason the
+    diagnostic is an **Error** on a factory call.
+  - RASK034 has the same defect and is **not** fixed here; it is tracked separately.
+  - The chain branch is deliberately additive: the factory branch still owns `Generated.X(…)`, so nothing
+    reports twice. Each new branch requires the operation's type to genuinely be `Build<T>` — without that
+    the children indexer qualifies too (it is also a property reference) and every keyless row reported
+    twice.
+- **Both shipped quick-fixes wrote factory syntax.** RASK014's lightbulb was titled "Use the generated
+  factory" and rewrote `new Widget()` into `Widget()`; it now produces the bare entry `Widget`, which is
+  what RASK014's own message has been telling the reader to write. RASK023's inserted `Alt: ""`, a named
+  argument — on a chain that is not merely stale but broken, so it now appends a `.Alt("")` step (and still
+  inserts the named argument on a factory call).
+
 ### Changed
 - **The chain is now what the docs, the README, the site and the playground actually teach.** #681 made
   markup a chain but left the teaching surfaces describing the generated factory, so a newcomer's first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -507,6 +507,18 @@ them until tagged releases begin.
   radius — not latency; the outbox can never move, since it commits with the business change by design.
 
 ### Fixed
+- **Three more analyzers were blind to the chain, found by auditing the rest rather than stopping at the
+  ones that announced themselves.** These do not key on `Generated` at all — they test a TYPE, and a chain
+  hands back `Build<T>` rather than `T`.
+  - **RASK032 (native chrome nested in the HTML tree) never fired on a chain.** `Div[NativeHeaderBar…]`
+    serializes to nothing on a device; the diagnostic is an **Error** precisely so that never ships, and
+    it was reporting on none of the syntax the framework teaches.
+  - **RASK019 (`<head>` is a framework-managed slot) never fired on `Head[…]`.** Children passed there are
+    dropped, silently. The analyzer also had **no tests at all**; it has them now, for both spellings.
+  - **RASK021 (a root that renders the page shell) never fired on a chain.** It scans the root's `Render()`
+    for *invocations* named `Doctype`/`Html`/`Head`/`Body`, and a chain invokes nothing — `Html[…]` is an
+    element access and `Doctype` a bare identifier. It now recognises all three spellings, and the
+    standalone-identifier arm is deliberately narrow so a local called `Body` cannot trip it.
 - **Three analyzers were silently dead on the chain — the syntax the framework teaches.** Each identified
   its subject as "a static method on a class named `Generated`", which a chain never is: a chain's steps are
   extension methods on `Build<T>`, and its shortest spelling is a bare entry that is not an invocation at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -507,6 +507,29 @@ them until tagged releases begin.
   radius — not latency; the outbox can never move, since it commits with the business change by design.
 
 ### Fixed
+- **The quick-fixes for the newly chain-aware analyzers could damage code, found by reviewing the diff
+  rather than trusting that green tests meant done.**
+  - **RASK027's lightbulb deleted whatever enclosed the chain.** Making the analyzer fire on chains
+    without touching its fix left the provider looking *upward* for an argument to remove, so
+    `Wrap(Content: Button.OnClick(…).OnClickAsync(…)["x"], Label: "hi")` became `Wrap(Label: "hi")` —
+    the component silently gone, and the result still compiling. The diagnostic is now anchored on the
+    step's name rather than the whole chain, and the fix splices that one step out and never walks past
+    the node it was given.
+  - **RASK023's lightbulb could land the `Alt` on the wrong call.** `Wrap(Img)` became
+    `Wrap(Img).Alt("")` — uncompilable, and the image still had no text alternative. It now acts only on
+    the call the flagged node is the *callee* of.
+  - **RASK014's lightbulb could trade its error for a worse one.** The bare entry it now writes only
+    binds inside a markup host; in a service or a plain class `Widget` names the type and the rewrite is
+    `CS0119`. The fix is withheld there — the error stands with its message instead. The old test proved
+    nothing on this point: it asserted on text alone, inside a plain class.
+  - A false positive of my own making in RASK021: the bare-identifier arm matched shell names on the
+    identifier alone, so a local called `Body` in a root's `Render()` raised RASK021 on ordinary code —
+    build-breaking under `-warnaserror`. It is now restricted to `Doctype`, the one part of the shell a
+    chain writes bare; the rest are caught as element accesses.
+  - The four analyzers' copies of a `Build<T>` unwrapper collapse into one `BuilderEntry.BuildOf`, which
+    compares the resolved symbol instead of calling `ToDisplayString()` on every arity-1 generic. These
+    run on `OperationKind.PropertyReference` — every property read in the compilation — so the old
+    version allocated a string per `List<T>`/`Task<T>` read, per keystroke, in the IDE.
 - **Three more analyzers were blind to the chain, found by auditing the rest rather than stopping at the
   ones that announced themselves.** These do not key on `Generated` at all — they test a TYPE, and a chain
   hands back `Build<T>` rather than `T`.

--- a/benchmarks/Rask.Benchmarks/AttrBagBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/AttrBagBenchmarks.cs
@@ -22,6 +22,10 @@ namespace Rask.Benchmarks;
 // The tree is built inside the benchmark rather than in [GlobalSetup] on purpose. Setting up once and
 // re-rendering would measure only the serializer, which is the same for both arms — the difference
 // lives in constructing the bag, so constructing it is the thing to time.
+// RASK022 is suppressed on purpose: these rows are deliberately keyless. A .Key(…) per row is itself
+// an allocation, and the whole point here is to isolate the cost of the attribute bag — keying the
+// rows would fold an unrelated cost into both arms and blunt the very difference being measured.
+#pragma warning disable RASK022
 [MemoryDiagnoser]
 public partial class AttrBagBenchmarks : global::Rask.Core.RaskMarkup
 {
@@ -82,3 +86,4 @@ public partial class AttrBagBenchmarks : global::Rask.Core.RaskMarkup
         return Div[rows].ToHtml();
     }
 }
+#pragma warning restore RASK022

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -12,8 +12,8 @@ Some diagnostics ship an **IDE quick-fix** (the lightbulb / `Ctrl`+`.`):
 | ID | What the lightbulb does |
 |----|-------------------------|
 | **RASK001** | adds the `required` modifier |
-| **RASK014** | rewrites `new Widget()` into the generated `Widget()` factory call |
-| **RASK023** | inserts `Alt: ""` |
+| **RASK014** | rewrites `new Widget()` into the bare entry `Widget` |
+| **RASK023** | appends `.Alt("")` to the chain (or `Alt: ""` on a factory call) |
 | **RASK026** | deletes the redundant `StateHasChanged()` statement |
 | **RASK027** | removes the `OnXAsync` argument, keeping the sync one |
 | **CS0108** | adds `new` to a member that [hides a builder entry](#cs0108-a-member-hides-a-builder-entry) |
@@ -22,10 +22,10 @@ These are delivered by `Rask.Generators.CodeFixes`, packed alongside the analyze
 `Rask.Server` / `Rask.Wasm` packages — no extra reference needed.
 
 A fix is offered only when the rewrite means exactly what you wrote. **RASK014's is withheld when the
-construction has arguments or an object initializer**: the factory's parameters are generated from the
-component's public properties in an order that is not the constructor's, so moving positional arguments
-across would compile and mean something else — and an object initializer is only legal after `new`. In
-those cases the error stands with its message, which already spells out the chain to write.
+construction has arguments or an object initializer**: a chain sets each property by name in its own
+step, so moving positional constructor arguments across would compile and mean something else — and an
+object initializer is only legal after `new`. In those cases the error stands with its message, which
+already spells out the chain to write.
 
 Every RASK diagnostic reports under the single category **`Rask`**, so one `.editorconfig` line covers
 the family:

--- a/src/Rask.Generators.CodeFixes/ComponentConstructionCodeFixProvider.cs
+++ b/src/Rask.Generators.CodeFixes/ComponentConstructionCodeFixProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
@@ -19,13 +20,14 @@ namespace Rask.Generators.CodeFixes;
 ///         for. The diagnostic message already computes the exact replacement, so nothing is inferred here.
 ///     </para>
 ///     <para>
-///         <b>Deliberately withheld for anything but an argument-free, initializer-free construction.</b>
-///         A constructor call and a factory call are not the same shape: the factory's parameters are
-///         generated from the component's public properties in a defined order, which is not the
-///         constructor's, so carrying positional arguments across would compile and mean something else.
-///         And an object initializer is only legal after <c>new</c>, so it cannot ride along either. In
-///         both cases the error stands with its message, which names the factory to call — a quick fix
-///         that silently changes meaning is worse than none.
+///         <b>Deliberately withheld for anything but an argument-free, initializer-free construction
+///         inside a markup host.</b> A constructor call and a chain are not the same shape: a chain sets
+///         each property by name in its own step, so carrying positional constructor arguments across
+///         would compile and mean something else. An object initializer is only legal after <c>new</c>,
+///         so it cannot ride along either. And the bare entry only binds where entries live — outside a
+///         markup host the rewrite is <c>CS0119</c>, a worse error than the one it replaces. In every
+///         such case the error stands with its message, which spells out the chain to write; a quick fix
+///         that silently changes meaning, or trades one error for a worse one, is worse than none.
 ///     </para>
 /// </remarks>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ComponentConstructionCodeFixProvider))]
@@ -38,11 +40,56 @@ public sealed class ComponentConstructionCodeFixProvider : RaskCodeFixProvider<O
 
     protected override string EquivalenceKey => "RASK014_UseChain";
 
-    protected override Task<bool> CanFixAsync(CodeFixContext context, ObjectCreationExpressionSyntax node) =>
-        Task.FromResult(
-            node.Initializer is null
-            && (node.ArgumentList is null || node.ArgumentList.Arguments.Count == 0)
-            && FactoryName(node) is not null);
+    protected override async Task<bool> CanFixAsync(CodeFixContext context, ObjectCreationExpressionSyntax node)
+    {
+        if (node.Initializer is not null
+            || (node.ArgumentList is not null && node.ArgumentList.Arguments.Count != 0)
+            || FactoryName(node) is null)
+        {
+            return false;
+        }
+
+        // The bare entry only binds inside a MARKUP HOST: entries are protected static members on
+        // RaskMarkup, or injected into a host's own partial. In a service, a Program.cs, a DI factory or
+        // any plain class, `Widget` names the TYPE and the rewrite is CS0119 — worse than the error it
+        // replaces, since RASK014 fires there too. The old factory call had no such limit (it rode a
+        // project-wide `global using static`), which is why this gate arrived with the bare entry.
+        if (node.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } declaration)
+        {
+            return false;
+        }
+
+        var model = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        return model?.GetDeclaredSymbol(declaration, context.CancellationToken) is INamedTypeSymbol type
+               && IsMarkupHost(type);
+    }
+
+    // Mirrors BuilderEntry.IsEntryHost, which lives in the analyzer assembly and is not visible here:
+    // a type deriving from RaskMarkup (every Component does), or one carrying [RaskMarkup] because it
+    // could not spend its base slot.
+    private static bool IsMarkupHost(INamedTypeSymbol type)
+    {
+        foreach (var attribute in type.GetAttributes())
+        {
+            if (string.Equals(
+                    attribute.AttributeClass?.ToDisplayString(),
+                    "Rask.Core.RaskMarkupAttribute",
+                    StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        for (INamedTypeSymbol? current = type; current is not null; current = current.BaseType)
+        {
+            if (string.Equals(current.ToDisplayString(), "Rask.Core.RaskMarkup", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     protected override async Task<Document> FixAsync(
         Document document,

--- a/src/Rask.Generators.CodeFixes/ComponentConstructionCodeFixProvider.cs
+++ b/src/Rask.Generators.CodeFixes/ComponentConstructionCodeFixProvider.cs
@@ -10,7 +10,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 namespace Rask.Generators.CodeFixes;
 
 /// <summary>
-///     RASK014 — rewrite <c>new Widget()</c> into the generated <c>Widget()</c> factory call.
+///     RASK014 — rewrite <c>new Widget()</c> into the chain that builds it: the bare entry <c>Widget</c>.
 /// </summary>
 /// <remarks>
 ///     <para>
@@ -34,9 +34,9 @@ public sealed class ComponentConstructionCodeFixProvider : RaskCodeFixProvider<O
 {
     public override ImmutableArray<string> FixableDiagnosticIds { get; } = ["RASK014"];
 
-    protected override string Title => "Use the generated factory";
+    protected override string Title => "Build it with the chain";
 
-    protected override string EquivalenceKey => "RASK014_UseFactory";
+    protected override string EquivalenceKey => "RASK014_UseChain";
 
     protected override Task<bool> CanFixAsync(CodeFixContext context, ObjectCreationExpressionSyntax node) =>
         Task.FromResult(
@@ -57,13 +57,13 @@ public sealed class ComponentConstructionCodeFixProvider : RaskCodeFixProvider<O
         return await ReplaceNodeAsync(
             document,
             node,
-            InvocationExpression(IdentifierName(name)).WithTriviaFrom(node),
+            IdentifierName(name).WithTriviaFrom(node),
             cancellationToken).ConfigureAwait(false);
     }
 
-    // The factory is a static method named after the type, in scope project-wide through the generator's
-    // `global using static …Generated`. So the bare type name IS the call: carrying a qualified name over
-    // would name a type where a method has to go.
+    // The entry is a property named after the type, injected into every markup host by the generator. So
+    // the bare simple name IS the chain: carrying a qualified name over would name the TYPE, which is
+    // exactly what RASK014 is complaining about.
     private static string? FactoryName(ObjectCreationExpressionSyntax node) => node.Type switch
     {
         QualifiedNameSyntax qualified => qualified.Right.Identifier.Text,

--- a/src/Rask.Generators.CodeFixes/ImgMissingAltCodeFixProvider.cs
+++ b/src/Rask.Generators.CodeFixes/ImgMissingAltCodeFixProvider.cs
@@ -33,7 +33,11 @@ public sealed class ImgMissingAltCodeFixProvider : RaskCodeFixProvider<Expressio
     protected override async Task<Document> FixAsync(
         Document document, ExpressionSyntax node, CancellationToken cancellationToken)
     {
-        var enclosing = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+        // Only the call this node is the CALLEE of — never merely an enclosing one. Walking up to the
+        // nearest ancestor invocation reached straight out of the Img being fixed: `Wrap(Img)` became
+        // `Wrap(Img).Alt("")`, which neither compiles nor gives the image a text alternative, and
+        // `Generated.Div(Children: [Img])` had `Alt: ""` appended to the *Div*.
+        var enclosing = CalleeOf(node);
 
         if (enclosing is not null && await IsFactoryCallAsync(document, enclosing, cancellationToken)
                 .ConfigureAwait(false))
@@ -68,11 +72,25 @@ public sealed class ImgMissingAltCodeFixProvider : RaskCodeFixProvider<Expressio
         SyntaxFactory.LiteralExpression(
             SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(string.Empty));
 
-    // The end of the chain, so the new step lands after every existing one.
+    // The invocation this node is the callee of — `Img(…)`, or the `Img` in `Generated.Img(…)`. Null when
+    // the node merely sits inside some other call, which is the case that used to be mishandled.
+    private static InvocationExpressionSyntax? CalleeOf(ExpressionSyntax node) => node.Parent switch
+    {
+        InvocationExpressionSyntax invocation when invocation.Expression == node => invocation,
+        MemberAccessExpressionSyntax member when member.Name == node
+                                                 && member.Parent is InvocationExpressionSyntax outer
+                                                 && outer.Expression == member => outer,
+        _ => null,
+    };
+
+    // The end of the chain, so the new step lands after every existing one. Climbs only while the node is
+    // the RECEIVER of the next step, so it can never walk out into an enclosing expression.
     private static ExpressionSyntax Outermost(ExpressionSyntax node)
     {
         var current = node;
-        while (current.Parent is MemberAccessExpressionSyntax { Parent: InvocationExpressionSyntax outer })
+        while (current.Parent is MemberAccessExpressionSyntax member
+               && member.Expression == current
+               && member.Parent is InvocationExpressionSyntax outer)
         {
             current = outer;
         }

--- a/src/Rask.Generators.CodeFixes/ImgMissingAltCodeFixProvider.cs
+++ b/src/Rask.Generators.CodeFixes/ImgMissingAltCodeFixProvider.cs
@@ -9,31 +9,82 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Rask.Generators.CodeFixes;
 
-// Quick-fix for RASK023 (Img is missing Alt): append `Alt: ""` so the image is treated as decorative
+// Quick-fix for RASK023 (Img is missing Alt): give the image an empty Alt so it reads as decorative
 // and assistive tech skips it. The empty string is the safe default the analyzer message itself
-// suggests — the developer replaces it with real alt text when the image is informative. Appending a
-// named argument is always valid here because the analyzer fires only when no Alt was supplied.
+// suggests — the developer replaces it with real alt text when the image is informative.
+//
+// Two shapes, because RASK023 now fires on both. A chain gets a `.Alt("")` step appended to its END,
+// which is where a step belongs and is valid wherever the chain already was — including on a bare
+// entry (`Img` becomes `Img.Alt("")`), which carries no argument list to add anything to. The older
+// generated factory call keeps taking a named `Alt: ""` argument. Appending is always valid here
+// because the analyzer fires only when no Alt was supplied at all.
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ImgMissingAltCodeFixProvider))]
 [Shared]
-public sealed class ImgMissingAltCodeFixProvider : RaskCodeFixProvider<InvocationExpressionSyntax>
+public sealed class ImgMissingAltCodeFixProvider : RaskCodeFixProvider<ExpressionSyntax>
 {
+    private const string GeneratedClassName = "Generated";
+
     public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create("RASK023");
 
-    protected override string Title => "Add Alt: \"\" (decorative image)";
+    protected override string Title => "Add an empty Alt (decorative image)";
 
     protected override string EquivalenceKey => "RASK023_AddEmptyAlt";
 
-    protected override Task<Document> FixAsync(
+    protected override async Task<Document> FixAsync(
+        Document document, ExpressionSyntax node, CancellationToken cancellationToken)
+    {
+        var enclosing = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+
+        if (enclosing is not null && await IsFactoryCallAsync(document, enclosing, cancellationToken)
+                .ConfigureAwait(false))
+        {
+            var argument = SyntaxFactory.Argument(
+                SyntaxFactory.NameColon("Alt"),
+                default,
+                EmptyString());
+
+            return await ReplaceNodeAsync(
+                document,
+                enclosing,
+                enclosing.WithArgumentList(enclosing.ArgumentList.AddArguments(argument)),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        // A chain: append `.Alt("")` to the whole thing, not to whichever step happens to be nearest.
+        var chain = Outermost(enclosing ?? node);
+        var stepped = SyntaxFactory.InvocationExpression(
+            SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                chain.WithoutTrivia(),
+                SyntaxFactory.IdentifierName("Alt")),
+            SyntaxFactory.ArgumentList(
+                SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(EmptyString()))));
+
+        return await ReplaceNodeAsync(document, chain, stepped.WithTriviaFrom(chain), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static LiteralExpressionSyntax EmptyString() =>
+        SyntaxFactory.LiteralExpression(
+            SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(string.Empty));
+
+    // The end of the chain, so the new step lands after every existing one.
+    private static ExpressionSyntax Outermost(ExpressionSyntax node)
+    {
+        var current = node;
+        while (current.Parent is MemberAccessExpressionSyntax { Parent: InvocationExpressionSyntax outer })
+        {
+            current = outer;
+        }
+
+        return current;
+    }
+
+    private static async Task<bool> IsFactoryCallAsync(
         Document document, InvocationExpressionSyntax invocation, CancellationToken cancellationToken)
     {
-        var altArgument = SyntaxFactory.Argument(
-            SyntaxFactory.NameColon("Alt"),
-            default,
-            SyntaxFactory.LiteralExpression(
-                SyntaxKind.StringLiteralExpression,
-                SyntaxFactory.Literal(string.Empty)));
-
-        var newInvocation = invocation.WithArgumentList(invocation.ArgumentList.AddArguments(altArgument));
-        return ReplaceNodeAsync(document, invocation, newInvocation, cancellationToken);
+        var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        return model?.GetSymbolInfo(invocation, cancellationToken).Symbol is IMethodSymbol { IsStatic: true } method
+               && method.ContainingType?.Name == GeneratedClassName;
     }
 }

--- a/src/Rask.Generators.CodeFixes/SyncAsyncHandlerCodeFixProvider.cs
+++ b/src/Rask.Generators.CodeFixes/SyncAsyncHandlerCodeFixProvider.cs
@@ -8,41 +8,70 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Rask.Generators.CodeFixes;
 
-// Quick-fix for RASK027 (both OnX and OnXAsync passed to one factory call): drop the async one.
+// Quick-fix for RASK027 (both OnX and OnXAsync set on one component): drop the async one.
 //
-// The diagnostic is anchored on the async argument itself, so this is a single-node deletion with
-// nothing to infer. Which of the two to drop is a real choice — but the analyzer already made it by
-// pointing at the async sibling, and the title says which one goes, so the lightbulb preview shows the
-// author exactly what they are agreeing to. Keeping the sync one is also the reversible direction: the
-// async handler's body is one edit away from being moved into the sync one, where the reverse loses a
-// signature.
+// Which of the two to drop is a real choice — but the analyzer already made it by pointing at the async
+// sibling, and the title says which one goes, so the lightbulb preview shows the author exactly what they
+// are agreeing to. Keeping the sync one is also the reversible direction: the async handler's body is one
+// edit away from being moved into the sync one, where the reverse loses a signature.
+//
+// Two shapes, because RASK027 now fires on both. On a factory call the async handler is a named ARGUMENT
+// and goes with the argument. On a chain it is a STEP, and removing it means splicing the chain back
+// together — `Button.OnClick(a).OnClickAsync(b)` becomes `Button.OnClick(a)`.
+//
+// The node is taken exactly where the diagnostic points, and this provider deliberately does NOT walk up
+// looking for a shape it likes: the diagnostic sits inside an expression that may itself be an argument to
+// something else, and walking up from a chain once meant the fix deleted the entire enclosing argument —
+// `Wrap(Content: <chain>, Label: "hi")` became `Wrap(Label: "hi")`, silently taking the component with it.
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SyncAsyncHandlerCodeFixProvider))]
 [Shared]
-public sealed class SyncAsyncHandlerCodeFixProvider : RaskCodeFixProvider<ArgumentSyntax>
+public sealed class SyncAsyncHandlerCodeFixProvider : RaskCodeFixProvider<SyntaxNode>
 {
     public override ImmutableArray<string> FixableDiagnosticIds { get; } = ["RASK027"];
 
-    protected override string Title => "Remove the async handler argument";
+    protected override string Title => "Remove the async handler";
 
-    protected override string EquivalenceKey => "RASK027_RemoveAsyncArgument";
+    protected override string EquivalenceKey => "RASK027_RemoveAsyncHandler";
 
-    protected override Task<bool> CanFixAsync(CodeFixContext context, ArgumentSyntax node) =>
-        Task.FromResult(node is { NameColon: not null, Parent: ArgumentListSyntax });
+    protected override Task<bool> CanFixAsync(CodeFixContext context, SyntaxNode node) =>
+        Task.FromResult(AsyncArgument(node) is not null || AsyncStep(node) is not null);
 
     protected override async Task<Document> FixAsync(
         Document document,
-        ArgumentSyntax node,
+        SyntaxNode node,
         CancellationToken cancellationToken)
     {
-        if (node.Parent is not ArgumentListSyntax list)
+        if (AsyncArgument(node) is { Parent: ArgumentListSyntax list } argument)
         {
-            return document;
+            return await ReplaceNodeAsync(
+                document,
+                list,
+                list.WithArguments(list.Arguments.Remove(argument)),
+                cancellationToken).ConfigureAwait(false);
         }
 
-        return await ReplaceNodeAsync(
-            document,
-            list,
-            list.WithArguments(list.Arguments.Remove(node)),
-            cancellationToken).ConfigureAwait(false);
+        if (AsyncStep(node) is { } step && step.Expression is MemberAccessExpressionSyntax member)
+        {
+            // Splice the step out: the chain continues from whatever it was applied to.
+            return await ReplaceNodeAsync(
+                document,
+                step,
+                member.Expression.WithTriviaFrom(step),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        return document;
     }
+
+    // The factory shape: the diagnostic points at the named argument itself.
+    private static ArgumentSyntax? AsyncArgument(SyntaxNode node) =>
+        node is ArgumentSyntax { NameColon: not null, Parent: ArgumentListSyntax } argument ? argument : null;
+
+    // The chain shape: the diagnostic points at the step's NAME, whose grandparent is the step call.
+    private static InvocationExpressionSyntax? AsyncStep(SyntaxNode node) =>
+        node is SimpleNameSyntax name
+        && name.Parent is MemberAccessExpressionSyntax { Parent: InvocationExpressionSyntax invocation } member
+        && member.Name == name
+            ? invocation
+            : null;
 }

--- a/src/Rask.Generators/Analyzers/BuilderEntry.cs
+++ b/src/Rask.Generators/Analyzers/BuilderEntry.cs
@@ -210,6 +210,33 @@ internal static class BuilderEntry
         return true;
     }
 
+    /// <summary>The metadata name of the chain's receiver, for a one-off <c>GetTypeByMetadataName</c>.</summary>
+    public const string BuildMetadataName = "Rask.Core.Build`1";
+
+    /// <summary>
+    ///     The component a <c>Build&lt;T&gt;</c> is building, or <c>null</c> when the type is anything else —
+    ///     including a component that is not wrapped in one.
+    /// </summary>
+    /// <remarks>
+    ///     Distinct from <see cref="ChainedComponent" />, which hands the type back UNCHANGED when it is not
+    ///     a <c>Build&lt;T&gt;</c>. That is the right answer for "unwrap if needed", and the wrong one for
+    ///     "is this actually a chain?" — a caller asking the second question with the first answer accepts
+    ///     the children indexer, which is typed <c>Component</c>, and reports every row twice.
+    ///     <para>
+    ///         Takes the resolved <c>Build&lt;T&gt;</c> symbol rather than comparing display strings. These
+    ///         callers run on <c>OperationKind.PropertyReference</c>, which fires for every property read in
+    ///         the compilation, so a <c>ToDisplayString()</c> on each arity-1 generic — every
+    ///         <c>List&lt;T&gt;</c>, <c>Task&lt;T&gt;</c>, <c>Nullable&lt;T&gt;</c> — allocated a string per
+    ///         keystroke in the IDE. Resolve it once in <c>RegisterCompilationStartAction</c> and pass it in.
+    ///     </para>
+    /// </remarks>
+    public static INamedTypeSymbol? BuildOf(ITypeSymbol? type, INamedTypeSymbol? build) =>
+        build is not null
+        && type is INamedTypeSymbol { IsGenericType: true, Arity: 1 } named
+        && SymbolEqualityComparer.Default.Equals(named.ConstructedFrom, build)
+            ? named.TypeArguments[0] as INamedTypeSymbol
+            : null;
+
     public static bool DerivesFromComponent(ITypeSymbol? type, INamedTypeSymbol component)
     {
         for (var current = ChainedComponent(type); current is not null; current = current.BaseType)

--- a/src/Rask.Generators/Analyzers/DataGridColumnFieldAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/DataGridColumnFieldAnalyzer.cs
@@ -56,10 +56,15 @@ public sealed class DataGridColumnFieldAnalyzer : DiagnosticAnalyzer
         // The chain reaches none of the above: its steps are extension methods on Build<T>, not a static
         // Generated.BsDataGrid(...), so the factory branch matched no chain and a column that can never be
         // shown, hidden or reordered went unreported.
-        context.RegisterOperationAction(AnalyzeChain, OperationKind.Invocation);
+        context.RegisterCompilationStartAction(static start =>
+        {
+            // Resolved once rather than per callback.
+            var build = start.Compilation.GetTypeByMetadataName(BuilderEntry.BuildMetadataName);
+            start.RegisterOperationAction(ctx => AnalyzeChain(ctx, build), OperationKind.Invocation);
+        });
     }
 
-    private static void AnalyzeChain(OperationAnalysisContext context)
+    private static void AnalyzeChain(OperationAnalysisContext context, INamedTypeSymbol? build)
     {
         var operation = (IInvocationOperation)context.Operation;
 
@@ -76,7 +81,7 @@ public sealed class DataGridColumnFieldAnalyzer : DiagnosticAnalyzer
             return; // The factory branch owns this one.
         }
 
-        if (BuiltComponent(operation.Type) is not { Name: FactoryName })
+        if (BuilderEntry.BuildOf(operation.Type, build) is not { Name: FactoryName })
         {
             return;
         }
@@ -126,13 +131,6 @@ public sealed class DataGridColumnFieldAnalyzer : DiagnosticAnalyzer
         var index = step.TargetMethod.IsExtensionMethod ? 1 : 0;
         return step.Arguments.Length > index ? step.Arguments[index].Value.Syntax as ExpressionSyntax : null;
     }
-
-    // The component a Build<T> is building, or null when the type is anything else.
-    private static INamedTypeSymbol? BuiltComponent(ITypeSymbol? type) =>
-        type is INamedTypeSymbol { IsGenericType: true, Arity: 1 } named
-        && string.Equals(named.ConstructedFrom.ToDisplayString(), "Rask.Core.Build<T>", StringComparison.Ordinal)
-            ? named.TypeArguments[0] as INamedTypeSymbol
-            : null;
 
     // The next link DOWN the chain: a step's receiver is whatever produced the Build<T> it extends,
     // written either as an extension method (argument 0) or as an instance call.

--- a/src/Rask.Generators/Analyzers/DataGridColumnFieldAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/DataGridColumnFieldAnalyzer.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Rask.Generators.Analyzers;
 
@@ -51,6 +52,103 @@ public sealed class DataGridColumnFieldAnalyzer : DiagnosticAnalyzer
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+
+        // The chain reaches none of the above: its steps are extension methods on Build<T>, not a static
+        // Generated.BsDataGrid(...), so the factory branch matched no chain and a column that can never be
+        // shown, hidden or reordered went unreported.
+        context.RegisterOperationAction(AnalyzeChain, OperationKind.Invocation);
+    }
+
+    private static void AnalyzeChain(OperationAnalysisContext context)
+    {
+        var operation = (IInvocationOperation)context.Operation;
+
+        // Only the OUTERMOST link, so the chain is read once and as a whole — `.Columns(…)` and the step
+        // that turns the chooser on can sit in either order.
+        if (operation.Syntax.Parent is MemberAccessExpressionSyntax { Parent: InvocationExpressionSyntax })
+        {
+            return;
+        }
+
+        if (operation.TargetMethod.IsStatic
+            && string.Equals(operation.TargetMethod.ContainingType?.Name, GeneratedClassName, StringComparison.Ordinal))
+        {
+            return; // The factory branch owns this one.
+        }
+
+        if (BuiltComponent(operation.Type) is not { Name: FactoryName })
+        {
+            return;
+        }
+
+        IInvocationOperation? columnsStep = null;
+        var usesChooser = false;
+
+        for (var step = operation; step is not null; step = NextStep(step))
+        {
+            var name = step.TargetMethod.Name;
+            if (string.Equals(name, "Columns", StringComparison.Ordinal))
+            {
+                columnsStep = step;
+            }
+            else if (Array.IndexOf(ChooserArguments, name) >= 0)
+            {
+                usesChooser = true;
+            }
+        }
+
+        // The feature has to be in use — otherwise a missing Field is fine — and the columns have to be
+        // written inline, exactly as in the factory branch (a variable's contents are out of reach).
+        if (!usesChooser
+            || columnsStep is null
+            || StepArgument(columnsStep) is not CollectionExpressionSyntax columns)
+        {
+            return;
+        }
+
+        foreach (var element in columns.Elements)
+        {
+            if (element is ExpressionElementSyntax { Expression: BaseObjectCreationExpressionSyntax creation }
+                && context.Operation.SemanticModel?.GetTypeInfo(creation, context.CancellationToken).Type
+                    is { Name: ColumnTypeName }
+                && !SetsField(creation)
+                && !IsPinnedFixture(creation))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Rask034, creation.GetLocation()));
+            }
+        }
+    }
+
+    // A step's value is its first real argument — index 1 when it is written as an extension method,
+    // because argument 0 is the Build<T> receiver.
+    private static ExpressionSyntax? StepArgument(IInvocationOperation step)
+    {
+        var index = step.TargetMethod.IsExtensionMethod ? 1 : 0;
+        return step.Arguments.Length > index ? step.Arguments[index].Value.Syntax as ExpressionSyntax : null;
+    }
+
+    // The component a Build<T> is building, or null when the type is anything else.
+    private static INamedTypeSymbol? BuiltComponent(ITypeSymbol? type) =>
+        type is INamedTypeSymbol { IsGenericType: true, Arity: 1 } named
+        && string.Equals(named.ConstructedFrom.ToDisplayString(), "Rask.Core.Build<T>", StringComparison.Ordinal)
+            ? named.TypeArguments[0] as INamedTypeSymbol
+            : null;
+
+    // The next link DOWN the chain: a step's receiver is whatever produced the Build<T> it extends,
+    // written either as an extension method (argument 0) or as an instance call.
+    private static IInvocationOperation? NextStep(IInvocationOperation operation)
+    {
+        var receiver = operation.Instance
+                       ?? (operation.TargetMethod.IsExtensionMethod && operation.Arguments.Length != 0
+                           ? operation.Arguments[0].Value
+                           : null);
+
+        while (receiver is IParenthesizedOperation or IConversionOperation { IsImplicit: true })
+        {
+            receiver = receiver is IParenthesizedOperation p ? p.Operand : ((IConversionOperation)receiver).Operand;
+        }
+
+        return receiver as IInvocationOperation;
     }
 
     private static void Analyze(SyntaxNodeAnalysisContext context)

--- a/src/Rask.Generators/Analyzers/HeadChildrenAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/HeadChildrenAnalyzer.cs
@@ -68,9 +68,11 @@ public sealed class HeadChildrenAnalyzer : DiagnosticAnalyzer
     private static void Analyze(SyntaxNodeAnalysisContext context, INamedTypeSymbol headType)
     {
         var node = (ElementAccessExpressionSyntax)context.Node;
-        // `Head()[...]` — the indexer receiver expression is typed `Rask.Core.Components.Head`.
-        var receiverType = ModelExtensions
-            .GetTypeInfo(context.SemanticModel, node.Expression, context.CancellationToken).Type;
+        // `Head()[...]` — the indexer receiver is typed `Rask.Core.Components.Head`. On a chain (`Head[...]`,
+        // and every other spelling the framework now teaches) it is `Build<Head>` instead, so the receiver
+        // has to be unwrapped or the whole chain surface slips past this check.
+        var receiverType = BuilderEntry.ChainedComponent(ModelExtensions
+            .GetTypeInfo(context.SemanticModel, node.Expression, context.CancellationToken).Type);
         if (receiverType is null)
         {
             return;

--- a/src/Rask.Generators/Analyzers/NativeChromeInHtmlAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/NativeChromeInHtmlAnalyzer.cs
@@ -74,7 +74,11 @@ public sealed class NativeChromeInHtmlAnalyzer : DiagnosticAnalyzer
         var node = (ElementAccessExpressionSyntax)context.Node;
         foreach (var arg in node.ArgumentList.Arguments)
         {
-            var type = ModelExtensions.GetTypeInfo(context.SemanticModel, arg.Expression, context.CancellationToken).Type;
+            // A chain hands back Build<T>, not T, so the child's own type has to be unwrapped first —
+            // without this every native component written as a chain (which is all of them now) walked
+            // straight past the test below.
+            var type = BuilderEntry.ChainedComponent(
+                ModelExtensions.GetTypeInfo(context.SemanticModel, arg.Expression, context.CancellationToken).Type);
             if (type is not null && DerivesFrom(type, nativeComponent))
             {
                 context.ReportDiagnostic(Diagnostic.Create(Rask032, arg.Expression.GetLocation(), type.Name));

--- a/src/Rask.Generators/Analyzers/RootShellAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/RootShellAnalyzer.cs
@@ -101,9 +101,19 @@ public sealed class RootShellAnalyzer : DiagnosticAnalyzer
         }
 
         var produced = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var invocation in renderBody.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        foreach (var node in renderBody.DescendantNodes())
         {
-            var name = InvokedSimpleName(invocation.Expression);
+            // The factory spelling: `Html("en")`, `Head()`. The chain writes the same shell without ever
+            // invoking anything — `Html[ … ]` is an element access, and `Doctype` on its own is a bare
+            // identifier — so a scan over invocations alone saw none of it.
+            var name = node switch
+            {
+                InvocationExpressionSyntax invocation => InvokedSimpleName(invocation.Expression),
+                ElementAccessExpressionSyntax element => InvokedSimpleName(element.Expression),
+                IdentifierNameSyntax id when IsStandaloneValue(id) => id.Identifier.ValueText,
+                _ => null,
+            };
+
             if (name is not null && Array.IndexOf(_shellFactories, name) >= 0)
             {
                 produced.Add(name);
@@ -143,6 +153,19 @@ public sealed class RootShellAnalyzer : DiagnosticAnalyzer
 
     // Simple name of an invoked expression: `Doctype()` → "Doctype",
     // `Generated.Html(...)` → "Html", `Foo<T>()` → "Foo".
+    // A bare entry used as a value — `Doctype` standing alone. Excludes the identifier that merely NAMES
+    // something larger (the receiver of a call or an indexer, the right-hand side of a member access, a
+    // declaration), which the arms above already account for; counting those too would report the same
+    // shell twice and, worse, fire on any local that happens to be called Body.
+    private static bool IsStandaloneValue(IdentifierNameSyntax id) => id.Parent switch
+    {
+        InvocationExpressionSyntax invocation => invocation.Expression != id,
+        ElementAccessExpressionSyntax element => element.Expression != id,
+        MemberAccessExpressionSyntax => false,
+        QualifiedNameSyntax => false,
+        _ => true,
+    };
+
     private static string? InvokedSimpleName(ExpressionSyntax expression) => expression switch
     {
         IdentifierNameSyntax id => id.Identifier.ValueText,

--- a/src/Rask.Generators/Analyzers/RootShellAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/RootShellAnalyzer.cs
@@ -110,7 +110,7 @@ public sealed class RootShellAnalyzer : DiagnosticAnalyzer
             {
                 InvocationExpressionSyntax invocation => InvokedSimpleName(invocation.Expression),
                 ElementAccessExpressionSyntax element => InvokedSimpleName(element.Expression),
-                IdentifierNameSyntax id when IsStandaloneValue(id) => id.Identifier.ValueText,
+                IdentifierNameSyntax id when IsBareDoctype(id) => id.Identifier.ValueText,
                 _ => null,
             };
 
@@ -151,21 +151,33 @@ public sealed class RootShellAnalyzer : DiagnosticAnalyzer
         };
     }
 
-    // Simple name of an invoked expression: `Doctype()` → "Doctype",
-    // `Generated.Html(...)` → "Html", `Foo<T>()` → "Foo".
-    // A bare entry used as a value — `Doctype` standing alone. Excludes the identifier that merely NAMES
-    // something larger (the receiver of a call or an indexer, the right-hand side of a member access, a
-    // declaration), which the arms above already account for; counting those too would report the same
-    // shell twice and, worse, fire on any local that happens to be called Body.
-    private static bool IsStandaloneValue(IdentifierNameSyntax id) => id.Parent switch
-    {
-        InvocationExpressionSyntax invocation => invocation.Expression != id,
-        ElementAccessExpressionSyntax element => element.Expression != id,
-        MemberAccessExpressionSyntax => false,
-        QualifiedNameSyntax => false,
-        _ => true,
-    };
+    /// <summary>
+    ///     A bare <c>Doctype</c> used as a value — the one part of the shell a chain writes on its own,
+    ///     because it is the only one with no children to put in an indexer.
+    /// </summary>
+    /// <remarks>
+    ///     Deliberately <b>only</b> <c>Doctype</c>. Matching a bare <c>Body</c> or <c>Head</c> by name would
+    ///     report RASK021 on any local, parameter or field that happens to share it — `var Body = email.Body`
+    ///     is ordinary code — and the repo builds <c>-warnaserror</c>, so that is a broken build rather than a
+    ///     nag. The type would settle it, but an analyzer may not call <c>Compilation.GetSemanticModel</c>
+    ///     (RS1030) and this root's <c>Render()</c> generally lives in a different syntax tree from the entry
+    ///     point being analysed. <c>Doctype</c> is safe to match on the name alone: nothing else is plausibly
+    ///     called that, and the other three are still caught by the element-access arm, which is how a chain
+    ///     writes them (<c>Html[ … ]</c>).
+    /// </remarks>
+    private static bool IsBareDoctype(IdentifierNameSyntax id) =>
+        string.Equals(id.Identifier.ValueText, "Doctype", StringComparison.Ordinal)
+        && id.Parent switch
+        {
+            InvocationExpressionSyntax invocation => invocation.Expression != id,
+            ElementAccessExpressionSyntax element => element.Expression != id,
+            MemberAccessExpressionSyntax => false,
+            QualifiedNameSyntax => false,
+            _ => true,
+        };
 
+    // Simple name of an invoked or indexed expression: `Doctype()` → "Doctype",
+    // `Generated.Html(...)` → "Html", `Html[ … ]` → "Html", `Foo<T>()` → "Foo".
     private static string? InvokedSimpleName(ExpressionSyntax expression) => expression switch
     {
         IdentifierNameSyntax id => id.Identifier.ValueText,

--- a/src/Rask.Generators/Analyzers/SyncAsyncHandlerAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/SyncAsyncHandlerAnalyzer.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Rask.Generators.Analyzers;
 
@@ -55,7 +56,91 @@ public sealed class SyncAsyncHandlerAnalyzer : DiagnosticAnalyzer
             }
 
             start.RegisterSyntaxNodeAction(ctx => Analyze(ctx, component), SyntaxKind.InvocationExpression);
+
+            // The chain reaches none of the above: its steps are extension methods on Build<T>, not a
+            // static Generated.Button(...), so the factory branch matched no chain and one of the two
+            // handlers was dropped in silence — the exact thing this diagnostic exists to prevent.
+            start.RegisterOperationAction(ctx => AnalyzeChain(ctx, component), OperationKind.Invocation);
         });
+    }
+
+    private static void AnalyzeChain(OperationAnalysisContext context, INamedTypeSymbol component)
+    {
+        var operation = (IInvocationOperation)context.Operation;
+
+        // Only the OUTERMOST link, so the chain is judged once and as a whole.
+        if (operation.Syntax.Parent is MemberAccessExpressionSyntax { Parent: InvocationExpressionSyntax })
+        {
+            return;
+        }
+
+        if (operation.TargetMethod.IsStatic
+            && string.Equals(operation.TargetMethod.ContainingType?.Name, GeneratedClassName, StringComparison.Ordinal))
+        {
+            return; // The factory branch owns this one.
+        }
+
+        if (BuiltComponent(operation.Type) is not { } built || !InheritsFrom(built, component))
+        {
+            return;
+        }
+
+        // Every step written on this chain, and where. A step that was handed `null` is the deliberate
+        // "set at most one" conditional shape, exactly as a null argument is in the factory branch.
+        var steps = new Dictionary<string, IInvocationOperation>(StringComparer.Ordinal);
+        for (var step = operation; step is not null; step = NextStep(step))
+        {
+            var value = step.TargetMethod.IsExtensionMethod && step.Arguments.Length > 1
+                ? step.Arguments[1].Value
+                : step.Arguments.Length != 0 ? step.Arguments[0].Value : null;
+
+            if (value is not { ConstantValue: { HasValue: true, Value: null } })
+            {
+                steps[step.TargetMethod.Name] = step;
+            }
+        }
+
+        foreach (var entry in steps)
+        {
+            var asyncName = entry.Key;
+            if (asyncName.Length <= "OnAsync".Length
+                || !asyncName.StartsWith("On", StringComparison.Ordinal)
+                || !asyncName.EndsWith("Async", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var syncName = asyncName.Substring(0, asyncName.Length - "Async".Length);
+            if (steps.ContainsKey(syncName))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Rask027, entry.Value.Syntax.GetLocation(), syncName, asyncName));
+            }
+        }
+    }
+
+    // The component a Build<T> is building, or null when the type is anything else.
+    private static INamedTypeSymbol? BuiltComponent(ITypeSymbol? type) =>
+        type is INamedTypeSymbol { IsGenericType: true, Arity: 1 } named
+        && string.Equals(named.ConstructedFrom.ToDisplayString(), "Rask.Core.Build<T>", StringComparison.Ordinal)
+            ? named.TypeArguments[0] as INamedTypeSymbol
+            : null;
+
+    // The next link DOWN the chain: a step's receiver is whatever produced the Build<T> it extends,
+    // written either as an extension method (argument 0) or as an instance call.
+    private static IInvocationOperation? NextStep(IInvocationOperation operation)
+    {
+        var receiver = operation.Instance
+                       ?? (operation.TargetMethod.IsExtensionMethod && operation.Arguments.Length != 0
+                           ? operation.Arguments[0].Value
+                           : null);
+
+        while (receiver is IParenthesizedOperation or IConversionOperation { IsImplicit: true })
+        {
+            receiver = receiver is IParenthesizedOperation p ? p.Operand : ((IConversionOperation)receiver).Operand;
+        }
+
+        return receiver as IInvocationOperation;
     }
 
     private static void Analyze(SyntaxNodeAnalysisContext context, INamedTypeSymbol component)

--- a/src/Rask.Generators/Analyzers/SyncAsyncHandlerAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/SyncAsyncHandlerAnalyzer.cs
@@ -60,11 +60,13 @@ public sealed class SyncAsyncHandlerAnalyzer : DiagnosticAnalyzer
             // The chain reaches none of the above: its steps are extension methods on Build<T>, not a
             // static Generated.Button(...), so the factory branch matched no chain and one of the two
             // handlers was dropped in silence — the exact thing this diagnostic exists to prevent.
-            start.RegisterOperationAction(ctx => AnalyzeChain(ctx, component), OperationKind.Invocation);
+            var build = start.Compilation.GetTypeByMetadataName(BuilderEntry.BuildMetadataName);
+            start.RegisterOperationAction(ctx => AnalyzeChain(ctx, component, build), OperationKind.Invocation);
         });
     }
 
-    private static void AnalyzeChain(OperationAnalysisContext context, INamedTypeSymbol component)
+    private static void AnalyzeChain(
+        OperationAnalysisContext context, INamedTypeSymbol component, INamedTypeSymbol? build)
     {
         var operation = (IInvocationOperation)context.Operation;
 
@@ -80,7 +82,7 @@ public sealed class SyncAsyncHandlerAnalyzer : DiagnosticAnalyzer
             return; // The factory branch owns this one.
         }
 
-        if (BuiltComponent(operation.Type) is not { } built || !InheritsFrom(built, component))
+        if (BuilderEntry.BuildOf(operation.Type, build) is not { } built || !InheritsFrom(built, component))
         {
             return;
         }
@@ -113,18 +115,21 @@ public sealed class SyncAsyncHandlerAnalyzer : DiagnosticAnalyzer
             var syncName = asyncName.Substring(0, asyncName.Length - "Async".Length);
             if (steps.ContainsKey(syncName))
             {
+                // Anchored on the STEP NAME, not on the whole chain. An invocation's span starts at the
+                // head of the chain, so reporting the invocation would let the quick-fix walk up out of
+                // the chain entirely and delete whatever encloses it.
                 context.ReportDiagnostic(Diagnostic.Create(
-                    Rask027, entry.Value.Syntax.GetLocation(), syncName, asyncName));
+                    Rask027, StepNameLocation(entry.Value), syncName, asyncName));
             }
         }
     }
 
-    // The component a Build<T> is building, or null when the type is anything else.
-    private static INamedTypeSymbol? BuiltComponent(ITypeSymbol? type) =>
-        type is INamedTypeSymbol { IsGenericType: true, Arity: 1 } named
-        && string.Equals(named.ConstructedFrom.ToDisplayString(), "Rask.Core.Build<T>", StringComparison.Ordinal)
-            ? named.TypeArguments[0] as INamedTypeSymbol
-            : null;
+    // The `.OnXAsync` name itself, so the report — and the quick-fix that reads it back — lands on the
+    // one step being removed rather than on the chain that carries it.
+    private static Location StepNameLocation(IInvocationOperation step) =>
+        step.Syntax is InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax member }
+            ? member.Name.GetLocation()
+            : step.Syntax.GetLocation();
 
     // The next link DOWN the chain: a step's receiver is whatever produced the Build<T> it extends,
     // written either as an extension method (argument 0) or as an instance call.

--- a/tests/Rask.Core.Tests/BuilderCallbackTests.cs
+++ b/tests/Rask.Core.Tests/BuilderCallbackTests.cs
@@ -157,7 +157,10 @@ public partial class BuilderCallbackTests : global::Rask.Core.RaskMarkup
     public void The_sync_handler_still_wins_the_shared_slot()
     {
         Action sync = Noop;
+        // Setting both is the whole point of this test — RASK027 is exactly right to flag it elsewhere.
+#pragma warning disable RASK027
         var div = Div.OnClickAsync(() => Task.CompletedTask).OnClick(sync).Value;
+#pragma warning restore RASK027
 
         Assert.Same(sync, div.OnClick);
         Assert.Null(div.OnClickAsync);

--- a/tests/Rask.Core.Tests/Routing/OutletTests.cs
+++ b/tests/Rask.Core.Tests/Routing/OutletTests.cs
@@ -125,7 +125,11 @@ public partial class OutletTests : global::Rask.Core.RaskMarkup
             var kids = new List<Component>(Extra + 1);
             for (var i = 0; i < Extra; i++)
             {
+                // No .Key(…) on purpose: this test asserts exact HTML, and a key would add a
+                // data-rask-key attribute to it. RASK022 is right about real lists.
+#pragma warning disable RASK022
                 kids.Add(I);
+#pragma warning restore RASK022
             }
 
             kids.Add(Outlet);

--- a/tests/Rask.Generators.Tests/CodeFixProviderTests.cs
+++ b/tests/Rask.Generators.Tests/CodeFixProviderTests.cs
@@ -11,6 +11,8 @@ public class CodeFixProviderTests
         namespace Demo;
         public sealed partial class App : Component
         {
+            private static Component Wrap(Component c) => c;
+
             protected override Component? Render()
             {
                 {{body}}
@@ -66,6 +68,19 @@ public class CodeFixProviderTests
             new ImgMissingAltAnalyzer(), new ImgMissingAltCodeFixProvider(), "RASK023",
             App("return Img;"));
         Assert.Contains("Img.Alt(\"\")", fixhed);
+    }
+
+    // The fix must act on the Img, never on whatever encloses it. Walking up to the nearest ancestor
+    // invocation produced `Wrap(Img).Alt("")` — uncompilable, and the image still had no alt.
+    [Fact]
+    public async Task Rask023_AltLandsOnTheImg_NotOnAnEnclosingCall()
+    {
+        var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
+            new ImgMissingAltAnalyzer(), new ImgMissingAltCodeFixProvider(), "RASK023",
+            App("return Wrap(Img);"));
+
+        Assert.Contains("Wrap(Img.Alt(\"\"))", fixhed);
+        Assert.DoesNotContain("Wrap(Img).Alt", fixhed);
     }
 
     // ---- RASK001: property becomes a required factory param -> add `required` ----
@@ -141,7 +156,22 @@ public class CodeFixProviderTests
             public string? Id { get; set; }
             public override Component? Render() => this;
         }
-        class Caller { void M() { {{body}} } }
+        // A MARKUP HOST, because the bare entry the fix writes only binds inside one.
+        partial class Caller : Component { protected override Component? Render() => null; void M() { {{body}} } }
+        """;
+
+    // The same construction outside a markup host: `Widget` there names the TYPE, so the rewrite would be
+    // CS0119 — a worse error than the one it replaces. The fix is withheld rather than offered.
+    private static string PlainCaller(string body) => $$"""
+        using Rask.Core;
+        namespace Demo;
+        public sealed partial class Widget : Component
+        {
+            public Widget() { }
+            public string? Id { get; set; }
+            public override Component? Render() => this;
+        }
+        class NotAHost { void M() { {{body}} } }
         """;
 
     [Fact]
@@ -153,6 +183,19 @@ public class CodeFixProviderTests
         // The bare entry — which is what RASK014's own message tells the reader to write.
         Assert.Contains("var x = Widget;", fixhed);
         Assert.DoesNotContain("new Widget()", fixhed);
+    }
+
+    [Fact]
+    public async Task Rask014_Withheld_OutsideAMarkupHost()
+    {
+        // Entries are protected static members on RaskMarkup, so `Widget` in a plain class names the TYPE
+        // and the rewrite would be CS0119 — worse than the error it replaces. RASK014 still fires; only
+        // the lightbulb stands down.
+        var offered = await CodeFixHarness.IsAnalyzerFixOfferedAsync(
+            new ComponentConstructionAnalyzer(), new ComponentConstructionCodeFixProvider(), "RASK014",
+            PlainCaller("var x = new Widget();"));
+
+        Assert.False(offered);
     }
 
     [Fact]
@@ -239,6 +282,56 @@ public class CodeFixProviderTests
 
         Assert.DoesNotContain("OnClickAsync", fixhed);
         Assert.Contains("OnClick: () => {}", fixhed);
+    }
+
+    // On a chain the async handler is a STEP, so the fix splices it out rather than deleting an argument.
+    [Fact]
+    public async Task Rask027_RemovesTheAsyncStep_FromAChain()
+    {
+        var source = """
+            using System.Threading.Tasks;
+            using Rask.Core;
+            namespace Demo;
+            public sealed partial class App : Component
+            {
+                protected override Component? Render() =>
+                    Button.OnClick(() => {}).OnClickAsync(async () => await Task.Yield())["x"];
+            }
+            """;
+        var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
+            new SyncAsyncHandlerAnalyzer(), new SyncAsyncHandlerCodeFixProvider(), "RASK027", source);
+
+        Assert.DoesNotContain("OnClickAsync", fixhed);
+        Assert.Contains("Button.OnClick(() => {})[\"x\"]", fixhed);
+    }
+
+    // The fix must never reach OUTSIDE the chain it was offered on. It used to walk up to the nearest
+    // enclosing ArgumentSyntax, so a chain sitting in a named argument had that whole argument deleted —
+    // the component silently disappeared and the remaining code still compiled.
+    [Fact]
+    public async Task Rask027_DoesNotDeleteTheEnclosingArgument()
+    {
+        var source = """
+            using System.Threading.Tasks;
+            using Rask.Core;
+            namespace Demo;
+            public sealed partial class App : Component
+            {
+                private static Component Wrap(Component Content, string Label) => Content;
+
+                protected override Component? Render() =>
+                    Wrap(
+                        Content: Button.OnClick(() => {}).OnClickAsync(async () => await Task.Yield())["x"],
+                        Label: "hi");
+            }
+            """;
+        var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
+            new SyncAsyncHandlerAnalyzer(), new SyncAsyncHandlerCodeFixProvider(), "RASK027", source);
+
+        Assert.DoesNotContain("OnClickAsync", fixhed);
+        Assert.Contains("Content:", fixhed);          // the argument survives
+        Assert.Contains("Label: \"hi\"", fixhed);
+        Assert.Contains("Button.OnClick(() => {})", fixhed);
     }
 
     // ---- CS0108: a member hides an inherited builder entry -> add `new` ----

--- a/tests/Rask.Generators.Tests/CodeFixProviderTests.cs
+++ b/tests/Rask.Generators.Tests/CodeFixProviderTests.cs
@@ -47,6 +47,27 @@ public class CodeFixProviderTests
         Assert.Contains("Img(\"/a.png\", Alt: \"\")", fixhed);
     }
 
+    // A chain takes a `.Alt("")` STEP, not a named argument — appending `Alt: ""` into whichever step
+    // happened to be nearest would not even compile.
+    [Fact]
+    public async Task Rask023_AppendsAltStep_ToAChain()
+    {
+        var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
+            new ImgMissingAltAnalyzer(), new ImgMissingAltCodeFixProvider(), "RASK023",
+            App("return Img.Src(\"/a.png\");"));
+        Assert.Contains("Img.Src(\"/a.png\").Alt(\"\")", fixhed);
+    }
+
+    [Fact]
+    public async Task Rask023_AppendsAltStep_ToABareEntry()
+    {
+        // A bare entry has no argument list at all, so only a step can be added.
+        var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
+            new ImgMissingAltAnalyzer(), new ImgMissingAltCodeFixProvider(), "RASK023",
+            App("return Img;"));
+        Assert.Contains("Img.Alt(\"\")", fixhed);
+    }
+
     // ---- RASK001: property becomes a required factory param -> add `required` ----
 
     [Fact]
@@ -105,7 +126,7 @@ public class CodeFixProviderTests
         Assert.True(offered);
     }
 
-    // ---- RASK014: `new Widget()` -> the generated factory ----
+    // ---- RASK014: `new Widget()` -> the chain that builds it ----
     //
     // A user component rather than a built-in tag: inside a `using static …Generated` scope a tag name
     // binds to the generated factory METHOD, so `new Div()` doesn't resolve to the type there at all.
@@ -124,24 +145,25 @@ public class CodeFixProviderTests
         """;
 
     [Fact]
-    public async Task Rask014_RewritesArgumentlessNew_ToTheFactoryCall()
+    public async Task Rask014_RewritesArgumentlessNew_ToTheBareEntry()
     {
         var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
             new ComponentConstructionAnalyzer(), new ComponentConstructionCodeFixProvider(), "RASK014",
             Caller("var x = new Widget();"));
-        Assert.Contains("var x = Widget();", fixhed);
+        // The bare entry — which is what RASK014's own message tells the reader to write.
+        Assert.Contains("var x = Widget;", fixhed);
         Assert.DoesNotContain("new Widget()", fixhed);
     }
 
     [Fact]
-    public async Task Rask014_DropsTheQualifier_BecauseTheFactoryIsAMethodNotAType()
+    public async Task Rask014_DropsTheQualifier_BecauseTheEntryIsNotAType()
     {
-        // `new Demo.Widget()` must become `Widget()`, not `Demo.Widget()` — the latter names a type where
+        // `new Demo.Widget()` must become `Widget`, not `Demo.Widget` — the latter names a type where
         // a method has to go, and would not compile.
         var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
             new ComponentConstructionAnalyzer(), new ComponentConstructionCodeFixProvider(), "RASK014",
             Caller("var x = new Demo.Widget();"));
-        Assert.Contains("var x = Widget();", fixhed);
+        Assert.Contains("var x = Widget;", fixhed);
     }
 
     [Fact]

--- a/tests/Rask.Generators.Tests/DataGridColumnFieldAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/DataGridColumnFieldAnalyzerTests.cs
@@ -37,6 +37,30 @@ public class DataGridColumnFieldAnalyzerTests
                     IReadOnlyList<string> HiddenColumns = null,
                     IReadOnlyList<string> ColumnOrder = null) => null;
             }
+
+            // The chain surface, reproduced in the shape the analyzer keys on: a component named
+            // BsDataGrid, and steps that are EXTENSION METHODS on Rask.Core.Build<T> handing it back.
+            public sealed class BsDataGrid<T> { }
+
+            public static class BsDataGridSteps
+            {
+                public static Rask.Core.Build<BsDataGrid<T>> Data<T>(
+                    this Rask.Core.Build<BsDataGrid<T>> b, IEnumerable<T> v) => b;
+
+                public static Rask.Core.Build<BsDataGrid<T>> Columns<T>(
+                    this Rask.Core.Build<BsDataGrid<T>> b, IReadOnlyList<BsColumn<T>> v) => b;
+
+                public static Rask.Core.Build<BsDataGrid<T>> ColumnChooser<T>(
+                    this Rask.Core.Build<BsDataGrid<T>> b, bool v) => b;
+
+                public static Rask.Core.Build<BsDataGrid<T>> HiddenColumns<T>(
+                    this Rask.Core.Build<BsDataGrid<T>> b, IReadOnlyList<string> v) => b;
+            }
+        }
+
+        namespace Rask.Core
+        {
+            public readonly struct Build<T> { }
         }
 
         namespace Demo
@@ -48,10 +72,76 @@ public class DataGridColumnFieldAnalyzerTests
 
             public static class Use
             {
+                // The entry a chain opens on. How it is produced is irrelevant to the analyzer — what
+                // matters is that the chain's type is Build<BsDataGrid<Row>>.
+                private static Rask.Core.Build<BsDataGrid<Row>> Grid => default;
+
                 public static object M() => {{call}};
             }
         }
         """;
+
+    // The chain is what the framework teaches. Its steps are extension methods on Build<T>, not a static
+    // Generated.BsDataGrid(...), so the factory branch matched none of these and a column that could never
+    // be shown, hidden or reordered went unreported.
+    [Fact]
+    public async Task Chain_ChooserOn_ColumnWithoutField_ReportsRask034()
+    {
+        var d = Assert.Single(await Diagnostics(App(
+            """
+            Grid.ColumnChooser(true).Columns(
+            [
+                new BsColumn<Row> { Title = "Name", Value = r => r.Name },
+                new BsColumn<Row> { Title = "Amount", Field = r => r.Amount },
+            ])
+            """)));
+
+        Assert.Equal("RASK034", d.Id);
+    }
+
+    [Fact]
+    public async Task Chain_ControlledHiddenColumns_TriggersTheCheck_Too()
+    {
+        var d = Assert.Single(await Diagnostics(App(
+            """
+            Grid.HiddenColumns(new[] { "amount" }).Columns(
+            [
+                new BsColumn<Row> { Title = "Name", Value = r => r.Name },
+            ])
+            """)));
+
+        Assert.Equal("RASK034", d.Id);
+    }
+
+    [Fact]
+    public async Task Chain_NoChooser_ColumnWithoutField_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(App(
+            """
+            Grid.Columns(
+            [
+                new BsColumn<Row> { Title = "Name", Value = r => r.Name },
+            ])
+            """)));
+
+    [Fact]
+    public async Task Chain_ChooserOn_EveryColumnHasField_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(App(
+            """
+            Grid.ColumnChooser(true).Columns(
+            [
+                new BsColumn<Row> { Title = "Name", Field = r => r.Name },
+            ])
+            """)));
+
+    [Fact]
+    public async Task Chain_ChooserOn_PinnedFixtureWithoutField_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(App(
+            """
+            Grid.ColumnChooser(true).Columns(
+            [
+                new BsColumn<Row> { Title = "N", Value = r => r.Name, Hideable = false, Reorderable = false },
+            ])
+            """)));
 
     [Fact]
     public async Task ChooserOn_ColumnWithoutField_ReportsRask034()

--- a/tests/Rask.Generators.Tests/HeadChildrenAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/HeadChildrenAnalyzerTests.cs
@@ -1,0 +1,60 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Rask.Generators.Analyzers;
+
+namespace Rask.Generators.Tests;
+
+// RASK019 — `<head>` is a framework-managed slot, so passing children to Head is a mistake: they are
+// dropped. The analyzer had no tests of its own; these cover the factory spelling it was written for and
+// the chain spelling that is what the framework now teaches.
+public class HeadChildrenAnalyzerTests
+{
+    private static string App(string body) => $$"""
+        using Rask.Core;
+        using static Rask.Core.Components.Generated;
+        namespace Demo;
+        public sealed partial class Page : Component
+        {
+            protected override Component? Render()
+            {
+                {{body}}
+            }
+        }
+        """;
+
+    [Fact]
+    public async Task FactoryHeadWithChildren_ReportsRask019() =>
+        Assert.Equal("RASK019", Assert.Single(await Diagnostics(App("return Head()[Title()[\"x\"]];"))).Id);
+
+    // The chain receiver is Build<Head>, not Head, so the type test walked straight past it.
+    [Fact]
+    public async Task ChainHeadWithChildren_ReportsRask019() =>
+        Assert.Equal("RASK019", Assert.Single(await Diagnostics(App("return Head[Title[\"x\"]];"))).Id);
+
+    [Fact]
+    public async Task HeadWithNoChildren_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(App("return Div[Head];")));
+
+    private static async Task<ImmutableArray<Diagnostic>> Diagnostics(string source)
+    {
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            GeneratorDriverFixture.BuildReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+        // A snippet that does not bind reports nothing, which would read as "the analyzer is fine".
+        var errors = compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+        Assert.True(errors.Count == 0, "The snippet under test does not compile:\n"
+                                       + string.Join("\n", errors.Select(e => e.ToString())));
+
+        var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new HeadChildrenAnalyzer());
+        var all = await compilation.WithAnalyzers(analyzers).GetAnalyzerDiagnosticsAsync();
+        return all.Where(d => d.Id == "RASK019").ToImmutableArray();
+    }
+}

--- a/tests/Rask.Generators.Tests/ImgMissingAltAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/ImgMissingAltAnalyzerTests.cs
@@ -49,6 +49,29 @@ public class ImgMissingAltAnalyzerTests
         // Factory order is Src, Alt, ... so the second positional argument is Alt.
         Assert.Empty(await Diagnostics(App("return Img(\"/a.png\", \"A logo\");")));
 
+    // The chain is what the framework teaches now, so the a11y guard has to see it. These are the same
+    // four cases as above, written the way a user writes them today.
+    [Fact]
+    public async Task Chain_NoAlt_ReportsRask023()
+    {
+        var d = Assert.Single(await Diagnostics(App("return Img.Src(\"/a.png\");")));
+        Assert.Equal("RASK023", d.Id);
+        Assert.Contains("Alt", d.GetMessage());
+    }
+
+    [Fact]
+    public async Task BareEntry_NoAlt_ReportsRask023() =>
+        // The shortest spelling of all: no invocation anywhere, just the entry.
+        Assert.Equal("RASK023", Assert.Single(await Diagnostics(App("return Img;"))).Id);
+
+    [Fact]
+    public async Task Chain_WithAlt_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(App("return Img.Src(\"/a.png\").Alt(\"A logo\");")));
+
+    [Fact]
+    public async Task Chain_EmptyAltForDecorative_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(App("return Img.Alt(\"\").Src(\"/a.png\");")));
+
     private static async Task<ImmutableArray<Diagnostic>> Diagnostics(string source)
     {
         var compilation = CSharpCompilation.Create(

--- a/tests/Rask.Generators.Tests/MissingKeyAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/MissingKeyAnalyzerTests.cs
@@ -26,6 +26,22 @@ public class MissingKeyAnalyzerTests
                                                 }
                                                 """;
 
+    // The chain is what the framework teaches, so keyless-list detection has to see it. A chain's steps
+    // are extension methods on Build<T>, not a static Generated.Li(...), so the factory branch matched
+    // none of these and the warning was silently absent from every chain ever written.
+    [Fact]
+    public async Task ChainSelectProjection_NoKey_ReportsRask022()
+    {
+        var d = Assert.Single(await Diagnostics(App(
+            "return Ul[ _items.Select(i => Li[i.ToString()]) ];")));
+        Assert.Equal("RASK022", d.Id);
+    }
+
+    [Fact]
+    public async Task ChainSelectProjection_WithKey_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(App(
+            "return Ul[ _items.Select(i => Li.Key(i)[i.ToString()]) ];")));
+
     [Fact]
     public async Task SelectProjection_NoKey_ReportsRask022()
     {

--- a/tests/Rask.Generators.Tests/NativeChromeInHtmlAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/NativeChromeInHtmlAnalyzerTests.cs
@@ -29,6 +29,33 @@ public class NativeChromeInHtmlAnalyzerTests
         Assert.Contains("NativeHeaderBar", d.GetMessage());
     }
 
+    // The chain is what the framework teaches, and every link of one — the bare entry included — is typed
+    // Build<T> rather than T. The type test walked straight past that, so native chrome nested in HTML
+    // went unreported across the whole chain surface.
+    //
+    // Spelled with an explicit Build<NativeHeaderBar> rather than `NativeHeaderBar.Title("Hi")` because a
+    // native component's ENTRY is injected into the consumer by the generator, which does not run in this
+    // harness — written that way the snippet does not bind at all (CS0103), and the test would fail for a
+    // reason that has nothing to do with the analyzer. The type handed to the indexer is identical.
+    [Fact]
+    public async Task ChainNativeComponentAsElementChild_ReportsRask032()
+    {
+        var src = """
+                  using Rask.Core;
+                  using static Rask.Core.Components.Generated;
+                  using Rask.Native.Components;
+                  namespace Demo;
+                  public sealed class Page : Component
+                  {
+                      protected override Component? Render() => Div()[default(Build<NativeHeaderBar>)];
+                  }
+                  """;
+
+        var d = Assert.Single(await GetDiagnosticsAsync(src));
+        Assert.Equal("RASK032", d.Id);
+        Assert.Contains("NativeHeaderBar", d.GetMessage());
+    }
+
     [Fact]
     public async Task NativeComponentInsideNativeWebViewContent_ReportsRask032()
     {

--- a/tests/Rask.Generators.Tests/RootShellAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/RootShellAnalyzerTests.cs
@@ -66,6 +66,29 @@ public class RootShellAnalyzerTests
         Assert.Contains("ChainApp", d.GetMessage());
     }
 
+    // A LOCAL that happens to be called Body is not the page shell. The bare-identifier arm added for the
+    // chain matches by name, so without a symbol check this reports RASK021 on ordinary code — and the
+    // repo builds -warnaserror, so a false positive here breaks a build rather than merely nagging.
+    [Fact]
+    public async Task UseRask_LocalNamedLikeTheShell_NoDiagnostic()
+    {
+        var src = EntryStubs + """
+                               namespace Demo;
+                               public sealed partial class LocalApp : Component
+                               {
+                                   protected override Component? Render()
+                                   {
+                                       var Body = "an email body";
+                                       var Doctype = 1;
+                                       return Div[Body, Doctype.ToString()];
+                                   }
+                               }
+                               """
+                             + "namespace Demo { class Host { void M() { Rask.Server.RaskEndpointExtensions.UseRask<LocalApp>(null!); } } }";
+
+        Assert.Empty(await GetDiagnosticsAsync(src));
+    }
+
     [Fact]
     public async Task UseRask_RootRendersOnlyItsBody_NoDiagnostic()
     {

--- a/tests/Rask.Generators.Tests/RootShellAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/RootShellAnalyzerTests.cs
@@ -45,6 +45,27 @@ public class RootShellAnalyzerTests
         Assert.Contains("App", d.GetMessage());
     }
 
+    // The chain spelling of the same mistake. `Html[…]` is an element access on a bare entry, not an
+    // invocation, so a name-matched scan over InvocationExpressionSyntax never sees it. Uses the REAL
+    // Rask.Core entries (inherited from RaskMarkup, so they bind here) rather than the local stubs the
+    // other cases declare — those stubs are methods, which is precisely what a chain is not.
+    [Fact]
+    public async Task UseRask_RootRendersTheShellAsAChain_ReportsRask021()
+    {
+        var src = EntryStubs + """
+                               namespace Demo;
+                               public sealed partial class ChainApp : Component
+                               {
+                                   protected override Component? Render() => Html[Body[Div["hi"]]];
+                               }
+                               """
+                             + "namespace Demo { class Host { void M() { Rask.Server.RaskEndpointExtensions.UseRask<ChainApp>(null!); } } }";
+
+        var d = Assert.Single(await GetDiagnosticsAsync(src));
+        Assert.Equal("RASK021", d.Id);
+        Assert.Contains("ChainApp", d.GetMessage());
+    }
+
     [Fact]
     public async Task UseRask_RootRendersOnlyItsBody_NoDiagnostic()
     {

--- a/tests/Rask.Generators.Tests/SyncAsyncHandlerAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/SyncAsyncHandlerAnalyzerTests.cs
@@ -35,6 +35,24 @@ public class SyncAsyncHandlerAnalyzerTests
         Assert.Contains("OnClickAsync", d.GetMessage());
     }
 
+    // The chain is what the framework teaches. A chain's steps are extension methods on Build<T>, not a
+    // static Generated.Button(...), so the factory branch matched none of these and one of the two
+    // handlers was silently dropped with nothing said.
+    [Fact]
+    public async Task ChainBothSyncAndAsyncClick_ReportsRask027()
+    {
+        var d = Assert.Single(await Diagnostics(App(
+            "return Button.OnClick(() => {}).OnClickAsync(async () => await Task.Yield())[\"x\"];")));
+        Assert.Equal("RASK027", d.Id);
+        Assert.Contains("OnClick", d.GetMessage());
+        Assert.Contains("OnClickAsync", d.GetMessage());
+    }
+
+    [Fact]
+    public async Task ChainOnlyAsync_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(App(
+            "return Button.OnClickAsync(async () => await Task.Yield())[\"x\"];")));
+
     [Fact]
     public async Task OnlySync_NoDiagnostic() =>
         Assert.Empty(await Diagnostics(App("return Button(OnClick: () => {})[\"x\"];")));


### PR DESCRIPTION
> **Stacked on #701** (→ #699 → #696) — based on `fix/rask034-chain`. Retarget down the stack as each parent merges.

#699 and #701 fixed the four analyzers that **announced themselves**: they matched *"a static method on a class named `Generated`"*, so grepping for that name found them. I said in #697 it was worth auditing the rest. It was.

## Three more, from a different family

These never mention `Generated`. They test a **TYPE**, and a chain hands back `Build<T>` rather than `T` — so nothing pointed at them. They turned up only by asking the same question of every analyzer.

| ID | Severity | What was unreported on a chain |
|---|---|---|
| **RASK032** | **Error** | Native chrome nested in HTML — `Div[NativeHeaderBar…]` serializes to nothing on a device. It is an Error precisely so that never ships, and it fired on none of the taught syntax. |
| **RASK019** | Error | Children passed to `Head[…]`, which are dropped silently. This analyzer also had **no tests at all**. |
| **RASK021** | Warning | A root rendering the page shell. It scans `Render()` for *invocations*, and a chain invokes nothing — `Html[…]` is an element access, `Doctype` a bare identifier. |

## The fixes

RASK019 and RASK032 are one-line unwraps through `BuilderEntry.ChainedComponent`, which returns `T` for a `Build<T>` and the type unchanged otherwise — safe applied unconditionally.

RASK021 keeps its **name-based** design (its existing tests declare same-named local helper methods, so a semantic test would break them) and gains the two chain spellings. The standalone-identifier arm is deliberately narrow — it excludes any identifier that merely *names* a larger expression — so a local called `Body` cannot trip it.

## ⚠️ A failing analyzer test can be a false negative

This cost me a wrong conclusion, and it is the most reusable thing in this PR.

These harnesses build a `CSharpCompilation` and **never check that it compiled**. A snippet that does not bind reports nothing — which reads exactly like a blind analyzer.

My first RASK032 test wrote `Div[NativeHeaderBar.Title("Hi")]` and failed with **`CS0103`**: a native component's *entry* is injected by the generator, which no analyzer harness runs. Rask.Core's own entries (`Div`, `Li`, `Img`, `Head`, `Html`) do bind — they are inherited from the compiled `RaskMarkup` — but anything outside Rask.Core does not.

The test now expresses the type directly with `default(Build<NativeHeaderBar>)`, identical to what a chain hands the indexer, and the new `HeadChildrenAnalyzerTests` **asserts its snippets compile** before trusting any result.

Every fix was confirmed red before green — RASK032's by stashing the fix and re-running it.

## Testing

- `dotnet format --verify-no-changes` — clean (exit 0).
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors. No new in-repo findings, which is expected: nothing nests native chrome in HTML, passes `Head` children, or renders the shell from a root.
- `scripts/run-unit-local.sh` — **6,082 passed, 0 failed**.
- Browser E2E + CLI build gate + watch hot-reload gate via the pre-push hook.

## Changelog

`[Unreleased] → Fixed`.
