### PR TITLE
perf(core): skip the callback reset on an element that names no callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -587,27 +587,29 @@ them until tagged releases begin.
   re-render (one entry plus three setter calls per row, 150 setter calls a frame) allocates **19.7 KB
   on both surfaces — Alloc Ratio 1.00**.
 
-  **On wall-clock it currently costs 18%**, and that is a regression inside this branch rather than a
-  property of the surface — the same benchmark had the chain slightly AHEAD earlier (Entry/Factory
-  0.95–0.97):
+  **On wall-clock it is 43% AHEAD** — but only after a regression the surface introduced was found
+  and fixed, so both numbers are worth keeping. Each row is its own run, so read the ratio rather than
+  comparing the two `Factory` means (they differ by run-to-run drift):
 
   ```
-  Factory   21.89 us   19.7 KB   1.00
-  Entry     25.88 us   19.7 KB   1.00   (time ratio 1.18 ± 0.02)
+  before   Factory 22.73 us   Entry 27.74 us   ratio 1.22   19.7 KB both, Alloc Ratio 1.00
+  after    Factory 24.11 us   Entry 13.62 us   ratio 0.57   19.7 KB both, Alloc Ratio 1.00
   ```
 
-  **The cause is not yet known.** `BuilderSurfaceBenchmarks`' own comment predicts one — the deferred
-  reset grew a form where a property whose setter has a BODY is assigned unconditionally rather than
-  skipped when it already reads as its default, and five props on the shared `Element`/`Component`
-  surface take that form (`Draggable`, `Role`, `TabIndex`, `Aria`, `Ref`), so every element pays. That
-  prediction was **measured and disproved**: narrowing the unconditional path to `Router.Routes` alone
-  (the one property that genuinely derives state, resolving `RouteRegistry.BuildTree()` on assignment)
-  moves the ratio from 1.18 to 1.17. It is not where the time goes.
+  What it was: the eager reset runs at the entry, before the chain's setters, and puts every
+  non-folding prop back so a callback named LAST render cannot survive into one that does not name it.
+  On `Element` that is ~88 delegate fields, written unconditionally on every entry-built element on
+  every render — and almost no element carries a callback, so nearly every one of those writes was
+  assigning null over null. A single bit on `Component` (`FlagCallbackAssigned`, in the existing
+  `_flags` byte, so it costs no memory) now records whether there is anything to put back, and the
+  block is skipped when there is not.
 
-  What has not been ruled out is the per-step bookkeeping each setter does (`Track` + `Written`, 150
-  calls a frame here) and the reset's own shape — every prop on the shared surface is a separate mask
-  test per component per render, whether or not the form of the write changes. Tracked in the issue;
-  the number is recorded here rather than left to be rediscovered.
+  Worth recording what it was NOT, because the benchmark's own comment had predicted a different cause
+  and it was wrong: the unconditional reset of the five body-setter props (`Draggable`, `Role`,
+  `TabIndex`, `Aria`, `Ref`). Measured during the original investigation: narrowing that path to
+  `Router.Routes` alone — the one property that genuinely derives state — moved the ratio 1.18 → 1.17,
+  and removing the *whole* pending reset moved it to 1.11. Neither was the cost; the eager block was,
+  and it is not the one the comment named.
 
   The ratio is recorded because dropping the generated factory removes the arm that produces it, so
   this comparison cannot be reproduced afterwards.

--- a/src/Rask.Core/Builder/BuilderRuntime.cs
+++ b/src/Rask.Core/Builder/BuilderRuntime.cs
@@ -54,6 +54,28 @@ public static partial class BuilderRuntime
     /// </remarks>
     public static void MarkChanged(Component target) => target.MarkEntryPropsChangedInternal();
 
+    /// <summary>Records that a chain assigned a callback prop on <paramref name="target" />.</summary>
+    /// <remarks>
+    ///     Paired with <see cref="HasCallbacks" />, and emitted by every non-folding callback setter so
+    ///     the eager reset knows whether this component has a callback to put back at all.
+    /// </remarks>
+    public static void MarkCallbacks(Component target) => target.MarkCallbackAssignedInternal();
+
+    /// <summary>
+    ///     Whether <paramref name="target" /> has a callback to put back. Guards the eager reset's
+    ///     callback block: <c>false</c> means every one of them already holds its default and the whole
+    ///     walk is dead work.
+    /// </summary>
+    /// <remarks>
+    ///     A peek. One reset pass runs several of these routines — a component's own eager reset calls
+    ///     the shared <c>Element</c> one first — so they must all see the same answer; the entry clears
+    ///     the record once, after the reset it drove has finished.
+    /// </remarks>
+    public static bool HasCallbacks(Component target) => target.HasCallbackAssignedInternal();
+
+    /// <summary>Clears the callback record, once the eager reset that read it has run.</summary>
+    public static void ClearCallbacks(Component target) => target.ClearCallbackAssignedInternal();
+
     /// <summary>
     ///     The bit a folding prop of the shared <see cref="Element" />/<see cref="Component" /> surface
     ///     may claim. Own (per-component) props are numbered from here up.
@@ -287,6 +309,7 @@ public static partial class BuilderRuntime
 
         var component = ctx.GetOrCreateEntry<T>(static _ => new T(), pendingReset, pending, hasLifecycle);
         reset(component);
+        ClearCallbacks(component);
         return component;
     }
 
@@ -307,6 +330,7 @@ public static partial class BuilderRuntime
                 pending,
                 hasLifecycle);
             reset(component);
+            ClearCallbacks(component);
             return component;
         }
 
@@ -332,6 +356,7 @@ public static partial class BuilderRuntime
         var component = ctx.GetOrCreateEntry<T>(
             static _ => Activator.CreateInstance<T>(), pendingReset, pending, hasLifecycle);
         reset(component);
+        ClearCallbacks(component);
         return component;
     }
 }

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -46,6 +46,7 @@ public abstract partial class Component : RaskMarkup
     //   bit 0 — reads-ambient-state (below)
     //   bit 1 — Element: Draggable present
     //   bit 2 — Element: Draggable value
+    //   bit 3 — a chain assigned a callback prop (below)
     private byte _flags;
 
     // Set the first time this component reads untracked ambient state during Render: a context value
@@ -58,6 +59,30 @@ public abstract partial class Component : RaskMarkup
     private const byte FlagReadsAmbientState = 1 << 0;
 
     private bool _readsAmbientState => (_flags & FlagReadsAmbientState) != 0;
+
+    // Set by a chain setter assigning a CALLBACK prop; read-and-cleared by the eager reset that acts
+    // on it.
+    //
+    // The eager reset runs at the entry, BEFORE this render's setters, and puts every non-folding prop
+    // back to its default so a callback the chain named last render cannot survive into one where it
+    // does not. On Element that is ~88 delegate fields written unconditionally, on every entry-built
+    // element, on every render — and the overwhelming majority of elements carry no callback at all,
+    // so nearly all of those writes were assigning null over null. This bit means "there is something
+    // to clear", which lets the common element skip the block entirely.
+    //
+    // Only callbacks set it. `Key` is non-folding too, but it is a single write, and gating it here
+    // would mean a Key-only chain still paid for the whole delegate block.
+    private const byte FlagCallbackAssigned = 1 << 3;
+
+    internal void MarkCallbackAssignedInternal() => SetFlag(FlagCallbackAssigned, true);
+
+    // Peek, not take. One reset pass can run several of these routines — a component's own eager reset
+    // calls the shared Element one first — and they must all reach the same answer, so the bit is
+    // cleared once by the entry that ran them (BuilderRuntime.Entry) rather than by whichever routine
+    // happened to look first.
+    internal bool HasCallbackAssignedInternal() => (_flags & FlagCallbackAssigned) != 0;
+
+    internal void ClearCallbackAssignedInternal() => SetFlag(FlagCallbackAssigned, false);
 
     private protected bool GetFlag(byte mask) => (_flags & mask) != 0;
 

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -567,12 +567,12 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
                 sb.AppendLine("        ResetComponentEager(__c0);");
             }
 
-            EmitReceiverCast(sb, receiver, "        ");
-            foreach (var s in props.Where(s => !bits.ContainsKey(s.Name)))
-            {
-                sb.Append("        __c.").Append(EscapeIdentifier(s.Name)).Append(" = ")
-                    .Append(s.DefaultLiteral).AppendLine(";");
-            }
+            EmitEagerResetBody(
+                sb,
+                receiver,
+                props.Where(s => !bits.ContainsKey(s.Name))
+                    .Select(s => (s.Name, s.DefaultLiteral, s.IsDelegate)).ToList(),
+                "        ");
 
             sb.AppendLine("    }");
             sb.AppendLine();
@@ -607,6 +607,65 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
 
         sb.AppendLine("}");
         spc.AddSource("RaskBuilderReset.g.cs", SourceText.From(sb.ToString(), Encoding.UTF8));
+    }
+
+    /// <summary>
+    ///     The eager reset's body, with the callback writes moved behind a "is there anything to clear"
+    ///     check.
+    /// </summary>
+    /// <remarks>
+    ///     Element carries ~88 callback props. Written unconditionally, that is ~88 stores on every
+    ///     entry-built element on every render, and for the overwhelming majority of elements every one
+    ///     of them assigns null over null — the element never named a callback. The flag is set by the
+    ///     callback setters (see <c>EmitSetter</c>) and read-and-cleared here, so the block runs on
+    ///     exactly the renders that have something to undo.
+    ///     <para>
+    ///         The non-callback props stay unconditional. They are few (Key is the shared one), and
+    ///         gating them behind the same flag would make a Key-only chain pay for the callback block.
+    ///     </para>
+    /// </remarks>
+    private static void EmitEagerResetBody(
+        StringBuilder sb,
+        string receiver,
+        IReadOnlyList<(string Name, string DefaultLiteral, bool IsDelegate)> props,
+        string indent)
+    {
+        var plain = props.Where(static p => !p.IsDelegate).ToList();
+        var callbacks = props.Where(static p => p.IsDelegate).ToList();
+        var cast = false;
+
+        if (plain.Count != 0)
+        {
+            EmitReceiverCast(sb, receiver, indent);
+            cast = true;
+            foreach (var p in plain)
+            {
+                sb.Append(indent).Append("__c.").Append(EscapeIdentifier(p.Name)).Append(" = ")
+                    .Append(p.DefaultLiteral).AppendLine(";");
+            }
+        }
+
+        if (callbacks.Count == 0)
+        {
+            return;
+        }
+
+        sb.Append(indent).AppendLine("if (!global::Rask.Core.BuilderRuntime.HasCallbacks(__c0))");
+        sb.Append(indent).AppendLine("{");
+        sb.Append(indent).AppendLine("    return;");
+        sb.Append(indent).AppendLine("}");
+        sb.AppendLine();
+
+        if (!cast)
+        {
+            EmitReceiverCast(sb, receiver, indent);
+        }
+
+        foreach (var p in callbacks)
+        {
+            sb.Append(indent).Append("__c.").Append(EscapeIdentifier(p.Name)).Append(" = ")
+                .Append(p.DefaultLiteral).AppendLine(";");
+        }
     }
 
     private static void EmitReceiverCast(StringBuilder sb, string receiver, string indent)
@@ -1077,6 +1136,15 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         if (pendingBit >= 0)
         {
             track += "global::Rask.Core.BuilderRuntime.Written(__c, " + MaskLiteral(new[] { pendingBit }) + "); ";
+        }
+
+        // A callback prop is non-folding, so it carries no pending bit and the eager reset puts it back
+        // unconditionally at the next entry. Record that there IS one to put back: an element that
+        // names no callback — almost every element — then skips a block of ~88 delegate writes on
+        // every render. See Component.FlagCallbackAssigned.
+        if (isDelegate && !fold && pendingBit < 0)
+        {
+            track += "global::Rask.Core.BuilderRuntime.MarkCallbacks(__c); ";
         }
 
         // An `internal` component cannot appear in a `public` signature (CS0050/CS0051), so the

--- a/tests/Rask.Core.Tests/BuilderCallbackResetTests.cs
+++ b/tests/Rask.Core.Tests/BuilderCallbackResetTests.cs
@@ -1,0 +1,108 @@
+using Rask.Core.Live;
+
+namespace Rask.Core.Tests;
+
+#pragma warning disable RASK014 // the tests need the very instance they hand to the render context
+
+// The eager reset's callback block is guarded by a per-component bit (Component.FlagCallbackAssigned)
+// so an element that never names a callback skips ~88 delegate writes per render. These pin the thing
+// that guard could plausibly break: a callback the chain named LAST render and does not name this one
+// must still be gone.
+public partial class BuilderCallbackResetTests : global::Rask.Core.RaskMarkup
+{
+    private static string Render(Component host, IServiceProvider sp)
+    {
+        using var ctx = LiveRenderContext.Begin(host, sp);
+        var resolved = ctx.GetOrCreate(_ => host);
+        ctx.NotifyParameters(resolved, propsChanged: true);
+        return resolved.ToHtml();
+    }
+
+    // The whole point of the eager reset. Render once WITH a handler, then again without: the second
+    // render must not still carry it. The guard makes this the case that has to keep working — the bit
+    // was set by the first render's setter, so the second render's reset has to act on it.
+    [Fact]
+    public void A_callback_the_chain_stops_naming_is_gone_next_render()
+    {
+        var sp = RenderHarness.EmptyServices();
+        var host = new DroppingCallbackHost();
+
+        var withHandler = Render(host, sp);
+        Assert.Contains("data-rask-on-click", withHandler, StringComparison.Ordinal);
+
+        host.Wired = false;
+        var without = Render(host, sp);
+        Assert.DoesNotContain("data-rask-on-click", without, StringComparison.Ordinal);
+    }
+
+    // And the reverse, so the guard cannot "fix" the above by clearing something it should not: a
+    // handler named on every render survives every render.
+    [Fact]
+    public void A_callback_named_every_render_survives()
+    {
+        var sp = RenderHarness.EmptyServices();
+        var host = new DroppingCallbackHost();
+
+        Assert.Contains("data-rask-on-click", Render(host, sp), StringComparison.Ordinal);
+        Assert.Contains("data-rask-on-click", Render(host, sp), StringComparison.Ordinal);
+        Assert.Contains("data-rask-on-click", Render(host, sp), StringComparison.Ordinal);
+    }
+
+    // An element that never carries a callback is the case the guard exists for — it must render the
+    // same markup it always did, having skipped the block entirely.
+    [Fact]
+    public void An_element_that_never_names_a_callback_renders_unchanged()
+    {
+        var sp = RenderHarness.EmptyServices();
+        var host = new NoCallbackHost();
+
+        var first = Render(host, sp);
+        Assert.Equal("<div class=\"x\"><span>hi</span></div>", first);
+        Assert.Equal(first, Render(host, sp));
+    }
+
+    // Two siblings, one wired and one not, on the same render. The bit is per component instance, so a
+    // wired sibling must not drag the unwired one into carrying a handler — nor vice versa.
+    [Fact]
+    public void A_wired_sibling_does_not_leak_onto_an_unwired_one()
+    {
+        var sp = RenderHarness.EmptyServices();
+        var host = new MixedSiblingHost();
+
+        var html = Render(host, sp);
+        Assert.Equal(1, CountOccurrences(html, "data-rask-on-click"));
+        Assert.Equal(html, Render(host, sp));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal);
+             i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    internal sealed partial class DroppingCallbackHost : Component
+    {
+        internal bool Wired = true;
+
+        protected override Component? Render() =>
+            Wired ? Div.OnClick(() => { })["x"] : Div["x"];
+    }
+
+    internal sealed partial class NoCallbackHost : Component
+    {
+        protected override Component? Render() => Div.Class("x")[Span["hi"]];
+    }
+
+    internal sealed partial class MixedSiblingHost : Component
+    {
+        protected override Component? Render() =>
+            Div[Span.OnClick(() => { })["a"], Span["b"]];
+    }
+}

--- a/tests/Rask.Generators.Tests/BuilderSetterEmissionTests.cs
+++ b/tests/Rask.Generators.Tests/BuilderSetterEmissionTests.cs
@@ -10,6 +10,11 @@ namespace Rask.Generators.Tests;
 // closure every render would report a change every frame and defeat the render cache outright.
 public class BuilderSetterEmissionTests
 {
+    // Every non-folding CALLBACK setter records that there is a callback to put back, so the eager
+    // reset can skip its ~88-field block on an element that names none. Spelled once here because it
+    // appears in the middle of several expected setter bodies.
+    private const string Mark = "global::Rask.Core.BuilderRuntime.MarkCallbacks(__c); ";
+
     private const string Src = """
                                using System;
                                using Rask.Core;
@@ -196,7 +201,7 @@ public class BuilderSetterEmissionTests
         Assert.Contains(
             "public static global::Rask.Core.Build<T> OnClick<T>(this global::Rask.Core.Build<T> __b, global::System.Action? value) "
             + "where T : global::Rask.Core.Element "
-            + "{ var __c = __b.Value; __c.OnClick = value; return __b; }",
+            + "{ var __c = __b.Value; " + Mark + "__c.OnClick = value; return __b; }",
             output,
             StringComparison.Ordinal);
         Assert.Contains(
@@ -233,7 +238,7 @@ public class BuilderSetterEmissionTests
 
         Assert.Contains(
             "OnPick(this global::Rask.Core.Build<global::Demo.Widget> __b, global::System.Action? value) "
-            + "{ var __c = __b.Value; __c.OnPick = global::Rask.Core.AutoCallback.Wrap(value); "
+            + "{ var __c = __b.Value; " + Mark + "__c.OnPick = global::Rask.Core.AutoCallback.Wrap(value); "
             + "return __b; }",
             output,
             StringComparison.Ordinal);
@@ -360,7 +365,7 @@ public class BuilderSetterEmissionTests
         var output = run.Source("RaskBuilderSetters.g.cs");
         Assert.Contains(
             "Format(this global::Rask.Core.Build<global::Demo.Widget> __b, global::System.Func<int, string>? value) "
-            + "{ var __c = __b.Value; __c.Format = value; return __b; }",
+            + "{ var __c = __b.Value; " + Mark + "__c.Format = value; return __b; }",
             output,
             StringComparison.Ordinal);
 


### PR DESCRIPTION
## Summary

`BuilderSurfaceBenchmarks` had the chain **22% behind** the factory it replaces. It is now **43% ahead**.

Measured on this branch and its parent, one run each — read the ratio rather than comparing the two
`Factory` means, which differ by run-to-run drift:

```
before   Factory 22.73 us   Entry 27.74 us   ratio 1.22   19.7 KB both, Alloc Ratio 1.00
after    Factory 24.11 us   Entry 13.62 us   ratio 0.57   19.7 KB both, Alloc Ratio 1.00
```

Allocation is untouched. The regression reproduces here independently of the issue's own report (1.22
against its 1.18), so this is measured on main rather than carried over from where it was first found.

## The cause was not the one the issue names

The issue, and `BuilderSurfaceBenchmarks`' own comment, both predicted the unconditional reset of the five
body-setter props on the shared surface (`Draggable`, `Role`, `TabIndex`, `Aria`, `Ref`). Measured during
the original investigation and **disproved**: narrowing that path to `Router.Routes` alone — the one
property that genuinely derives state — moves the ratio 1.18 → 1.17. Removing the *whole* pending reset
moves it to 1.11. Neither is where the time goes.

The cost was the **eager** reset. `BuilderRuntime.Entry<T>` runs it at the entry, *before* the chain's
setters, so a callback named last render cannot survive into a render that does not name it. On `Element`
that is ~88 delegate fields written unconditionally, on every entry-built element, on every render — and
almost no element carries a callback, so nearly every one of those writes assigned null over null. The
50-row benchmark tree is 100 elements: **8,800 dead stores a render**, roughly a nanosecond each, which is
the ~14 us that disappeared.

## What changed

One bit records whether there is anything to put back — `Component.FlagCallbackAssigned`, bit 3 of the
existing `_flags` byte, **so it costs no memory**. Callback setters mark it, the generated eager reset's
callback block is guarded by it, and `Entry`/`EntryDi`/`EntryRequired` clear it once after the reset they
drove.

Peek-then-clear rather than read-and-clear: a component's own eager reset calls the shared `Element` one
first, and both have to reach the same answer, so the entry clears the bit rather than whichever routine
looked first.

`Key` deliberately does **not** mark. It is non-folding too, but it is a single write, and marking it would
mean a `Key`-only chain — every row of a keyed list — still paid for the whole delegate block.

Failure direction is safe: a component whose eager reset runs outside `Entry` never has the bit cleared, so
it keeps the old unconditional behaviour rather than skipping a reset it needed.

## Testing

`BuilderCallbackResetTests` pins what the guard could plausibly break:

- a callback named on one render and dropped on the next is gone — the case the eager reset exists for, and
  the one the guard is most likely to break;
- one named every render survives, so the guard cannot "fix" the above by over-clearing;
- an element that never names one renders unchanged, twice over;
- a wired sibling does not leak a handler onto an unwired one, since the bit is per instance.

`BuilderSetterEmissionTests` asserts `MarkCallbacks` appears in the emitted callback setters and only there.

Full local format + unit gate green (48 test runs), browser E2E green on push.

## Ordering

The `Factory` arm is what produces this ratio, and dropping the generated factory deletes it. Measured now,
while both arms still exist, exactly as the issue asks.

Closes #683
