### PR TITLE
fix(gates): classify a build failure by error kind before blaming the branch

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -32,7 +32,11 @@ fi
 #
 # Leaving these out meant a whole feature could land ungated — the playground tutorial was largely a
 # samples/ + docs/ change, and reported "no code changes staged".
-if ! git diff --cached --name-only | grep -E '^(src/|samples/|docs/|tests/|benchmarks/|Rask\.slnx$|Directory\.)' >/dev/null; then
+#   scripts/ and .githooks/ are in here because the gates are themselves code with tests now:
+#   scripts/run-unit-local.sh runs scripts/tests/*.test.sh, which covers the failure classification
+#   that decides whether a red gate blames your branch or your machine (#718). Without these prefixes a
+#   change to the gate logic is the one change that skips the gate.
+if ! git diff --cached --name-only | grep -E '^(src/|samples/|docs/|tests/|benchmarks/|scripts/|\.githooks/|Rask\.slnx$|Directory\.)' >/dev/null; then
   echo "pre-commit: no code changes staged — skipping the format + unit gate."
   exit 0
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -20,8 +20,10 @@ else
   echo "pre-push: running the local E2E gate (browser journeys)."
   echo "          bypass with 'git push --no-verify' or RASK_SKIP_E2E=1 (e.g. docs-only pushes)."
 
+  # As with the CLI gate below: run-e2e-local.sh classifies a build failure by error kind and has
+  # already named the culprit, so this line stays neutral about which one it was (#718).
   if ! "$root/scripts/run-e2e-local.sh"; then
-    echo "pre-push: E2E gate FAILED — push aborted. Fix the failing journey, or bypass with --no-verify." >&2
+    echo "pre-push: E2E gate FAILED — push aborted. Fix the cause named above, or bypass with --no-verify." >&2
     exit 1
   fi
 fi
@@ -43,8 +45,10 @@ else
   echo "pre-push: this push touches the generators or the packages they emit — running the CLI build gate."
   echo "          bypass with 'git push --no-verify' or RASK_SKIP_CLI_BUILD_E2E=1."
 
+  # The gate classifies its own failure by error kind and has already said which culprit it found —
+  # a NETSDK-only failure is the machine, not the branch (#718). Don't second-guess it here.
   if ! "$root/scripts/run-cli-build-e2e.sh"; then
-    echo "pre-push: CLI build gate FAILED — push aborted. The code the CLI writes doesn't compile." >&2
+    echo "pre-push: CLI build gate FAILED — push aborted." >&2
     exit 1
   fi
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ them until tagged releases begin.
   mathematical or programming context; not emphasis (`em`) and not literal code (`code`).
 
 ### Fixed
+- **A gate that failed because the machine could not build browser targets blamed your code for it**
+  (#718). A concurrent `dotnet workload install` anywhere on the machine bumps the shared workload
+  manifests for the whole SDK band, and for a moment they reference Emscripten packs that are not on disk
+  — so `wasm-tools` resolves as missing everywhere, in every worktree, while `dotnet workload list` still
+  reports it installed. Every browser-targeting build then fails at evaluation with `NETSDK1147`, and the
+  CLI build gate announced *"the code the CLI writes doesn't compile"*. Measured on the failing run: **0
+  `error CS`, 24 `error NETSDK1147`**; the same gate passed minutes later with no change. It cost two
+  sessions about an hour between them. `scripts/lib/build-failure.sh` classifies a captured build log by
+  error kind and each gate prints the matching verdict — `code` keeps the old message, `workload` says
+  plainly that this is not your branch and how to confirm the install in flight, `sdk` covers other
+  `NETSDK` failures, and `unknown` (neither error kind present) stops the gates claiming a compile failure
+  for a failing assertion or a timeout. `CS` wins when both appear. Applied to the CLI build gate, the
+  E2E gate's graph build, and both `.githooks/pre-push` messages, with a table test
+  (`scripts/tests/build-failure-kind.test.sh`) that `run-unit-local.sh` runs first — and `scripts/` and
+  `.githooks/` added to the pre-commit path filter, since a change to the gate logic was previously the
+  one change that skipped the gate.
 - **The `add-html-tag` skill sent a new tag's test to a project that no longer holds any.** After the
   HTML/SVG family moved into `Rask.Html`, the skill's component path was updated but its TEST path still
   read `tests/Rask.Core.Tests/Components/{Tag}Tests.cs`, where the tag tests no longer live — they are in

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -109,6 +109,18 @@ Every change passes this gate before a PR (the `rask-ship` skill):
   (bypass with `git push --no-verify` or `RASK_SKIP_CLI_BUILD_E2E=1`). The gates are opted into by
   `RASK_CLI_BUILD_E2E=1`, which the script exports; without it every case reports **SKIPPED** rather than
   passing silently, so an un-run gate is always visible in the test output.
+- **A red gate names the culprit it actually found.** Both the CLI build gate and the E2E gate build
+  browser targets, so both can fail for a reason that has nothing to do with your branch — most often
+  `NETSDK1147`, the `wasm-tools` workload resolving as missing because a workload install elsewhere on
+  the machine bumped the shared manifests mid-flight (`dotnet workload list` keeps listing it as
+  installed throughout, so it will not tell you). They used to report that as *"the code the CLI writes
+  doesn't compile"*, which cost two sessions an hour chasing a scaffolder bug that did not exist.
+  `scripts/lib/build-failure.sh` now classifies a captured build log by error kind — `code` (`error CS`
+  present, your branch), `workload` (`NETSDK1147` and no `CS`), `sdk` (another `NETSDK`), `unknown`
+  (neither, so not a compile failure at all) — and each gate prints the matching explanation. `CS` wins
+  when both appear: a workload problem does not excuse real compile errors. The decision is four rows of
+  bash that had already been wrong once, so it has a table test,
+  `scripts/tests/build-failure-kind.test.sh`, run by `run-unit-local.sh` before anything else.
 - **The deploy gate runs locally, on pushes that touch the deploy path.**
   `scripts/run-deploy-e2e-local.sh` points the real `rask deploy` at a throwaway container standing in for
   a bare VPS — sshd plus its own Docker daemon (`docker:dind`, privileged) — and asserts on what happened

--- a/scripts/lib/build-failure.sh
+++ b/scripts/lib/build-failure.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Shared failure classification for the local gates.
+#
+# A gate that fails is only useful if it names the right culprit. Both the CLI build gate and the E2E
+# gate build browser targets, and both used to report *any* failure as "the generated code doesn't
+# compile" — which is a lie whenever the machine simply cannot build browser targets at that moment.
+#
+# The case that motivated this (#718): a concurrent `sudo dotnet workload install <anything>` installs a
+# new workload SET and bumps the shared mono.toolchain.current / emscripten.current manifests for the
+# whole SDK band. Between the manifest bump and the pack restore, the manifests reference Emscripten
+# packs that are not on disk yet, so `wasm-tools` resolves as MISSING — machine-wide, in every worktree —
+# while `dotnet workload list` still cheerfully lists it as installed. Measured on the failing run: 0
+# `error CS`, 24 `error NETSDK1147`. It clears on its own when the installing process exits, and racing
+# it with your own `dotnet workload restore` does not help.
+#
+# It cost two sessions about an hour between them, chasing a scaffolder bug that did not exist. The
+# distinction is a couple of greps, and getting it wrong trains people to distrust the gate — which is
+# worse than the gate simply failing.
+#
+# Source it, don't execute it:  . "$root/scripts/lib/build-failure.sh"
+
+# Classify a captured build/test log. Echoes exactly one kind:
+#
+#   code     — real compile errors (`error CS…`). The gate's own message is correct; the branch is broken.
+#   workload — `error NETSDK1147` and no CS errors. A browser target could not resolve its workload.
+#   sdk      — some other `error NETSDK…` and no CS errors. An SDK/restore problem, still not the branch.
+#   unknown  — neither appears. The gate failed somewhere that is not a compile at all (a failing
+#              assertion, a timeout, a crashed host), so claiming "it doesn't compile" would be wrong too.
+#
+# CS wins when both appear: a NETSDK error alongside genuine compile errors does not excuse them.
+rask_build_failure_kind() {
+  local log="${1:-}"
+
+  [ -n "$log" ] && [ -f "$log" ] || { printf 'unknown\n'; return 0; }
+
+  # `grep -c`, never `grep -q`. With `set -o pipefail` a `-q` grep exits on the first match, the writer
+  # takes SIGPIPE, and the pipeline reports failure — the same trap that let a 421-file commit past the
+  # pre-commit hook (see the note in .githooks/pre-commit). `|| true` because grep exits 1 on no match.
+  local cs netsdk workload
+  cs=$(grep -Ec 'error[[:space:]]+CS[0-9]+' "$log" 2>/dev/null || true)
+  netsdk=$(grep -Ec 'error[[:space:]]+NETSDK[0-9]+' "$log" 2>/dev/null || true)
+  workload=$(grep -Ec 'error[[:space:]]+NETSDK1147' "$log" 2>/dev/null || true)
+
+  if [ "${cs:-0}" -gt 0 ]; then
+    printf 'code\n'
+  elif [ "${workload:-0}" -gt 0 ]; then
+    printf 'workload\n'
+  elif [ "${netsdk:-0}" -gt 0 ]; then
+    printf 'sdk\n'
+  else
+    printf 'unknown\n'
+  fi
+}
+
+# Print the operator-facing explanation for a kind, to stderr.
+#
+#   $1 — kind, as returned by rask_build_failure_kind
+#   $2 — gate label, e.g. "CLI build gate"
+#   $3 — the message to use for the `code` kind, which is the only one the calling gate can word itself
+rask_explain_build_failure() {
+  local kind="${1:-unknown}" gate="${2:-gate}" code_message="${3:-}"
+
+  case "$kind" in
+    code)
+      [ -n "$code_message" ] && echo "$gate: $code_message" >&2
+      ;;
+    workload)
+      {
+        echo "$gate: this is NOT your branch."
+        echo
+        echo "  Your machine cannot build browser targets right now: the 'wasm-tools' workload is"
+        echo "  unresolvable (error NETSDK1147), and nothing failed to compile (0 'error CS')."
+        echo
+        echo "  The usual cause is a workload install in flight from another session or another worktree —"
+        echo "  it bumps the shared manifests for the whole SDK band machine-wide, and for a moment they"
+        echo "  reference Emscripten packs that are not on disk yet. 'dotnet workload list' still lists"
+        echo "  wasm-tools as installed throughout, so it will not tell you this."
+        echo
+        echo "  Check for one:"
+        echo "    ps aux | grep 'workload install'"
+        echo "    ls -la /usr/local/share/dotnet/metadata/workloads/InstalledWorkloadSets/"
+        echo
+        echo "  A workload set dated in the last few minutes is the cause. Wait for that process to exit"
+        echo "  and re-run. Do NOT run 'dotnet workload restore' alongside it — racing it does not help."
+        echo
+        echo "  A stale SDK feature-band registration (a workload registered for an SDK that is no longer"
+        echo "  installed, with no global.json pinning one) produces the same NETSDK1147."
+      } >&2
+      ;;
+    sdk)
+      {
+        echo "$gate: this looks like an SDK or restore problem, not your branch."
+        echo
+        echo "  The build reported 'error NETSDK…' and nothing failed to compile (0 'error CS'), so the"
+        echo "  code is not what broke. Read the NETSDK error above — it names the missing piece."
+      } >&2
+      ;;
+    *)
+      {
+        echo "$gate: failed without any compile error."
+        echo
+        echo "  Neither 'error CS' nor 'error NETSDK' appears in the output, so this is not a build"
+        echo "  failure — look for a failing assertion, a timeout, or a host that exited early."
+      } >&2
+      ;;
+  esac
+}

--- a/scripts/run-cli-build-e2e.sh
+++ b/scripts/run-cli-build-e2e.sh
@@ -22,20 +22,45 @@ fi
 root="$(git rev-parse --show-toplevel)"
 cd "$root"
 
+# shellcheck source=lib/build-failure.sh
+. "$root/scripts/lib/build-failure.sh"
+
 # The gates read this to decide whether to run; without it every case reports SKIPPED.
 export RASK_CLI_BUILD_E2E=1
+
+# Everything below is teed here so a failure can be classified by ERROR KIND before this gate blames
+# anyone. It used to report every failure as "the code the CLI writes doesn't compile", which is a lie
+# when the machine cannot build browser targets at that moment — see scripts/lib/build-failure.sh.
+log="$(mktemp -t rask-cli-build-gate.XXXXXX)"
+trap 'rm -f "$log"' EXIT
+
+# `|| status=$?` rather than letting `set -e` fire: this gate has to reach the classification below.
+# `set -o pipefail` (set above) is what makes `dotnet … | tee` report dotnet's status rather than tee's —
+# without it every run through a pipe reads as a pass.
+status=0
 
 echo "==> Build the CLI test project (Release)"
 # MinVerSkip is deliberately NOT set: the gate packs the Rask packages and reads the packed version off
 # the nupkg filename, so MinVer must stamp a real version here.
-dotnet build tests/Rask.Cli.Tests/Rask.Cli.Tests.csproj -c Release -m:1
+dotnet build tests/Rask.Cli.Tests/Rask.Cli.Tests.csproj -c Release -m:1 2>&1 | tee "$log" || status=$?
 
-echo "==> CLI build gates (scaffold output + tutorial walk-through must compile)"
-# Serial (-m:1 above, and one pack at a time inside the fixture): the gates share a single packed feed,
-# built lazily on first use.
-dotnet test tests/Rask.Cli.Tests/Rask.Cli.Tests.csproj -c Release --no-build \
-  --filter "FullyQualifiedName~BuildE2ETests|FullyQualifiedName~TutorialWalkthroughE2ETests" \
-  --logger "console;verbosity=normal"
+if [ "$status" -eq 0 ]; then
+  echo "==> CLI build gates (scaffold output + tutorial walk-through must compile)"
+  # Serial (-m:1 above, and one pack at a time inside the fixture): the gates share a single packed feed,
+  # built lazily on first use.
+  dotnet test tests/Rask.Cli.Tests/Rask.Cli.Tests.csproj -c Release --no-build \
+    --filter "FullyQualifiedName~BuildE2ETests|FullyQualifiedName~TutorialWalkthroughE2ETests" \
+    --logger "console;verbosity=normal" 2>&1 | tee -a "$log" || status=$?
+fi
+
+if [ "$status" -ne 0 ]; then
+  echo >&2
+  rask_explain_build_failure \
+    "$(rask_build_failure_kind "$log")" \
+    "CLI build gate" \
+    "FAILED — the code the CLI writes doesn't compile."
+  exit "$status"
+fi
 
 echo
 echo "==> CLI build gate passed."

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -21,9 +21,17 @@ fi
 root="$(git rev-parse --show-toplevel)"
 cd "$root"
 
+# shellcheck source=lib/build-failure.sh
+. "$root/scripts/lib/build-failure.sh"
+
 # The playground publish below needs the native relink (see the note there), which needs the wasm-tools
 # workload + emscripten. Check up front: without it the publish fails several minutes in, with an error
 # about a missing runtime pack rather than about a missing workload.
+#
+# This catches wasm-tools never having been installed. It does NOT catch the case in #718 — a concurrent
+# workload install elsewhere on the machine making it transiently unresolvable — because `dotnet workload
+# list` keeps listing it as installed throughout. That one surfaces as NETSDK1147 during the build below
+# and is classified there.
 if ! dotnet workload list 2>/dev/null | grep -q '^wasm-tools'; then
   echo "run-e2e-local: the 'wasm-tools' workload is not installed." >&2
   echo "  The playground publishes with a native relink so its tutorial can run SQLite in the browser." >&2
@@ -40,7 +48,23 @@ fi
 # (WasmExampleAppFixture boots this build with `dotnet run --no-build`). One consistent mode = no drift,
 # and it skips the slow, flaky relink. Serial (-m:1): the nested WASM publish double-builds Rask.Core.dll.
 echo "==> Build the E2E graph once (Release, serial, prebuilt WASM runtime)"
-dotnet build Rask.slnx -c Release -m:1 -p:WasmBuildNative=false
+# Teed and classified by error kind: this build is the first thing to fail when the machine cannot build
+# browser targets, and reporting that as a broken journey sends people to debug a test that is fine
+# (#718). `set -o pipefail` above is what makes the pipeline report dotnet's status rather than tee's.
+build_log="$(mktemp -t rask-e2e-build.XXXXXX)"
+trap 'rm -f "$build_log"' EXIT
+
+build_status=0
+dotnet build Rask.slnx -c Release -m:1 -p:WasmBuildNative=false 2>&1 | tee "$build_log" || build_status=$?
+
+if [ "$build_status" -ne 0 ]; then
+  echo >&2
+  rask_explain_build_failure \
+    "$(rask_build_failure_kind "$build_log")" \
+    "E2E gate" \
+    "FAILED — the E2E graph does not compile."
+  exit "$build_status"
+fi
 
 echo "==> Publish the samples the E2E fixtures boot"
 # Server shard boots the *published* host; the WASM static-host shards need their published wwwroot bundle.

--- a/scripts/run-unit-local.sh
+++ b/scripts/run-unit-local.sh
@@ -33,6 +33,15 @@ fi
 root="$(git rev-parse --show-toplevel)"
 cd "$root"
 
+# Cheap and first: the gates' own shared logic. rask_build_failure_kind decides whether a red gate tells
+# you your branch is broken or your machine is busy, and it is plain bash, so nothing else would catch a
+# regression in it.
+echo "==> Gate script tests"
+for t in scripts/tests/*.test.sh; do
+  [ -e "$t" ] || continue
+  bash "$t"
+done
+
 echo "==> Build once (Release, no WASM bundle: -p:RaskWasm=false -p:WasmBuildNative=false)"
 dotnet build Rask.slnx -c Release -p:RaskWasm=false -p:WasmBuildNative=false -p:MinVerSkip=true
 

--- a/scripts/tests/build-failure-kind.test.sh
+++ b/scripts/tests/build-failure-kind.test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Table test for rask_build_failure_kind (scripts/lib/build-failure.sh).
+#
+# This is three predicates over two counts, and it decides whether a red gate tells you your branch is
+# broken or your machine is busy. Getting it wrong is exactly the failure #718 reported — an hour lost to
+# a scaffolder bug that did not exist — so every row is stated rather than left to the two cases someone
+# happened to try. Same reasoning as BakeScopedAssetsTask.IsNodeReuseBakeFailure's table test (#690),
+# which was also a handful of booleans that had already been wrong once with nothing objecting.
+#
+# Usage:  scripts/tests/build-failure-kind.test.sh   (run by scripts/run-unit-local.sh)
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+# shellcheck source=../lib/build-failure.sh
+. "$root/scripts/lib/build-failure.sh"
+
+tmp="$(mktemp -d -t rask-build-failure-test.XXXXXX)"
+trap 'rm -rf "$tmp"' EXIT
+
+failures=0
+checked=0
+
+# assert <name> <expected-kind> <log-contents>
+assert() {
+  local name="$1" expected="$2" contents="$3"
+  local log="$tmp/$(echo "$name" | tr -c 'A-Za-z0-9' '_').log"
+
+  printf '%s' "$contents" > "$log"
+
+  local actual
+  actual="$(rask_build_failure_kind "$log")"
+  checked=$((checked + 1))
+
+  if [ "$actual" = "$expected" ]; then
+    printf '  ok   %-52s -> %s\n' "$name" "$actual"
+  else
+    printf '  FAIL %-52s -> %s (expected %s)\n' "$name" "$actual" "$expected" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+echo "==> rask_build_failure_kind"
+
+# The case the gate always got right, and must keep getting right.
+assert "compile errors alone" code \
+  '/src/App/Program.cs(12,9): error CS0246: The type or namespace name '\''Foo'\'' could not be found
+/src/App/Program.cs(14,5): error CS1002: ; expected
+'
+
+# The case from #718, in the shape it actually arrived: many NETSDK1147, not one CS.
+assert "NETSDK1147 alone is the machine, not the branch" workload \
+  '/proj/App.csproj : error NETSDK1147: To build this project, the following workloads must be installed: wasm-tools
+/proj/Other.csproj : error NETSDK1147: To build this project, the following workloads must be installed: wasm-tools
+'
+
+# Both present: a workload problem does not excuse real compile errors, so the branch is still blamed.
+assert "CS wins when both appear" code \
+  '/proj/App.csproj : error NETSDK1147: To build this project, the following workloads must be installed: wasm-tools
+/src/App/Program.cs(3,1): error CS0103: The name '\''Bar'\'' does not exist in the current context
+'
+
+# A different SDK failure is still not the branch, but it is not the wasm-tools story either.
+assert "other NETSDK errors report as an SDK problem" sdk \
+  '/proj/App.csproj : error NETSDK1045: The current .NET SDK does not support targeting .NET 99.0.
+'
+
+# A failing assertion is not a compile failure, and saying "it does not compile" would be wrong here too.
+assert "a failing test is neither" unknown \
+  'Failed Rask.Cli.Tests.CliBuildE2ETests.Scaffold_Compiles
+  Assert.Equal() Failure: Values differ
+Total tests: 27   Passed: 26   Failed: 1
+'
+
+# A build that failed before emitting any diagnostic (killed host, timeout, crashed node).
+assert "empty log" unknown ''
+
+# MSBuild writes warnings with the same shape; a warning must never be read as a failure kind.
+assert "warnings only are not errors" unknown \
+  '/proj/App.csproj : warning NETSDK1137: It is no longer necessary to use Microsoft.NET.Sdk.Web
+/src/App/Program.cs(5,9): warning CS0168: The variable '\''e'\'' is declared but never used
+'
+
+# A path that does not exist must not crash the gate mid-failure.
+echo "==> missing log file"
+checked=$((checked + 1))
+missing="$(rask_build_failure_kind "$tmp/does-not-exist.log")"
+if [ "$missing" = "unknown" ]; then
+  printf '  ok   %-52s -> %s\n' "missing log file" "$missing"
+else
+  printf '  FAIL %-52s -> %s (expected unknown)\n' "missing log file" "$missing" >&2
+  failures=$((failures + 1))
+fi
+
+# No argument at all, same reason.
+checked=$((checked + 1))
+none="$(rask_build_failure_kind)"
+if [ "$none" = "unknown" ]; then
+  printf '  ok   %-52s -> %s\n' "no argument" "$none"
+else
+  printf '  FAIL %-52s -> %s (expected unknown)\n' "no argument" "$none" >&2
+  failures=$((failures + 1))
+fi
+
+echo
+if [ "$failures" -ne 0 ]; then
+  echo "build-failure-kind: $failures of $checked checks FAILED." >&2
+  exit 1
+fi
+
+echo "build-failure-kind: $checked checks passed."


### PR DESCRIPTION
## Summary

Both the CLI build gate and the E2E gate build browser targets, so both fail for reasons that have nothing to do with your branch. The commonest is `NETSDK1147`: a concurrent `dotnet workload install` anywhere on the machine installs a new workload set and bumps the shared `mono.toolchain.current` / `emscripten.current` manifests for the whole SDK band. Between the manifest bump and the pack restore they reference Emscripten packs that are not on disk yet, so `wasm-tools` resolves as missing **machine-wide, in every worktree** — while `dotnet workload list` still lists it as installed.

The CLI gate reported that as *"the code the CLI writes doesn't compile"*. Measured on the failing run: **0 `error CS`, 24 `error NETSDK1147`**; the same gate passed minutes later with no change. It cost two sessions about an hour between them, chasing a scaffolder bug that did not exist.

A gate that goes red for an environmental reason *and blames your code* trains people to distrust it, which is worse than it simply failing.

## What changed

`scripts/lib/build-failure.sh` classifies a captured build log into one of four kinds:

| kind | condition | what the gate says |
|---|---|---|
| `code` | `error CS` present | the gate's existing message — the branch is broken |
| `workload` | `NETSDK1147`, no `CS` | this is not your branch; how to confirm the install in flight |
| `sdk` | another `NETSDK`, no `CS` | an SDK/restore problem, still not the branch |
| `unknown` | neither | not a compile failure at all — a failing assertion, a timeout, a host that exited early |

`CS` wins when both appear: a workload problem does not excuse real compile errors.

Applied to the CLI build gate, the E2E gate's graph build (it fails first, and for the same reason), and both `.githooks/pre-push` messages, which now stay neutral about a culprit the script has already named.

## Testing

- `scripts/tests/build-failure-kind.test.sh` — a table test over all nine rows, run by `run-unit-local.sh` before anything else. The decision is four predicates over two counts and it decides whether a red gate sends you to your own diff or to `ps aux`, so it is stated rather than left to the two cases someone happened to try. Same reasoning as `BakeScopedAssetsTask.IsNodeReuseBakeFailure`'s table test in #690.
- **Verified by making it fail**: reordering the classifier to check `workload` before `cs` turns the "CS wins when both appear" row red; restoring it goes green. The first attempt at that break silently did not apply, and the suite stayed green — which is exactly the false negative the check exists to rule out, so it is worth stating that the red was observed.
- `scripts/` and `.githooks/` added to the pre-commit path filter. A change to the gate logic was otherwise the one change that skipped the gate.
- Full local format + unit gate green; E2E gate green on push (this PR edits `run-e2e-local.sh`, so that run is the real verification of the edit).

## Notes

`grep -c … || true` throughout, never `grep -q`: with `pipefail` a `-q` grep exits on the first match, the writer takes `SIGPIPE`, and the pipeline reports failure — the same trap already documented in `.githooks/pre-commit`, where it once let a 421-file commit through unchecked.

Closes #718
