### PR TITLE
fix(skills): make the add-html-tag test template compile, and add the <var> element

### DIFF
--- a/.claude/skills/add-html-tag/SKILL.md
+++ b/.claude/skills/add-html-tag/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-html-tag
-description: Scaffold a new HTML tag component in Rask.Html. Use whenever adding support for an HTML element (e.g. <dialog>, <details>, <progress>, <video>) to the Rask framework. Creates src/Rask.Html/Components/{Tag}.cs and the matching tests/Rask.Core.Tests/Components/{Tag}Tests.cs asserting exact attribute order; the factory is generated automatically.
+description: Scaffold a new HTML tag component in Rask.Html. Use whenever adding support for an HTML element (e.g. <dialog>, <details>, <progress>, <video>) to the Rask framework. Creates src/Rask.Html/Components/{Tag}.cs and the matching tests/Rask.Html.Tests/Components/{Tag}Tests.cs asserting exact attribute order; the factory is generated automatically.
 ---
 
 # add-html-tag
@@ -31,13 +31,15 @@ nullable enabled, expression-bodied single-line members.
 See `templates/Component.cs`. References: `src/Rask.Html/Components/Span.cs` (simple),
 `Br.cs` (void), `Button.cs` (attributes), base `src/Rask.Core/Element.cs`.
 
-## 2. Test — `tests/Rask.Core.Tests/Components/{Tag}Tests.cs`
+## 2. Test — `tests/Rask.Html.Tests/Components/{Tag}Tests.cs`
 Two methods, xUnit:
 - `Render_NullProps_…` — only `TagName` (and self-close shape) renders.
 - `Render_AllPropsSet_…` — **asserts exact attribute order**: id, class, style, data-*, **then**
   tag-specific attrs. Tests assert this ordering — preserve it.
 
-See `templates/ComponentTests.cs`. Reference: `tests/Rask.Core.Tests/Components/ButtonTests.cs`.
+See `templates/ComponentTests.cs`. Reference: `tests/Rask.Html.Tests/Components/ProgressTests.cs`.
+The test class is `partial` and derives `RaskMarkup` — that is how it gets the tag's builder entry,
+since Rask.Html's entries are injected into a consumer's hosts rather than inherited (RASK036).
 
 ## 3. Finish
 This is a new feature → run the **`rask-ship`** gate (format → warnings-as-errors build → the

--- a/.claude/skills/add-html-tag/templates/ComponentTests.cs
+++ b/.claude/skills/add-html-tag/templates/ComponentTests.cs
@@ -1,22 +1,30 @@
-// Template — copy to tests/Rask.Core.Tests/Components/{Tag}Tests.cs.
+// Template — copy to tests/Rask.Html.Tests/Components/{Tag}Tests.cs.
 // Asserts exact attribute order: id, class, style, data-*, then tag-specific.
-#pragma warning disable RASK014 // tests construct components directly
-namespace Rask.Core.Tests.Components;
+//
+// `partial` and `: RaskMarkup` are both load-bearing. The tag family ships from Rask.Html, so its
+// builder entries are INJECTED into this project's own markup hosts rather than inherited from
+// Rask.Core — a non-partial host gets none of them (RASK036) and `{Tag}` would not resolve.
+namespace Rask.Html.Tests.Components;
 
-public class {Tag}Tests
+public partial class {Tag}Tests : global::Rask.Core.RaskMarkup
 {
     [Fact]
-    public void Render_NullProps_EmitsBareTag()
-    {
-        var html = HtmlSerializer.Serialize(new {Tag}());
-        Assert.Equal("<{tag}></{tag}>", html);          // self-closing: "<{tag}>"
-    }
+    public void Render_NullProps_ReturnsOpenAndCloseTags() =>
+        Assert.Equal("<{tag}></{tag}>", {Tag}.ToHtml());          // self-closing: "<{tag} />"
 
     [Fact]
-    public void Render_AllPropsSet_EmitsAttributesInOrder()
-    {
-        var c = new {Tag} { Id = "x", Class = "c", Name = "n", Open = true };
-        var html = HtmlSerializer.Serialize(c);
-        Assert.Equal("""<{tag} id="x" class="c" name="n" open></{tag}>""", html);
-    }
+    public void Render_AllPropsSet_EmitsExpectedAttributes() =>
+        Assert.Equal(
+            "<{tag} id=\"i\" class=\"c\" style=\"s\" data-k=\"v\" name=\"n\" open></{tag}>",
+            {Tag}
+                .Name("n")
+                .Open(true)
+                .Id("i")
+                .Class("c")
+                .Style("s")
+                .Data(new Dictionary<string, string?> { ["k"] = "v" }).ToHtml());
+
+    [Fact]
+    public void Render_StringChild_EncodesText() =>
+        Assert.Equal("<{tag}>&lt;x&gt;</{tag}>", {Tag}["<x>"].ToHtml());
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **`<var>`** — the one element MDN lists that Rask had no component for (part of #694). A variable in a
+  mathematical or programming context; not emphasis (`em`) and not literal code (`code`).
+
 ### Changed
 - **The HTML/SVG element family moved out of `Rask.Core` into a new `Rask.Html` assembly.** ~155 tag
   components (`Div`, `Span`, `Table`, `Input`, the 41 `<svg>` elements, `Doctype`) now live in

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -171,7 +171,7 @@ rather than sending you to a search engine.
 ### Text & inline
 
 [`a`][a], [`abbr`][abbr], [`b`][b], [`bdi`][bdi], [`bdo`][bdo], [`br`][br], [`cite`][cite], [`code`][code], [`data`][data], [`dfn`][dfn], [`del`][del], [`em`][em], [`i`][i], [`ins`][ins], [`kbd`][kbd],
-[`mark`][mark], [`q`][q], [`ruby`][ruby]/[`rp`][rp]/[`rt`][rt], [`s`][s], [`samp`][samp], [`small`][small], [`span`][span], [`strong`][strong], [`sub`][sub], [`sup`][sup], [`time`][time], [`u`][u], [`wbr`][wbr]:
+[`mark`][mark], [`q`][q], [`ruby`][ruby]/[`rp`][rp]/[`rt`][rt], [`s`][s], [`samp`][samp], [`small`][small], [`span`][span], [`strong`][strong], [`sub`][sub], [`sup`][sup], [`time`][time], [`u`][u], [`var`][var], [`wbr`][wbr]:
 
 <!-- demo:elements-text -->
 
@@ -327,6 +327,7 @@ See also: [Getting started](getting-started.md) for building your first componen
 [tr]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tr
 [track]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/track
 [u]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/u
+[var]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/var
 [ul]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ul
 [video]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video
 [wbr]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/wbr

--- a/samples/Rask.Example.Shared/Features/Elements/ElementsTextDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Elements/ElementsTextDemo.cs
@@ -13,7 +13,7 @@ public sealed partial class ElementsTextDemo : Component
         ],
         P[
             "Inline code ", Code["Div()[…]"], ", a key ", Kbd["Ctrl"], "+", Kbd["C"],
-            ", sample output ", Samp["exit 0"], ", a variable x", Sub["1"], " to the n", Sup["2"], "."
+            ", sample output ", Samp["exit 0"], ", a variable ", Var["x"], Sub["1"], " to the n", Sup["2"], "."
         ],
         P[
             "Define a term: ", Dfn["Rask"], " is a C# UI framework. Abbreviate it ", Abbr["UI"],

--- a/src/Rask.Html/Components/Var.cs
+++ b/src/Rask.Html/Components/Var.cs
@@ -1,0 +1,11 @@
+namespace Rask.Html.Components;
+
+/// <summary>
+///     A variable in a mathematical expression or a programming context — a name standing in for a value,
+///     rendered italic by default. Not for emphasis (<c>em</c>) and not for literal code (<c>code</c>).
+///     <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/var">MDN</see>
+/// </summary>
+public sealed partial class Var : Element
+{
+    protected override string TagName => "var";
+}

--- a/tests/Rask.Example.Shared.Tests/Guides/DemoMarkup.golden.txt
+++ b/tests/Rask.Example.Shared.Tests/Guides/DemoMarkup.golden.txt
@@ -4783,6 +4783,7 @@ code
 kbd
 kbd
 samp
+var
 sub
 sup
 p

--- a/tests/Rask.Html.Tests/Components/VarTests.cs
+++ b/tests/Rask.Html.Tests/Components/VarTests.cs
@@ -1,0 +1,22 @@
+namespace Rask.Html.Tests.Components;
+
+public partial class VarTests : global::Rask.Core.RaskMarkup
+{
+    [Fact]
+    public void Render_NullProps_ReturnsOpenAndCloseTags() =>
+        Assert.Equal("<var></var>", Var.ToHtml());
+
+    [Fact]
+    public void Render_AllPropsSet_EmitsExpectedAttributes() =>
+        Assert.Equal(
+            "<var id=\"i\" class=\"c\" style=\"s\" data-k=\"v\"></var>",
+            Var
+                .Id("i")
+                .Class("c")
+                .Style("s")
+                .Data(new Dictionary<string, string?> { ["k"] = "v" }).ToHtml());
+
+    [Fact]
+    public void Render_StringChild_EncodesText() =>
+        Assert.Equal("<var>&lt;x&gt;</var>", Var["<x>"].ToHtml());
+}


### PR DESCRIPTION
## Summary

**#722 landed the skill's path fix while this was open — but it corrected `SKILL.md` only, and left
`templates/ComponentTests.cs` untouched.** That template is what actually gets copied, and it is stale
in four ways at once:

```
// Template — copy to tests/Rask.Core.Tests/Components/{Tag}Tests.cs.   <- moved project
namespace Rask.Core.Tests.Components;                                   <- moved namespace
public class {Tag}Tests                                                 <- not partial, no RaskMarkup
    HtmlSerializer.Serialize(new {Tag}())                               <- pre-chain style
```

So a reader following the corrected `SKILL.md` to the right *directory* still copies a file that does
not compile there. This rewrites it to match what the moved tests actually look like, and states the
part that is easy to get wrong and hard to diagnose:

```csharp
public partial class {Tag}Tests : global::Rask.Core.RaskMarkup
```

`partial` and the `RaskMarkup` base are load-bearing. Rask.Html's builder entries are *injected* into a
consumer's markup hosts rather than inherited from Rask.Core, so a non-partial host gets none of them
(RASK036) and `{Tag}` simply would not resolve — the failure reads as "the tag does not exist", which
points nowhere near the missing modifier.

**Also: `<var>`** — the one element MDN lists that Rask had no component for, part of #694.

## Why the two are together

The second is how the first was found. I set out only to fix the skill, and the honest way to verify a
scaffolding template is to scaffold with it rather than read it — which is what surfaced that the
template was stale in ways `SKILL.md` alone could not fix, and produced a working component on the way.

## Testing

- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 errors, 0 warnings.
- `dotnet format --verify-no-changes` — clean.
- Full unit suite — 49 assemblies, green (`Rask.Html.Tests` 464, `Rask.Example.Shared.Tests` 338).
- `DemoMarkupGoldenTests` caught the demo change, as designed. Regenerated with `RASK_UPDATE_GOLDEN=1`;
  the diff is one line, `+var`, which is the whole review.

## User-facing surface

- `docs/elements.md` lists `var` in **Text & inline** with its MDN link.
- `ElementsTextDemo` uses it: that demo previously wrote *"a variable x"* as plain prose, which is
  precisely the case `<var>` exists for.
- CHANGELOG entry under `### Added`.

Cleanly separable if you would rather `<var>` landed on its own — the template fix stands alone.
