### PR TITLE
docs(html): point the tag skill at Rask.Html's test project, and correct two stale remarks

### DIFF
--- a/.claude/skills/add-html-tag/SKILL.md
+++ b/.claude/skills/add-html-tag/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-html-tag
-description: Scaffold a new HTML tag component in Rask.Html. Use whenever adding support for an HTML element (e.g. <dialog>, <details>, <progress>, <video>) to the Rask framework. Creates src/Rask.Html/Components/{Tag}.cs and the matching tests/Rask.Core.Tests/Components/{Tag}Tests.cs asserting exact attribute order; the factory is generated automatically.
+description: Scaffold a new HTML tag component in Rask.Html. Use whenever adding support for an HTML element (e.g. <dialog>, <details>, <progress>, <video>) to the Rask framework. Creates src/Rask.Html/Components/{Tag}.cs and the matching tests/Rask.Html.Tests/Components/{Tag}Tests.cs asserting exact attribute order; the factory is generated automatically.
 ---
 
 # add-html-tag
@@ -29,15 +29,19 @@ nullable enabled, expression-bodied single-line members.
   (`AppendUrlAttr` for URL attrs; `AppendAttr(sb, "disabled", null)` for bare boolean attrs).
 
 See `templates/Component.cs`. References: `src/Rask.Html/Components/Span.cs` (simple),
-`Br.cs` (void), `Button.cs` (attributes), base `src/Rask.Core/Element.cs`.
+`Br.cs` (void), `Img.cs` (attributes), base `src/Rask.Core/Element.cs`.
 
-## 2. Test — `tests/Rask.Core.Tests/Components/{Tag}Tests.cs`
+Note the split: Rask.Core still declares the handful of tags its own engine constructs — the shell
+(`Html`/`Body`/`Head`), the error and not-found pages' markup, and `Button` among them. A NEW tag goes in
+`Rask.Html`, so don't take `src/Rask.Core/Components/Button.cs` as the pattern to copy.
+
+## 2. Test — `tests/Rask.Html.Tests/Components/{Tag}Tests.cs`
 Two methods, xUnit:
 - `Render_NullProps_…` — only `TagName` (and self-close shape) renders.
 - `Render_AllPropsSet_…` — **asserts exact attribute order**: id, class, style, data-*, **then**
   tag-specific attrs. Tests assert this ordering — preserve it.
 
-See `templates/ComponentTests.cs`. Reference: `tests/Rask.Core.Tests/Components/ButtonTests.cs`.
+See `templates/ComponentTests.cs`. Reference: `tests/Rask.Html.Tests/Components/ImgTests.cs`.
 
 ## 3. Finish
 This is a new feature → run the **`rask-ship`** gate (format → warnings-as-errors build → the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **The `add-html-tag` skill sent a new tag's test to a project that no longer holds any.** After the
+  HTML/SVG family moved into `Rask.Html`, the skill's component path was updated but its TEST path still
+  read `tests/Rask.Core.Tests/Components/{Tag}Tests.cs`, where the tag tests no longer live — they are in
+  `tests/Rask.Html.Tests/Components/`. Its "attributes" reference also pointed at
+  `src/Rask.Html/Components/Button.cs`, which does not exist: `Button` is one of the handful of tags
+  `Rask.Core` retained for its own shell and error pages. Both corrected, with a note about the split so
+  the retained tags are not taken as the pattern to copy, and the same path fixed in `CLAUDE.md`.
+- **Two native components documented a shadowing that no longer happens.** `NativeButton.Style` and
+  `NativeImage.Source` carried `new` to shadow the generated `Style`/`Source` markup entries; the move
+  stopped those entries being injected into native components, so `new` became CS0109 and was removed —
+  but each `<remarks>` still claimed to shadow them. Rewritten to say why the keyword went, rather than
+  dropped, since nothing being left to shadow is precisely the outcome the split was for.
+
 ### Changed
 - **The HTML/SVG element family moved out of `Rask.Core` into a new `Rask.Html` assembly.** ~155 tag
   components (`Div`, `Span`, `Table`, `Input`, the 41 `<svg>` elements, `Doctype`) now live in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,5 +86,5 @@ started / migration / testing / architecture (`docs/`). Trimming: `samples/Rask.
 `dotnet publish -c Release` with zero IL warnings — new reflection needs a DAM annotation or justified suppression.
 
 ## Conventions
-- **New HTML tag** → `add-html-tag` skill (`src/Rask.Html/Components/{Tag}.cs` + `tests/Rask.Core.Tests/Components/{Tag}Tests.cs`).
+- **New HTML tag** → `add-html-tag` skill (`src/Rask.Html/Components/{Tag}.cs` + `tests/Rask.Html.Tests/Components/{Tag}Tests.cs`).
 - **New diagnostic** → `add-diagnostic` skill. Diagnostic IDs RASK001–048 are documented in `docs/diagnostics.md`.

--- a/src/Rask.Native/Components/NativeButton.cs
+++ b/src/Rask.Native/Components/NativeButton.cs
@@ -13,8 +13,11 @@ public sealed partial class NativeButton : NativeViewComponent
 {
     /// <summary>The visual treatment. Leave <c>null</c> for <see cref="NativeButtonStyle.Filled" />.</summary>
     /// <remarks>
-    ///     Shadows the generated <c>Style</c> markup entry, which a native component has no use for — it
-    ///     renders platform views, never HTML.
+    ///     This carried <c>new</c> until the HTML element family moved into <c>Rask.Html</c>: it shadowed
+    ///     the generated <c>Style</c> markup entry, which a native component has no use for. Those entries
+    ///     are no longer injected into native components, so there is nothing left to shadow and <c>new</c>
+    ///     became CS0109 — which is the outcome the split was for. A tag is not in scope where only
+    ///     platform views can render.
     /// </remarks>
     public NativeButtonStyle? Style { get; set; }
 

--- a/src/Rask.Native/Components/NativeImage.cs
+++ b/src/Rask.Native/Components/NativeImage.cs
@@ -14,8 +14,10 @@ public sealed partial class NativeImage : NativeViewComponent
 {
     /// <summary>A bundled asset name or an absolute URL. Required.</summary>
     /// <remarks>
-    ///     Shadows the generated <c>Source</c> markup entry, which a native component has no use for — it
-    ///     renders platform views, never HTML.
+    ///     This carried <c>new</c> until the HTML element family moved into <c>Rask.Html</c>: it shadowed
+    ///     the generated <c>Source</c> markup entry, which a native component has no use for. Those entries
+    ///     are no longer injected into native components, so there is nothing left to shadow and <c>new</c>
+    ///     became CS0109.
     /// </remarks>
     public required string Source { get; set; }
 


### PR DESCRIPTION
Two follow-ups to the HTML/SVG move (#710), both agreed with its author.

## The `add-html-tag` skill would scaffold into the wrong project

The move updated the skill's **component** path to `src/Rask.Html/Components/{Tag}.cs` but left its **test** path at `tests/Rask.Core.Tests/Components/{Tag}Tests.cs` — a project that no longer holds a single tag test, since they now live in `tests/Rask.Html.Tests/Components/`. The next tag added through the skill would have had its test scaffolded into the wrong place, and the skill is the documented way to add one.

Its "attributes" reference was stale in the opposite direction: it named `src/Rask.Html/Components/Button.cs`, which **does not exist**. `Button` is one of the handful of tags `Rask.Core` retained for its own shell and error pages. Now `Img.cs` (which genuinely asserts the full attribute order), plus a short note about the split so a retained tag isn't taken as the pattern to copy for a new one.

Same test path corrected in `CLAUDE.md`.

## Two native components documented a shadowing that no longer happens

`NativeButton.Style` and `NativeImage.Source` carried `new` to shadow the generated `Style`/`Source` markup entries. Once the element family leaves `Rask.Core`, those entries stop being injected into native components — so `new` became CS0109 and was correctly removed when #710 landed. But each `<remarks>` still asserted the shadowing, leaving two public members documented with something that is no longer true.

Rewritten to record *why* the keyword went rather than deleted, because nothing being left to shadow is precisely the outcome the split was for: a tag should not be in scope where only platform views can render, which is what RASK032 and RASK048 exist to enforce.

## Note on how this was found

The CS0109 pair is a **cross-PR break** — #710 and #719 each built clean on the base it was gated against, and only failed in the composition. That was the third instance of that class in one day, and the reason I now re-build the merge commit after landing anything: green plus green does not compose to green.

## Testing

Documentation and comments only; no behaviour change. `dotnet format` clean; `CI=true dotnet build Rask.slnx -warnaserror -m:1` 0 errors 0 warnings; `scripts/run-unit-local.sh` green; pre-push browser E2E passed and the CLI build gate passed 
(it triggers here because the push touches the generators' packages).