### PR TITLE
test(generators): fail the build when two analyzer assemblies share a diagnostic id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- **Two analyzer assemblies could number a diagnostic the same, and nothing failed.** Roslyn's `RS1019`
+  catches a duplicate id within ONE compilation, so the common case was already covered — but it is
+  per-compilation, and Rask declares descriptors in three analyzer assemblies (`Rask.Generators`,
+  `Rask.Cqrs.Generators`, `Rask.Jobs.Generators`). Declaring `RASK022` a second time from a different
+  assembly builds clean, warnings-as-errors and all: the family then ships two meanings under one number,
+  with one help link pointing at whichever doc section was written second.
+
+  `DiagnosticDescriptorTests` could not have caught it either — its `AllDescriptors()` keys a dictionary
+  on the id, so two colliding descriptors silently collapsed into one entry and every invariant it asserts
+  passed. The new check enumerates without collapsing, deduplicating by the descriptor's own equality
+  instead, so one descriptor reachable both through `SupportedDiagnostics` and through the static field
+  behind it still counts once while two genuinely different ones stay two. Verified by injecting a
+  cross-assembly duplicate: the solution built clean and the test went red.
+
+  Prompted by RASK047 being claimed by two open branches on the same afternoon — the third id collision in
+  a day, after RASK044/045 and RASK046.
+
+### Fixed
 - **Two analyzers had stopped firing altogether on chain-built markup — including an accessibility
   check.** `RASK022` (a list item without a `Key`) and `RASK023` (an `Img` without `Alt`) each identified
   their subject as *"a static method on the class named `Generated`"* — the factory. A chain has no such

--- a/tests/Rask.Generators.Tests/DiagnosticDescriptorTests.cs
+++ b/tests/Rask.Generators.Tests/DiagnosticDescriptorTests.cs
@@ -60,6 +60,95 @@ public class DiagnosticDescriptorTests
     private static IReadOnlyList<DiagnosticDescriptor> RaskDescriptors() =>
         AllDescriptors().Where(d => d.Id.StartsWith("RASK", StringComparison.Ordinal)).ToList();
 
+    // The same enumeration WITHOUT collapsing by id, plus the type each descriptor was declared on.
+    //
+    // AllDescriptors above keys a dictionary on the id, which is what makes a collision invisible: two
+    // different diagnostics numbered the same silently become one entry and every invariant here passes.
+    // Deduplication is by the descriptor's OWN equality (DiagnosticDescriptor compares its fields), so one
+    // descriptor reachable both through SupportedDiagnostics and through the static field behind it counts
+    // once, while two genuinely different descriptors sharing an id stay two.
+    private static IReadOnlyList<(string Owner, DiagnosticDescriptor Descriptor)> RaskDescriptorsByOwner()
+    {
+        var found = new List<(string, DiagnosticDescriptor)>();
+        var seen = new HashSet<DiagnosticDescriptor>();
+
+        foreach (var assembly in new[]
+                 {
+                     typeof(RoutesGenerator).Assembly,
+                     typeof(Rask.Cqrs.Generators.CqrsDispatchGenerator).Assembly,
+                     typeof(Rask.Jobs.Generators.JobRegistryGenerator).Assembly,
+                 })
+        {
+            foreach (var type in assembly.GetTypes())
+            {
+                if (typeof(DiagnosticAnalyzer).IsAssignableFrom(type) && !type.IsAbstract
+                    && Activator.CreateInstance(type) is DiagnosticAnalyzer analyzer)
+                {
+                    Add(type, analyzer.SupportedDiagnostics);
+                }
+
+                foreach (var field in type.GetFields(BindingFlags.Static | BindingFlags.NonPublic
+                                                     | BindingFlags.Public))
+                {
+                    if (field.GetValue(null) is DiagnosticDescriptor descriptor)
+                    {
+                        Add(type, [descriptor]);
+                    }
+                }
+            }
+        }
+
+        return found;
+
+        void Add(Type owner, ImmutableArray<DiagnosticDescriptor> descriptors)
+        {
+            foreach (var d in descriptors)
+            {
+                if (d.Id.StartsWith("RASK", StringComparison.Ordinal) && seen.Add(d))
+                {
+                    found.Add((owner.Name, d));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    ///     One id, one diagnostic. Nothing else in the build enforces this, and it went wrong three times in
+    ///     a single day.
+    /// </summary>
+    /// <remarks>
+    ///     Two branches that each need a new diagnostic both read the highest number in
+    ///     <c>docs/diagnostics.md</c> and both pick the next one. That file is documentation — the
+    ///     descriptors are the source of truth — so nothing fails: the analyzers compile, both fire, and the
+    ///     family ships two different meanings under one number, with one help link pointing at whichever
+    ///     doc section was written second. RASK044/045 were already taken when a third branch wanted a
+    ///     number, RASK046 had to be surrendered to Key-opens-the-chain, and RASK047 was claimed twice on
+    ///     the same afternoon.
+    /// </remarks>
+    [Fact]
+    public void No_two_diagnostics_share_an_id()
+    {
+        var collisions = RaskDescriptorsByOwner()
+            .GroupBy(x => x.Descriptor.Id, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1)
+            .Select(g => $"{g.Key} is declared {g.Count()} times: "
+                         + string.Join(" | ", g.Select(x => $"{x.Owner} \"{x.Descriptor.Title}\"")))
+            .ToList();
+
+        Assert.True(collisions.Count == 0,
+            "Two diagnostics cannot share an id — pick the next FREE number, and check the descriptors "
+            + "rather than docs/diagnostics.md, which lags:\n  " + string.Join("\n  ", collisions));
+    }
+
+    [Fact]
+    public void The_id_scan_sees_every_diagnostic()
+    {
+        // Same vacuity guard as The_family_is_discoverable_at_all, for the non-deduplicating enumeration:
+        // if it found nothing, the collision check above would pass without ever comparing anything.
+        Assert.True(RaskDescriptorsByOwner().Count >= 30,
+            $"expected the whole RASK family, found {RaskDescriptorsByOwner().Count}");
+    }
+
     [Fact]
     public void The_family_is_discoverable_at_all()
     {


### PR DESCRIPTION
## Why

RASK047 was claimed independently by two open branches on the same afternoon — the third id collision in a day, after RASK044/045 were already taken and RASK046 had to be surrendered to Key-opens-the-chain.

I assumed nothing in the build caught this. **That assumption was half wrong, and the half that was right is the dangerous half.**

Roslyn's `RS1019` *does* reject a duplicate diagnostic id — within **one compilation**. So two descriptors colliding inside `Rask.Generators` already fail the build today, and this test is not what covers that case.

But it is per-compilation, and Rask declares descriptors in **three** analyzer assemblies: `Rask.Generators`, `Rask.Cqrs.Generators`, `Rask.Jobs.Generators`. Declaring `RASK022` a second time from a different one builds **completely clean** — warnings-as-errors, analyzers on, whole solution. The family then ships two meanings under one number, with one help link pointing at whichever `docs/diagnostics.md` section was written second.

`DiagnosticDescriptorTests` could not have caught it either, because it was structured to hide it:

```csharp
found[d.Id] = d;   // AllDescriptors() keys a dictionary on the id
```

Two colliding descriptors collapse into one entry, and every invariant the file asserts keeps passing.

## What this does

Enumerates the same three assemblies **without** collapsing by id, deduplicating by the descriptor's own equality instead — `DiagnosticDescriptor` compares its fields, so one descriptor reachable both through `SupportedDiagnostics` and through the static field behind it counts once, while two genuinely different descriptors sharing an id stay two. The failure names both claimants with their declaring type and title.

A companion vacuity guard asserts the scan sees the whole family, since a scan that silently found nothing would pass the collision check forever — the same reason `The_family_is_discoverable_at_all` already exists.

## Verified by making it fail, in both directions

| Duplicate declared in | Build | This test |
|---|---|---|
| `Rask.Generators` (same compilation) | **red** — `error RS1019: Diagnostic Id 'RASK022' is already used by analyzer '__CollisionProbe'` | red |
| `Rask.Cqrs.Generators` (across assemblies) | **green — 0 errors, 0 warnings** | **red** |

The second row is the gap this closes. Both probes were reverted; `git status` is clean apart from the test and the CHANGELOG.

## Testing

`dotnet format` clean; `CI=true dotnet build Rask.slnx -warnaserror -m:1` clean; `scripts/run-unit-local.sh` green; pre-push browser E2E passed. `DiagnosticDescriptorTests` is 6/6.

Test-only plus a CHANGELOG entry — no product code changes.