### PR TITLE
fix(analyzers): make RASK022 and RASK023 see a chain, not only the factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- **Two analyzers had stopped firing altogether on chain-built markup — including an accessibility
+  check.** `RASK022` (a list item without a `Key`) and `RASK023` (an `Img` without `Alt`) each identified
+  their subject as *"a static method on the class named `Generated`"* — the factory. A chain has no such
+  method: `Li[…]` is a property reference plus a children indexer, and `Img.Src("/x")` ends at the `Src`
+  **setter**. So neither analyzer failed on the chain; neither ever ran. Every chain-written `<img>` in
+  every consuming app was going unchecked for `alt`, and every keyless chain-built list unwarned — on the
+  only spelling the docs teach.
+
+  Their own tests could not have caught it: those compile without running the builder generator, so they
+  cannot express a chain at all. `AnalyzersOnTheChainSurfaceTests` runs the generator first, and its two
+  keyless/alt-less cases fail on the previous behaviour.
+
+  Both now read the chain down to the entry that opened it and ask whether the step was named, via a
+  shared `BuilderEntry.TryReadChain`. The factory path is untouched while it still exists, and every
+  existing factory test still passes. What it deliberately does **not** do is flag any expression merely
+  *typed* as a component: a static markup helper (`Ui.Badge(x)`) yields one and cannot be keyed, so only
+  a factory call or a chain — the two things that can carry the step — are considered.
+
+  Re-enabled, the pair found five real sites in this repo. Closes #704.
+
+  This is the same failure mode `BuilderEntry.ChainedComponent` already records for RASK025/038/044, and
+  it is worth stating as a rule: **a green build proves nothing about an analyzer still firing.** Only its
+  tests do, and only if they use the surface people actually write.
+
 - **A keyed row's own state followed its POSITION, not its item.** A child's identity inside its parent
   was its ordinal among entry-built siblings, and `Key` took no part — the parent's child map never read
   it. `Key` was only ever the diff codec's identity (`data-rask-key`), one layer above. So inserting an

--- a/benchmarks/Rask.Benchmarks/AttrBagBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/AttrBagBenchmarks.cs
@@ -1,7 +1,15 @@
+#pragma warning disable RASK022 // keyless rows on purpose — see the note below
+
 using BenchmarkDotNet.Attributes;
 using Rask.Core;
 
 namespace Rask.Benchmarks;
+
+// RASK022 is suppressed for this file. Its rows ARE keyless, and correctly reported — but this benchmark
+// renders the bare minimum around the one attribute it measures, and giving every row a Key would add a
+// per-element write to both arms and move the absolute figures already recorded in the CHANGELOG
+// (80.7 KB -> 63.52 KB). The A/B is between two spellings of Data, not a reconciliation claim, so the
+// key would buy nothing here and cost the record its meaning.
 
 // What `.Data("test-id", "primary")` costs against `.Data(new Dictionary<string, string?> { … })`,
 // which is what a call site had to write before it existed.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -299,9 +299,15 @@ rendered body as parameters. Do **not** add a runtime `<script>`; it's auto-appe
 ## RASK022
 **List item is missing a `Key`** · Warning
 
-A Rask factory call appears in a sibling-list context (a `.Select`/`.SelectMany` projection, or
-`.Add` in a loop) without a `Key:`. Keyless items reconcile **by position**, which loses focus and
-input state and emits untrusted structural diffs on insert/remove/move.
+A Rask component appears in a sibling-list context (a `.Select`/`.SelectMany` projection, or `.Add`
+in a loop) without a `Key`. Keyless items reconcile **by position**, which loses focus and input state
+and emits untrusted structural diffs on insert/remove/move — and for a component, position also
+decides which instance is reused, so the row's own state follows the slot rather than the item
+(see [RASK046](#rask046)).
+
+Both spellings are recognised: a chain (`Li[…]`, `Li.Class("c")[…]`) and, while it still exists, a
+generated factory call. The chain form went unreported until #704 — the check matched a method named
+after the component, and a chain has none.
 
 ```csharp
 // ✗ items.Select(i => Li[ i.Name ])
@@ -315,8 +321,13 @@ for why identity beats position.
 ## RASK023
 **`Img` is missing `Alt` text** · Warning
 
-An `Img(...)` factory call supplies no `Alt`. Without a text alternative, screen readers fall back to
+An `Img` is built without naming `Alt`. Without a text alternative, screen readers fall back to
 announcing the file name (or nothing), failing [WCAG 1.1.1](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content).
+
+Both spellings are recognised: a chain (`Img.Src("/x")`, or the bare `Img`) and, while it still exists,
+a generated factory call. **The chain form went unreported until #704** — the check matched a static
+method named `Img`, and on a chain the outermost call is the `Src` setter, so an accessibility check
+that the docs' own examples should have tripped never fired at all.
 
 ```csharp
 // ✗ Img.Src("/logo.png")

--- a/src/Rask.Generators/Analyzers/BuilderEntry.cs
+++ b/src/Rask.Generators/Analyzers/BuilderEntry.cs
@@ -123,6 +123,93 @@ internal static class BuilderEntry
             ? named.TypeArguments[0]
             : type;
 
+    /// <summary>
+    ///     Reads a chain from its OUTERMOST link down to the entry that opened it: what it builds, and
+    ///     which steps it named along the way.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         For the analyzers that ask "was this component given X?", because on a chain that question
+    ///         cannot be answered from the outermost call. `Li[…]` is a property reference plus a children
+    ///         indexer, and `Img.Src("/x")` ends at a SETTER — so an analyzer matching a method named after
+    ///         the component finds nothing and simply never fires. That is not a hypothetical: RASK022 and
+    ///         RASK023 were both silently dead on the chain until #704, and the two before them
+    ///         (RASK025/038/044) went the same way when the receiver changed.
+    ///     </para>
+    ///     <para>
+    ///         Succeeds only for the outermost link, so one chain is read once rather than once per step.
+    ///         An entry is a property typed <c>Build&lt;T&gt;</c>, which is exactly what an ordinary method
+    ///         returning a component is not — that distinction is what keeps a static markup helper
+    ///         (<c>Ui.Badge(x)</c>) from being mistaken for something that could take a key.
+    ///     </para>
+    /// </remarks>
+    public static bool TryReadChain(
+        ExpressionSyntax node,
+        SemanticModel model,
+        CancellationToken cancellationToken,
+        out SimpleNameSyntax entry,
+        out ITypeSymbol? built,
+        out HashSet<string> steps)
+    {
+        entry = null!;
+        built = null;
+        steps = new HashSet<string>(StringComparer.Ordinal);
+
+        // Something chained onto it means this is not the outermost link: `Img.Src("/x")` inside
+        // `Img.Src("/x").Alt("a")`, or `Li` inside `Li.Class("c")`.
+        if (node.Parent is ElementAccessExpressionSyntax access && access.Expression == node)
+        {
+            return false;
+        }
+
+        if (node.Parent is MemberAccessExpressionSyntax { Parent: InvocationExpressionSyntax })
+        {
+            return false;
+        }
+
+        var current = (ExpressionSyntax?)node;
+        while (current is not null)
+        {
+            switch (current)
+            {
+                case ElementAccessExpressionSyntax indexer:
+                    current = indexer.Expression;
+                    continue;
+                case ParenthesizedExpressionSyntax paren:
+                    current = paren.Expression;
+                    continue;
+                case InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax member }:
+                    steps.Add(member.Name.Identifier.ValueText);
+                    current = member.Expression;
+                    continue;
+            }
+
+            break;
+        }
+
+        // `Li` is an IdentifierName; a qualified entry (`RaskEntriesX.Li`) is the Name half of a member
+        // access, which is how a type in scope with the same simple name is worked around.
+        var name = current switch
+        {
+            IdentifierNameSyntax id => (SimpleNameSyntax)id,
+            MemberAccessExpressionSyntax member => member.Name,
+            _ => null,
+        };
+
+        if (name is null
+            || model.GetSymbolInfo(name, cancellationToken).Symbol is not IPropertySymbol property
+            || property.Type is not INamedTypeSymbol { IsGenericType: true, Arity: 1 } built1
+            || !string.Equals(
+                built1.ConstructedFrom.ToDisplayString(), "Rask.Core.Build<T>", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        entry = name;
+        built = built1.TypeArguments[0];
+        return true;
+    }
+
     public static bool DerivesFromComponent(ITypeSymbol? type, INamedTypeSymbol component)
     {
         for (var current = ChainedComponent(type); current is not null; current = current.BaseType)

--- a/src/Rask.Generators/Analyzers/ImgMissingAltAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/ImgMissingAltAnalyzer.cs
@@ -23,8 +23,8 @@ public sealed class ImgMissingAltAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor Rask023 = new(
         "RASK023",
         "Img is missing Alt text",
-        "Img is created without Alt — set Alt: to a text alternative, or Alt: \"\" for a decorative "
-        + "image, so screen readers don't announce the file name (WCAG 1.1.1)",
+        "Img is created without Alt — name '.Alt(…)' with a text alternative, or '.Alt(\"\")' for a "
+        + "decorative image, so screen readers don't announce the file name (WCAG 1.1.1)",
         DiagnosticHelp.Category,
         DiagnosticSeverity.Warning,
         true,
@@ -54,27 +54,47 @@ public sealed class ImgMissingAltAnalyzer : DiagnosticAnalyzer
 
             start.RegisterSyntaxNodeAction(
                 ctx => Analyze(ctx, img),
-                SyntaxKind.InvocationExpression);
+                SyntaxKind.InvocationExpression,
+                SyntaxKind.ElementAccessExpression,
+                SyntaxKind.IdentifierName);
         });
     }
 
     private static void Analyze(SyntaxNodeAnalysisContext context, INamedTypeSymbol img)
     {
-        var invocation = (InvocationExpressionSyntax)context.Node;
+        var node = (ExpressionSyntax)context.Node;
+        var model = context.SemanticModel;
 
-        // Is this the generated Img factory? A static `Generated.Img(...)` returning Rask.Core.Components.Img.
-        if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol method
-            || !method.IsStatic
-            || !string.Equals(method.ContainingType?.Name, GeneratedClassName, StringComparison.Ordinal)
-            || !string.Equals(method.Name, "Img", StringComparison.Ordinal)
-            || !SymbolEqualityComparer.Default.Equals(method.ReturnType, img))
+        // The FACTORY: a static `Generated.Img(...)` returning Rask.Core.Components.Img.
+        if (node is InvocationExpressionSyntax invocation
+            && model.GetSymbolInfo(invocation, context.CancellationToken).Symbol is IMethodSymbol method
+            && method.IsStatic
+            && string.Equals(method.ContainingType?.Name, GeneratedClassName, StringComparison.Ordinal)
+            && string.Equals(method.Name, "Img", StringComparison.Ordinal)
+            && SymbolEqualityComparer.Default.Equals(method.ReturnType, img))
+        {
+            if (!SuppliesAlt(invocation, method))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Rask023, NameLocation(invocation)));
+            }
+
+            return;
+        }
+
+        // A CHAIN. This analyzer used to look only for a method NAMED Img, so `Img.Src("/x")` — whose
+        // outermost call is the `Src` SETTER, and whose bare form is not a call at all — never matched and
+        // the alt check silently stopped firing on the spelling the docs teach (#704). An accessibility
+        // check that does not run is worse than one that is noisy.
+        if (!BuilderEntry.TryReadChain(
+                node, model, context.CancellationToken, out var entry, out var built, out var steps)
+            || !SymbolEqualityComparer.Default.Equals(built, img))
         {
             return;
         }
 
-        if (!SuppliesAlt(invocation, method))
+        if (!steps.Contains(AltParameter))
         {
-            context.ReportDiagnostic(Diagnostic.Create(Rask023, NameLocation(invocation)));
+            context.ReportDiagnostic(Diagnostic.Create(Rask023, entry.GetLocation()));
         }
     }
 

--- a/src/Rask.Generators/Analyzers/MissingKeyAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/MissingKeyAnalyzer.cs
@@ -27,8 +27,9 @@ public sealed class MissingKeyAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor Rask022 = new(
         "RASK022",
         "List item is missing a Key",
-        "'{0}' is rendered in a list without a Key — set Key: so the diff codec reconciles it by "
-        + "identity (trusted keyed structural ops) instead of by position",
+        "'{0}' is rendered in a list without a Key — name '.Key(…)' so the diff codec reconciles it by "
+        + "identity (trusted keyed structural ops) instead of by position, and so the parent keeps each "
+        + "row's own state with the row rather than with the slot",
         DiagnosticHelp.Category,
         DiagnosticSeverity.Warning,
         true,
@@ -60,27 +61,60 @@ public sealed class MissingKeyAnalyzer : DiagnosticAnalyzer
 
             start.RegisterSyntaxNodeAction(
                 ctx => Analyze(ctx, component),
-                SyntaxKind.InvocationExpression);
+                SyntaxKind.InvocationExpression,
+                SyntaxKind.ElementAccessExpression);
         });
     }
 
     private static void Analyze(SyntaxNodeAnalysisContext context, INamedTypeSymbol component)
     {
-        var invocation = (InvocationExpressionSyntax)context.Node;
+        var node = (ExpressionSyntax)context.Node;
         var model = context.SemanticModel;
 
-        // 1) Is this a Rask factory call? Generated factories are static methods on a class named
-        //    `Generated` (namespace varies per component) returning a Component-derived type.
-        if (model.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol method
-            || !method.IsStatic
-            || !string.Equals(method.ContainingType?.Name, GeneratedClassName, StringComparison.Ordinal)
-            || !InheritsFrom(method.ReturnType as INamedTypeSymbol, component))
+        // 1) Is this a Rask construction that COULD carry a key? Two spellings.
+        //
+        //    The factory is a static method on a class named `Generated` (namespace varies per
+        //    component) returning a Component-derived type.
+        //
+        //    A CHAIN is not a method call at all, which is why this analyzer used to miss it entirely:
+        //    `Li[…]` is a property reference plus a children indexer, and `Li.Class("c")[…]` puts
+        //    extension setters in between. The outermost invocation's symbol is the last SETTER, never
+        //    the component — so matching on the method name found nothing and the keyless-list check
+        //    silently stopped firing on the only spelling the docs teach (#704).
+        //
+        //    The distinction still matters: an expression merely TYPED as a component is not enough. A
+        //    static helper returning markup (`Ui.Badge(x)`) yields a Component and cannot take a key, so
+        //    flagging it would be noise. Only a factory call or a chain can be keyed.
+        string name;
+        Location location;
+        if (node is InvocationExpressionSyntax invocation
+            && model.GetSymbolInfo(invocation, context.CancellationToken).Symbol is IMethodSymbol method
+            && method.IsStatic
+            && string.Equals(method.ContainingType?.Name, GeneratedClassName, StringComparison.Ordinal)
+            && InheritsFrom(method.ReturnType as INamedTypeSymbol, component))
         {
-            return;
-        }
+            // 2) Already keyed — a Key: argument, or a Data argument carrying rask-key (back-compat).
+            if (HasKeyArgument(invocation))
+            {
+                return;
+            }
 
-        // 2) Already keyed — a Key: argument, or a Data argument carrying rask-key (back-compat).
-        if (HasKeyArgument(invocation))
+            name = method.Name;
+            location = NameLocation(invocation);
+        }
+        else if (BuilderEntry.TryReadChain(
+                     node, model, context.CancellationToken, out var entry, out _, out var steps))
+        {
+            // Key names the identity; a Data step carrying rask-key is the VirtualizePage-style equivalent.
+            if (steps.Contains("Key") || steps.Contains("Data") && node.ToString().Contains("rask-key"))
+            {
+                return;
+            }
+
+            name = entry.Identifier.ValueText;
+            location = entry.GetLocation();
+        }
+        else
         {
             return;
         }
@@ -88,7 +122,7 @@ public sealed class MissingKeyAnalyzer : DiagnosticAnalyzer
         // 3) The produced "child expression": the call plus any `[...]` children indexer, paren,
         //    and `(Component)` cast wrapping it. Its (converted) type tells us it becomes a sibling
         //    component.
-        var outer = ClimbToChildExpression(invocation);
+        var outer = ClimbToChildExpression(node);
         var typeInfo = model.GetTypeInfo(outer, context.CancellationToken);
         var isChildLike =
             InheritsFrom(typeInfo.Type as INamedTypeSymbol, component)
@@ -106,7 +140,7 @@ public sealed class MissingKeyAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        context.ReportDiagnostic(Diagnostic.Create(Rask022, NameLocation(invocation), method.Name));
+        context.ReportDiagnostic(Diagnostic.Create(Rask022, location, name));
     }
 
     private static bool InheritsFrom(INamedTypeSymbol? type, INamedTypeSymbol target)

--- a/tests/Rask.Core.Tests/BuilderMarkupHostTests.cs
+++ b/tests/Rask.Core.Tests/BuilderMarkupHostTests.cs
@@ -34,7 +34,7 @@ public partial class BuilderMarkupHostTests : RaskMarkup
 
     // The render-fragment shape: a delegate, which a component cannot be.
     private static readonly Func<IReadOnlyList<string>, Component> _template =
-        messages => Div[messages.Select(static m => Span.Class("msg")[m])];
+        messages => Div[messages.Select(static m => Span.Key(m).Class("msg")[m])];
 
     [Fact]
     public void A_test_class_reaches_the_framework_entries() =>
@@ -46,7 +46,11 @@ public partial class BuilderMarkupHostTests : RaskMarkup
 
     [Fact]
     public void A_delegate_field_reaches_them_too() =>
-        Assert.Equal("<div><span class=\"msg\">a</span><span class=\"msg\">b</span></div>",
+        // The rows are keyed (RASK022), so each carries its data-rask-key — the attribute order is the
+        // fixed one: class before data-*.
+        Assert.Equal(
+            "<div><span class=\"msg\" data-rask-key=\"a\">a</span>"
+            + "<span class=\"msg\" data-rask-key=\"b\">b</span></div>",
             _template(["a", "b"]).ToHtml());
 
     // A `static class` cannot derive from anything, so it cannot be a markup host. It does not have to

--- a/tests/Rask.Generators.Tests/AnalyzersOnTheChainSurfaceTests.cs
+++ b/tests/Rask.Generators.Tests/AnalyzersOnTheChainSurfaceTests.cs
@@ -1,0 +1,127 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Rask.Generators.Analyzers;
+using Xunit;
+
+namespace Rask.Generators.Tests;
+
+// Several analyzers identify their subject as "a static method on the class named Generated" — the
+// FACTORY. Markup is now a chain, where the same markup is a property reference plus extension setters
+// and a children indexer, with no such method anywhere. An analyzer written that way does not fail on the
+// chain; it simply never fires, which is the worst way for a check to stop working.
+//
+// Their existing test files compile without running the builder generator, so they cannot express a chain
+// at all and could not have caught this. These run the generator first.
+public class AnalyzersOnTheChainSurfaceTests
+{
+    [Fact]
+    public async Task A_keyless_chain_built_list_reports_Rask022()
+    {
+        var d = await AnalyzeAsync(
+            """
+            using System.Linq;
+            using Rask.Core;
+            namespace Demo
+            {
+                public sealed partial class App : Component
+                {
+                    private readonly int[] _items = { 1, 2, 3 };
+
+                    protected override Component? Render() =>
+                        Ul[_items.Select(i => (Component)Li[i.ToString()])];
+                }
+            }
+            """,
+            "RASK022",
+            new MissingKeyAnalyzer());
+
+        Assert.NotEmpty(d);
+    }
+
+    [Fact]
+    public async Task A_keyed_chain_built_list_is_clean()
+    {
+        Assert.Empty(await AnalyzeAsync(
+            """
+            using System.Linq;
+            using Rask.Core;
+            namespace Demo
+            {
+                public sealed partial class App : Component
+                {
+                    private readonly int[] _items = { 1, 2, 3 };
+
+                    protected override Component? Render() =>
+                        Ul[_items.Select(i => (Component)Li.Key(i)[i.ToString()])];
+                }
+            }
+            """,
+            "RASK022",
+            new MissingKeyAnalyzer()));
+    }
+
+    [Fact]
+    public async Task An_alt_less_chain_built_img_reports_Rask023()
+    {
+        var d = await AnalyzeAsync(
+            """
+            using Rask.Core;
+            namespace Demo
+            {
+                public sealed partial class App : Component
+                {
+                    protected override Component? Render() => Img.Src("/logo.png");
+                }
+            }
+            """,
+            "RASK023",
+            new ImgMissingAltAnalyzer());
+
+        Assert.NotEmpty(d);
+    }
+
+    [Fact]
+    public async Task A_chain_built_img_with_alt_is_clean()
+    {
+        Assert.Empty(await AnalyzeAsync(
+            """
+            using Rask.Core;
+            namespace Demo
+            {
+                public sealed partial class App : Component
+                {
+                    protected override Component? Render() => Img.Src("/logo.png").Alt("A logo");
+                }
+            }
+            """,
+            "RASK023",
+            new ImgMissingAltAnalyzer()));
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(
+        string source, string id, DiagnosticAnalyzer analyzer)
+    {
+        var run = BuilderGeneratorHarness.Run(source);
+        var trees = run.Sources
+            .Select(s => s.SourceText.ToString())
+            .Prepend(source)
+            .Select(s => CSharpSyntaxTree.ParseText(s, new CSharpParseOptions(LanguageVersion.Latest)));
+
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            trees,
+            GeneratorDriverFixture.BuildReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+        var all = await compilation
+            .WithAnalyzers(ImmutableArray.Create(analyzer))
+            .GetAnalyzerDiagnosticsAsync();
+
+        return [.. all.Where(d => d.Id == id)];
+    }
+}


### PR DESCRIPTION
Closes #704.

## Two shipped analyzers had stopped firing altogether — one of them an accessibility check

`RASK022` (a list item without a `Key`) and `RASK023` (an `Img` without `Alt`) each identified their subject as *"a static method on the class named `Generated`"* — the factory. A chain has no such method:

- `Li[…]` is a **property reference** plus a children indexer.
- `Img.Src("/x")` ends at the `Src` **setter**; the bare `Img` is not a call at all.

So neither analyzer *failed* on the chain. Neither ever **ran**. Every chain-written `<img>` in every consuming app was going unchecked for `alt`, and every keyless chain-built list unwarned — on the only spelling the docs teach.

## Why nothing caught it

Their own tests compile **without running the builder generator**, so they cannot express a chain at all. `AnalyzersOnTheChainSurfaceTests` runs the generator first. Its keyless and alt-less cases fail on the previous behaviour; its keyed and alt-ed cases pass either way, which is exactly why the negative cases had to exist.

## The fix

Both analyzers now read the chain down to the entry that opened it and ask whether the step was named, through a shared `BuilderEntry.TryReadChain`. The factory path is untouched while it still exists, and **all 353 generator tests pass**, including the existing factory-spelling ones.

What this deliberately does **not** do is flag any expression merely *typed* as a component. A static markup helper (`Ui.Badge(x)`) yields one and cannot be keyed, so only a factory call or a chain — the two things that can carry the step — are considered. That is what keeps a re-enabled check from becoming noise.

## What it found once re-enabled

Five real sites in this repo:

- a keyless template in `BuilderMarkupHostTests` — now keyed, with its asserted HTML updated for the `data-rask-key` it emits;
- four rows in `AttrBagBenchmarks` — suppressed **with the reason**: that benchmark renders the bare minimum around the one attribute it measures, and keying every row would move figures already recorded in the CHANGELOG without buying the benchmark anything.

Messages and docs for both now say `.Key(…)` / `.Alt(…)` rather than `Key:` / `Alt:`.

## The rule worth keeping

This is the same failure mode `BuilderEntry.ChainedComponent` already records for RASK025/038/044: **a green build proves nothing about an analyzer still firing.** Only its tests do, and only if they use the surface people actually write.

## Not in here

The **quick-fixes** (#697) are deliberately excluded. They have to emit different syntax per spelling — `Alt: ""` for a factory call, `.Alt("")` for a chain — and that is only testable now that the analyzer fires at all. Next PR.

Four more analyzers are built the same way (`SyncAsyncHandler`, `PreferNamedArgs`, `DataGridColumnField`, `InputTypeMismatch`) and are listed on #704 for audit; `PreferNamedArgsAnalyzer` may be obsolete outright, since a chain has no named arguments.

## Testing

- `dotnet format --verify-no-changes` — clean.
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors.
- `scripts/run-unit-local.sh` — green, **6,043** tests.
- All **353** generator tests, including the 4 new chain-surface cases.
- CLI build gate (27/27) + watch gate — green via pre-push, which matters here: a re-enabled analyzer could have started firing on `rask new` output.