### PR TITLE
fix(gates): stop the pre-push gates blaming your branch for your machine

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -14,16 +14,67 @@ set -euo pipefail
 
 root="$(git rev-parse --show-toplevel)"
 
+gate_logs="${TMPDIR:-/tmp}/rask-pre-push-$$"
+mkdir -p "$gate_logs"
+
+# Run one gate, keep its full output, and — if it fails — say something TRUE about why.
+#
+# Every gate below builds. When the wasm-tools workload is momentarily unresolvable, every
+# browser-targeting project fails at EVALUATION with NETSDK1147 and the gate goes red without a single
+# compiler error. Reporting that as "the code the CLI writes doesn't compile" names the wrong culprit,
+# and it sent two people hunting a scaffolder bug that did not exist (#718). So the verdict is READ OFF
+# THE LOG rather than assumed: NETSDK errors with no `error CS` is the machine, not the branch.
+#
+# The output goes to a FILE as well as the terminal. `cmd | tail` reports tail's status, so a gate whose
+# exit code is swallowed is a false green; `tee` is only safe here because `pipefail` is set above.
+run_gate() {
+  gate_label="$1"
+  gate_script="$2"
+  gate_hint="$3"
+  gate_log="$gate_logs/$(basename "$gate_script" .sh).log"
+
+  if "$root/$gate_script" 2>&1 | tee "$gate_log"; then
+    return 0
+  fi
+
+  gate_netsdk="$(grep -c 'error NETSDK' "$gate_log" 2>/dev/null || true)"
+  gate_cs="$(grep -c 'error CS' "$gate_log" 2>/dev/null || true)"
+
+  if [ "${gate_netsdk:-0}" -gt 0 ] && [ "${gate_cs:-0}" -eq 0 ]; then
+    {
+      echo "pre-push: $gate_label FAILED — but this looks like YOUR MACHINE, not your branch."
+      echo "          ${gate_netsdk} NETSDK error(s) and no 'error CS' at all."
+      echo
+      echo "          A browser-targeting build fails at evaluation when the wasm-tools workload is"
+      echo "          momentarily unresolvable. The usual cause is a CONCURRENT 'dotnet workload install'"
+      echo "          — any workload, from any session, even another worktree — which installs a new"
+      echo "          workload set and bumps the shared mono/emscripten manifests for the whole SDK band"
+      echo "          before the packs are restored. It is machine-wide, and 'dotnet workload list' still"
+      echo "          reports wasm-tools as installed throughout."
+      echo
+      echo "          Confirm, in this order:"
+      echo "            ps aux | grep 'workload install' | grep -v grep"
+      echo "            ls -la /usr/local/share/dotnet/metadata/workloads/InstalledWorkloadSets/"
+      echo
+      echo "          A workload set dated minutes ago is the confirmation. Wait for that install to"
+      echo "          exit and push again — do NOT race it with your own 'dotnet workload restore'."
+    } >&2
+  else
+    echo "pre-push: $gate_label FAILED — push aborted. $gate_hint" >&2
+  fi
+
+  echo "pre-push: full gate output kept at $gate_log" >&2
+  exit 1
+}
+
 if [ "${RASK_SKIP_E2E:-}" = "1" ]; then
   echo "pre-push: RASK_SKIP_E2E=1 set — skipping the local browser E2E gate."
 else
   echo "pre-push: running the local E2E gate (browser journeys)."
   echo "          bypass with 'git push --no-verify' or RASK_SKIP_E2E=1 (e.g. docs-only pushes)."
 
-  if ! "$root/scripts/run-e2e-local.sh"; then
-    echo "pre-push: E2E gate FAILED — push aborted. Fix the failing journey, or bypass with --no-verify." >&2
-    exit 1
-  fi
+  run_gate "E2E gate (browser journeys)" scripts/run-e2e-local.sh \
+    "Fix the failing journey, or bypass with --no-verify."
 fi
 
 # Like the deploy gate below, this one is scoped to the pushes it can actually say something about:
@@ -36,17 +87,16 @@ if [ "${RASK_SKIP_CLI_BUILD_E2E:-}" = "1" ]; then
   echo "pre-push: RASK_SKIP_CLI_BUILD_E2E=1 set — skipping the CLI build gate."
 elif ! git rev-parse --verify --quiet origin/main >/dev/null; then
   echo "pre-push: no origin/main to diff against — running the CLI build gate to be safe."
-  "$root/scripts/run-cli-build-e2e.sh" || { echo "pre-push: CLI build gate FAILED — push aborted." >&2; exit 1; }
+  run_gate "CLI build gate" scripts/run-cli-build-e2e.sh \
+    "The code the CLI writes doesn't compile."
 elif ! git diff --name-only origin/main...HEAD | grep -E "$generator_paths" >/dev/null; then
   : # nothing in this push can change what the generators emit
 else
   echo "pre-push: this push touches the generators or the packages they emit — running the CLI build gate."
   echo "          bypass with 'git push --no-verify' or RASK_SKIP_CLI_BUILD_E2E=1."
 
-  if ! "$root/scripts/run-cli-build-e2e.sh"; then
-    echo "pre-push: CLI build gate FAILED — push aborted. The code the CLI writes doesn't compile." >&2
-    exit 1
-  fi
+  run_gate "CLI build gate" scripts/run-cli-build-e2e.sh \
+    "The code the CLI writes doesn't compile."
 fi
 
 # The watch gate runs a real `dotnet watch` session with 2-minute ceilings, so like the others it runs
@@ -64,10 +114,8 @@ else
   echo "pre-push: this push touches the hot-reload loop — running the watch gate."
   echo "          bypass with 'git push --no-verify' or RASK_SKIP_WATCH_E2E=1."
 
-  if ! "$root/scripts/run-watch-e2e.sh"; then
-    echo "pre-push: watch hot-reload gate FAILED — push aborted. An edit no longer reaches a running app." >&2
-    exit 1
-  fi
+  run_gate "watch hot-reload gate" scripts/run-watch-e2e.sh \
+    "An edit no longer reaches a running app."
 fi
 
 # The deploy gate boots a privileged container, so it runs only when this push actually touches the
@@ -85,8 +133,6 @@ else
   echo "pre-push: this push changes the deploy path — running the deploy gate against a container host."
   echo "          bypass with 'git push --no-verify' or RASK_SKIP_DEPLOY_E2E=1."
 
-  if ! "$root/scripts/run-deploy-e2e-local.sh"; then
-    echo "pre-push: deploy gate FAILED — push aborted. Fix it, or bypass with RASK_SKIP_DEPLOY_E2E=1." >&2
-    exit 1
-  fi
+  run_gate "deploy gate" scripts/run-deploy-e2e-local.sh \
+    "Fix it, or bypass with RASK_SKIP_DEPLOY_E2E=1."
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **The pre-push gates blamed your branch for your machine.** When the `wasm-tools` workload is momentarily
+  unresolvable every browser-targeting project fails at *evaluation* with `NETSDK1147`, and the CLI gate
+  reported that as *"the code the CLI writes doesn't compile"* — measured at 0 `error CS` against 24
+  `error NETSDK1147`. It sent two people hunting a scaffolder bug that did not exist.
+
+  All four gate arms (browser E2E, CLI build, watch hot-reload, deploy) now run through one `run_gate`
+  helper that keeps the full output and **reads the verdict off the log** instead of asserting one: NETSDK
+  errors with no compiler error at all is reported as an environment failure, naming the usual cause (a
+  concurrent `dotnet workload install` — from any session, any worktree — bumping the shared
+  mono/emscripten manifests for the whole SDK band before the packs are restored) and printing the two
+  commands that confirm it. Anything else keeps the original message, and a log with *both* kinds still
+  blames the code, because a real compiler error is the actionable one. Closes #718.
+- **The CLI build gate deleted packages out of the machine-global NuGet cache.** `EvictFromGlobalCache`
+  removes all 22 packed `Rask.*` packages at the version under test, which is load-bearing — without it a
+  restore reuses a previously-cached nupkg of the same version and the gate silently tests stale bits
+  (#534). But MinVer stamps the *same* version for the same commit in every worktree, so one gate run
+  could delete what another worktree's build was restoring at that moment.
+
+  The gate now restores into a private cache under `artifacts/`, scoped to the test invocation so the
+  repo's own build still uses the normal one. Verified directly: 20 package directories used to land in
+  `~/.nuget/packages` at the packed version and now none do, with the gate still passing 27/27. A test may
+  not reach outside its sandbox to delete shared state.
+
+  This is the prime suspect for #721, but **it is not a reproduction** — the gate ran green 8/8
+  consecutively while investigating. That is consistent with the reported failure having occurred while
+  nine sessions were saturating the machine, and it is why this is justified by the hazard being real in
+  the code rather than by a repro. #721 stays open pending a sighting under load.
+
 ### Added
 - **`<var>`** — the one element MDN lists that Rask had no component for (part of #694). A variable in a
   mathematical or programming context; not emphasis (`em`) and not literal code (`code`).

--- a/scripts/run-cli-build-e2e.sh
+++ b/scripts/run-cli-build-e2e.sh
@@ -30,9 +30,25 @@ echo "==> Build the CLI test project (Release)"
 # the nupkg filename, so MinVer must stamp a real version here.
 dotnet build tests/Rask.Cli.Tests/Rask.Cli.Tests.csproj -c Release -m:1
 
+# A package cache of the gate's OWN, and the reason is that this gate MUTATES one.
+#
+# CliBuildE2E.EvictFromGlobalCache deletes ~/.nuget/packages/<pkg>/<version> for all 22 Rask packages it
+# packs. That eviction is load-bearing — without it a restore reuses a previously-cached nupkg of the same
+# version and the gate silently tests stale bits, which is worse than no gate (#534). But MinVer stamps
+# the SAME version for the same commit in every worktree, so pointing it at the machine-global cache means
+# one gate run can delete the packages another worktree's build is restoring at that moment. A test may
+# not reach outside its own sandbox to delete shared state.
+#
+# Scoped to the test invocation on purpose: the repo's own build above keeps using the normal cache
+# (it only reads), so this re-downloads what the SCAFFOLDED projects need and nothing else, once, and
+# reuses it afterwards. artifacts/ is gitignored.
+gate_packages="$root/artifacts/cli-gate-packages"
+mkdir -p "$gate_packages"
+
 echo "==> CLI build gates (scaffold output + tutorial walk-through must compile)"
 # Serial (-m:1 above, and one pack at a time inside the fixture): the gates share a single packed feed,
 # built lazily on first use.
+NUGET_PACKAGES="$gate_packages" \
 dotnet test tests/Rask.Cli.Tests/Rask.Cli.Tests.csproj -c Release --no-build \
   --filter "FullyQualifiedName~BuildE2ETests|FullyQualifiedName~TutorialWalkthroughE2ETests" \
   --logger "console;verbosity=normal"


### PR DESCRIPTION
Two defects in the gates themselves. They go first because until they are fixed, every other gate run is either untrustworthy or aborts a legitimate push.

## #718 — the misattribution

When the `wasm-tools` workload is momentarily unresolvable, every browser-targeting project fails at **evaluation** with `NETSDK1147`, and the CLI arm reported it as:

> `CLI build gate FAILED — push aborted. The code the CLI writes doesn't compile.`

Measured on the failing run: **0 `error CS`, 24 `error NETSDK1147`**. It cost two sessions about an hour chasing a scaffolder bug that did not exist.

All four arms — browser E2E, CLI build, watch hot-reload, deploy — now go through one `run_gate` helper that keeps the full output and **reads the verdict off the log rather than asserting one**. NETSDK errors with no compiler error at all is reported as an environment failure, naming the usual cause (a concurrent `dotnet workload install`, from any session or worktree, bumping the shared mono/emscripten manifests for the whole SDK band ahead of the pack restore) and printing the two commands that confirm it.

**Verified by making it fire**, against four fake gates:

| Fake gate output | Verdict |
|---|---|
| NETSDK only | blames the machine ✓, does not blame the code ✓ |
| CS only | blames the code ✓, does not blame the machine ✓ |
| **both** | blames the **code** ✓ — a real compiler error is the actionable one |
| passes | exits 0 ✓ |

## #721 — the shared-state hazard behind the flake

`CliBuildE2E.EvictFromGlobalCache` deletes all 22 packed `Rask.*` packages from `~/.nuget/packages` at the version under test. That eviction is **load-bearing**: without it a restore reuses a previously-cached nupkg of the same version and the gate silently tests stale bits, which is worse than no gate (#534). But MinVer stamps the *same* version for the same commit in every worktree — so one gate run can delete the packages another worktree's build is restoring right then.

The gate now restores into a private cache under `artifacts/`, scoped to the test invocation so the repo's own build keeps using the normal one and only the scaffolded projects' packages are re-downloaded (once; it persists).

**Verified by before/after, not by argument:** 20 package directories used to land in `~/.nuget/packages` at the packed version. After the change, **zero** do — with the gate still passing 27/27.

### This does NOT close #721

The gate ran **green 8/8 consecutively** while I investigated, so there is no reproduction. That is itself consistent with the reported failure having happened while nine sessions were saturating this machine. This change stands on the hazard being demonstrable in the code; #721 stays open pending a sighting under load.

## Testing

`bash -n` clean on both scripts; the classifier verified against four fake gates as above; the CLI gate run twice end-to-end at 27/27 with the private cache; and this PR's own push exercised the new `run_gate` helper for real — browser E2E passed through it.