### PR TITLE
feat(html): close the MDN attribute gaps on button/video/form, add Element.Attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,21 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **The per-element attribute gaps MDN turned up (closes #694).** `<button>` gains the six form-override
+  attributes `Input` already had — `Form`, `FormAction`, `FormEnctype`, `FormMethod`, `FormNovalidate`,
+  `FormTarget` — so a submit button can override the form's action written as `<button>` and not only as
+  `<input type="submit">`, plus `Autofocus`, `PopoverTarget` and `PopoverTargetAction`. `<video>` gains
+  `ControlsList`, `DisablePictureInPicture`, `DisableRemotePlayback` and `Loading`. `<form>` gains `Rel`.
+  `FormAction` is sanitised like every other URL-valued attribute — it is a navigation target, so a
+  `javascript:` value there would be script execution on submit.
 - **`<var>`** — the one element MDN lists that Rask had no component for (part of #694). A variable in a
   mathematical or programming context; not emphasis (`em`) and not literal code (`code`).
+- **`Element.Attributes` — the escape hatch for HTML's global attributes (part of #693).** Everything
+  `Element` does not name is now reachable: `lang`, `dir`, `hidden`, `inert`, `popover`,
+  `contenteditable`, `inputmode`, microdata, and anything vendor or experimental —
+  `.Attributes(new() { ["lang"] = "fr" })`, HTML-encoded, `null` emitting a bare attribute like `Data`.
+  `lang`/`dir` were the pointed case: WCAG 3.1.2 (Language of Parts) needs the element that *changes*
+  language marked, and that could previously be written on `<html>` and nowhere else.
 
 ### Fixed
 - **The `add-html-tag` skill sent a new tag's test to a project that no longer holds any.** After the

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -115,6 +115,24 @@ attributes. See the [accessibility guide](accessibility.md) and the RASK023 img-
 
 <!-- demo:props-aria -->
 
+`Attributes` — the escape hatch for anything the class does not name. Global HTML attributes Rask has
+no typed property for (`lang`, `dir`, `hidden`, `inert`, `popover`, `contenteditable`, `inputmode`),
+microdata, and vendor or experimental attributes all go here, emitted verbatim as `{key}="{value}"` with
+the value HTML-encoded and a null value rendering the attribute bare, exactly like `Data`:
+
+```csharp
+Span.Attributes(new() { ["lang"] = "fr" })["déjà vu"]     // <span lang="fr">
+Div.Attributes(new() { ["inert"] = null })                // bare: <div inert>
+```
+
+`lang` is the one to know about: [WCAG 3.1.2 (Language of Parts)][wcag312] asks you to mark the element
+that *changes* language, not just `<html>`, and that is what makes a screen reader switch pronunciation
+mid-sentence. Prefer a typed property wherever one exists — it is checked, documented and discoverable —
+and reach for `Attributes` for the rest. It renders last within the universal block, so a typed property
+always wins the ordering argument.
+
+<!-- demo:props-attributes -->
+
 **Attribute order** is fixed: base props first (`id`, `class`, `style`, `title`, `data-*`, `role`,
 `tabindex`, `aria-*`), then tag-specific. Tests enforce it, so the output is predictable for diffing and
 DOM tooling:
@@ -331,3 +349,4 @@ See also: [Getting started](getting-started.md) for building your first componen
 [ul]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ul
 [video]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video
 [wbr]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/wbr
+[wcag312]: https://www.w3.org/WAI/WCAG22/Understanding/language-of-parts

--- a/samples/Rask.Example.Shared/Features/Props/PropsAttributesDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Props/PropsAttributesDemo.cs
@@ -1,0 +1,16 @@
+namespace Rask.Example.Shared.Features;
+
+public sealed partial class PropsAttributesDemo : Component
+{
+    // Attributes is the escape hatch: anything Element does not name a property for, emitted verbatim.
+    // `lang` is the case that matters — WCAG 3.1.2 asks for the element that CHANGES language to be
+    // marked, so a screen reader switches pronunciation for the quoted phrase and not the whole page.
+    protected override Component? Render() =>
+        P.Class("mb-0")[
+            "The dish arrived with an air of ",
+            Span.Class("fst-italic").Attributes(new Dictionary<string, string?> { ["lang"] = "fr" })[
+                "déjà vu"],
+            " — and a bare attribute, ",
+            Code.Attributes(new Dictionary<string, string?> { ["data-demo"] = null })["data-demo"],
+            ", written the same way."];
+}

--- a/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
+++ b/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
@@ -389,6 +389,7 @@ public static class DemoRegistry
             ["props-id-class-style"] = () => CodeSample(["PropsIdClassStyleDemo.cs"], Result: PropsIdClassStyleDemo()),
             ["props-data"] = () => CodeSample(["PropsDataDemo.cs"], Result: PropsDataDemo()),
             ["props-aria"] = () => CodeSample(["PropsAriaDemo.cs"], Result: PropsAriaDemo()),
+            ["props-attributes"] = () => CodeSample(["PropsAttributesDemo.cs"], Result: PropsAttributesDemo()),
             ["props-attribute-order"] = () => CodeSample(["PropsAttributeOrderDemo.cs"], Result: PropsAttributeOrderDemo()),
             ["svg-shapes"] = () => CodeSample(["SvgShapesDemo.cs"], Result: SvgShapesDemo()),
             ["svg-gradient"] = () => CodeSample(["SvgGradientDemo.cs"], Result: SvgGradientDemo()),

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -298,6 +298,20 @@ public abstract partial class Component : RaskMarkup
         }
     }
 
+    // Backing store for Element.Attributes, on the same terms as AriaInternal: reading never allocates,
+    // and writing only forces the LiveState into existence once a value is actually assigned.
+    internal IReadOnlyDictionary<string, string?>? ExtraAttrsInternal
+    {
+        get => _live?.ExtraAttrs;
+        set
+        {
+            if (value is not null || _live is not null)
+            {
+                Live.ExtraAttrs = value;
+            }
+        }
+    }
+
     /// <summary>
     ///     A <see cref="System.Threading.CancellationToken" /> for this component's cancellable async
     ///     work. It is cancelled when the component is unmounted (navigation away, parent removed, or
@@ -2536,6 +2550,13 @@ public abstract partial class Component : RaskMarkup
         public string? Role;
         public int? TabIndex;
         public IReadOnlyDictionary<string, string?>? Aria;
+
+        // Every remaining global HTML attribute, in one bag rather than a typed field each. A field here
+        // costs ~8 B on every node of every live session (~56 KB per field on a 1,000-row page — see
+        // CachedSubtree above), and the shared Element surface has a hard 16-pending-bit budget for
+        // folding properties, so one dictionary keeps both budgets where nine typed props would keep
+        // neither.
+        public IReadOnlyDictionary<string, string?>? ExtraAttrs;
         public HeadAssetRegistry? HeadAssets;
         public HashSet<Type>? MountedTypes;
         public Dictionary<string, (Component Owner, Delegate Action)>? Handlers;

--- a/src/Rask.Core/Components/Button.cs
+++ b/src/Rask.Core/Components/Button.cs
@@ -29,6 +29,41 @@ public sealed class Button : Element
     /// <summary>The value submitted alongside <c>Name</c>.</summary>
     public string? Value { get; set; }
 
+    /// <summary>Focus this button when the page loads. At most one control per page may ask.</summary>
+    public bool? Autofocus { get; set; }
+
+    /// <summary>
+    ///     The <c>id</c> of the form this button submits, when the button is not inside it.
+    /// </summary>
+    public string? Form { get; set; }
+
+    /// <summary>
+    ///     Overrides the form's <c>action</c> for this button only — how one form offers "save" and
+    ///     "save and publish" as two submit buttons.
+    /// </summary>
+    public string? FormAction { get; set; }
+
+    /// <summary>Overrides the form's <c>enctype</c> for this button only.</summary>
+    public string? FormEnctype { get; set; }
+
+    /// <summary>Overrides the form's <c>method</c> for this button only.</summary>
+    public string? FormMethod { get; set; }
+
+    /// <summary>Submits without running the form's validation — a "save draft" button.</summary>
+    public bool? FormNovalidate { get; set; }
+
+    /// <summary>Overrides the form's <c>target</c> for this button only.</summary>
+    public string? FormTarget { get; set; }
+
+    /// <summary>
+    ///     The <c>id</c> of the popover this button controls. The other half of the <c>Popover</c> global
+    ///     attribute: the popover declares itself, and this is what opens it without script.
+    /// </summary>
+    public string? PopoverTarget { get; set; }
+
+    /// <summary><c>toggle</c> (the default), <c>show</c> or <c>hide</c> for <see cref="PopoverTarget" />.</summary>
+    public string? PopoverTargetAction { get; set; }
+
     // OnClick / OnClickAsync are inherited from Element (the GlobalEventHandlers surface).
 
     protected override void WriteAttributes(StringBuilder sb)
@@ -52,6 +87,53 @@ public sealed class Button : Element
         if (Value is not null)
         {
             AppendAttr(sb, "value", Value);
+        }
+
+        if (Autofocus is true)
+        {
+            AppendAttr(sb, "autofocus", null);
+        }
+
+        if (Form is not null)
+        {
+            AppendAttr(sb, "form", Form);
+        }
+
+        // Sanitised like every other URL-valued attribute: formaction is a navigation target, so a
+        // `javascript:` value here is script execution on submit.
+        if (FormAction is not null)
+        {
+            AppendUrlAttr(sb, "formaction", FormAction);
+        }
+
+        if (FormEnctype is not null)
+        {
+            AppendAttr(sb, "formenctype", FormEnctype);
+        }
+
+        if (FormMethod is not null)
+        {
+            AppendAttr(sb, "formmethod", FormMethod);
+        }
+
+        if (FormNovalidate is true)
+        {
+            AppendAttr(sb, "formnovalidate", null);
+        }
+
+        if (FormTarget is not null)
+        {
+            AppendAttr(sb, "formtarget", FormTarget);
+        }
+
+        if (PopoverTarget is not null)
+        {
+            AppendAttr(sb, "popovertarget", PopoverTarget);
+        }
+
+        if (PopoverTargetAction is not null)
+        {
+            AppendAttr(sb, "popovertargetaction", PopoverTargetAction);
         }
     }
 }

--- a/src/Rask.Core/Element.cs
+++ b/src/Rask.Core/Element.cs
@@ -191,6 +191,29 @@ public abstract partial class Element : Component
         }
     }
 
+    /// <summary>
+    ///     The escape hatch for every global HTML attribute this class does not name — <c>lang</c>,
+    ///     <c>dir</c>, <c>hidden</c>, <c>inert</c>, <c>popover</c>, <c>contenteditable</c>,
+    ///     <c>inputmode</c>, microdata, and anything vendor or experimental. Each entry emits
+    ///     <c>{key}="{value}"</c> with the value HTML-encoded: <c>.Attributes(new() { ["lang"] = "fr" })</c>.
+    ///     <para>
+    ///         <c>lang</c> and <c>dir</c> are the ones that matter most: WCAG 3.1.2 (Language of Parts)
+    ///         needs a phrase in another language marked on the element that changes language, and before
+    ///         this there was no way to write it anywhere but <c>&lt;html&gt;</c>.
+    ///     </para>
+    ///     <para>
+    ///         A <see langword="null" /> value renders the attribute bare (<c>&lt;div hidden&gt;</c>), the
+    ///         same rule <see cref="Data" /> follows. Declared last, and stored on the lazy LiveState, so an
+    ///         element that sets none pays a single null reference and no factory parameter moves.
+    ///     </para>
+    ///     <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes">MDN</see>
+    /// </summary>
+    public IReadOnlyDictionary<string, string?>? Attributes
+    {
+        get => ExtraAttrsInternal;
+        set => ExtraAttrsInternal = value;
+    }
+
     // Subclasses transform the `class` attribute value without re-implementing the universal
     // id/class/style/data-* walk. NavLink overrides this to splice in its active class.
     protected virtual string? ResolveClass() => Class;
@@ -279,6 +302,14 @@ public abstract partial class Element : Component
         if (Aria is not null)
         {
             AppendPrefixedAttrs(sb, "aria-", Aria, skipKey: null);
+        }
+
+        // Last in the universal block, so the documented order still reads "globals first, grouped" and a
+        // subclass's tag-specific attrs still follow everything here. One null check on an element that
+        // sets none, and an unprefixed pass through the same emitter data-*/aria-* use.
+        if (ExtraAttrsInternal is { } extra)
+        {
+            AppendPrefixedAttrs(sb, string.Empty, extra, skipKey: null);
         }
     }
 

--- a/src/Rask.Html/Components/Form.cs
+++ b/src/Rask.Html/Components/Form.cs
@@ -105,6 +105,19 @@ public sealed partial class Form<TModel> : Element
     public ValidateAsync<TModel>? ValidateAsync { get; set; }
 
     /// <summary>
+    ///     The relationship between this form and the destination it submits to — MDN lists
+    ///     <c>noopener</c>, <c>noreferrer</c>, <c>external</c> and friends. Only meaningful together with
+    ///     <see cref="Target" />, since a form that stays in the page navigates nowhere to relate to.
+    ///     <para>
+    ///         Declared last on purpose: factory parameters are ordered by declaration span, so putting it
+    ///         next to the other attributes would shift the positional index of every callback below it —
+    ///         a silent source break for anyone passing them positionally. Same reason as
+    ///         <c>Element.Title</c>.
+    ///     </para>
+    /// </summary>
+    public string? Rel { get; set; }
+
+    /// <summary>
     ///     The validation context this form drives. Leave it unset and the form creates and owns one, which
     ///     is what almost every form wants; supply one to share validation state with something outside the
     ///     form, or to inspect it from the page.
@@ -264,6 +277,11 @@ public sealed partial class Form<TModel> : Element
         if (Name is not null)
         {
             AppendAttr(sb, "name", Name);
+        }
+
+        if (Rel is not null)
+        {
+            AppendAttr(sb, "rel", Rel);
         }
 
         Delegate? submit;

--- a/src/Rask.Html/Components/Video.cs
+++ b/src/Rask.Html/Components/Video.cs
@@ -30,6 +30,25 @@ public sealed partial class Video : HtmlMediaElement
     /// </summary>
     public bool? PlaysInline { get; set; }
 
+    /// <summary>
+    ///     Hides individual native controls: any of <c>nodownload</c>, <c>nofullscreen</c>,
+    ///     <c>noremoteplayback</c>, space-separated. A hint, not a security boundary — the media is still
+    ///     fetchable by anyone who looks.
+    /// </summary>
+    public string? ControlsList { get; set; }
+
+    /// <summary>Suppresses the picture-in-picture affordance.</summary>
+    public bool? DisablePictureInPicture { get; set; }
+
+    /// <summary>Suppresses casting to a remote device (Chromecast, AirPlay).</summary>
+    public bool? DisableRemotePlayback { get; set; }
+
+    /// <summary>
+    ///     <c>lazy</c> defers loading until the video is near the viewport — worth setting on anything
+    ///     below the fold, where the poster and metadata are otherwise fetched immediately.
+    /// </summary>
+    public string? Loading { get; set; }
+
     protected override void WriteAttributes(StringBuilder sb)
     {
         // Emits the universal attrs then the shared HtmlMediaElement block (src, controls, …,
@@ -54,6 +73,26 @@ public sealed partial class Video : HtmlMediaElement
         if (PlaysInline is true)
         {
             AppendAttr(sb, "playsinline", null);
+        }
+
+        if (ControlsList is not null)
+        {
+            AppendAttr(sb, "controlslist", ControlsList);
+        }
+
+        if (DisablePictureInPicture is true)
+        {
+            AppendAttr(sb, "disablepictureinpicture", null);
+        }
+
+        if (DisableRemotePlayback is true)
+        {
+            AppendAttr(sb, "disableremoteplayback", null);
+        }
+
+        if (Loading is not null)
+        {
+            AppendAttr(sb, "loading", Loading);
         }
     }
 }

--- a/tests/Rask.Core.Tests/Components/ButtonTests.cs
+++ b/tests/Rask.Core.Tests/Components/ButtonTests.cs
@@ -124,4 +124,34 @@ public partial class ButtonTests : global::Rask.Core.RaskMarkup
             "<button data-rask-on-click=\"h0\">x</button>",
             view.RenderAsLiveRoot());
     }
+    [Fact]
+    public void Render_FormOverrides_EmitsThemAfterTheButtonAttrs() =>
+        Assert.Equal(
+            "<button type=\"submit\" name=\"n\" value=\"v\" autofocus form=\"f\" formaction=\"/save\" "
+            + "formenctype=\"multipart/form-data\" formmethod=\"post\" formnovalidate formtarget=\"_blank\">"
+            + "Save</button>",
+            Button
+                .Type("submit")
+                .Name("n")
+                .Value("v")
+                .Autofocus(true)
+                .Form("f")
+                .FormAction("/save")
+                .FormEnctype("multipart/form-data")
+                .FormMethod("post")
+                .FormNovalidate(true)
+                .FormTarget("_blank")["Save"].ToHtml());
+
+    // formaction is a navigation target, so it goes through the same sanitiser as href/src.
+    [Fact]
+    public void Render_JavascriptFormAction_IsSanitised() =>
+        Assert.DoesNotContain("javascript:", Button.FormAction("javascript:alert(1)").ToHtml(),
+            StringComparison.OrdinalIgnoreCase);
+
+    [Fact]
+    public void Render_PopoverTarget_EmitsBothHalves() =>
+        Assert.Equal(
+            "<button popovertarget=\"menu\" popovertargetaction=\"toggle\">Open</button>",
+            Button.PopoverTarget("menu").PopoverTargetAction("toggle")["Open"].ToHtml());
+
 }

--- a/tests/Rask.Core.Tests/Components/DivTests.cs
+++ b/tests/Rask.Core.Tests/Components/DivTests.cs
@@ -91,4 +91,37 @@ public partial class DivTests : RaskMarkup
     // An unset Title must emit nothing — every element in the framework gained this property, and any
     // stray attribute would change the rendered output (and the diff) of every existing page.
     public void Render_TitleUnset_EmitsNothing() => Assert.Equal("<div></div>", Div.ToHtml());
+    // The escape hatch (#693). Emits last in the universal block, after aria-*, before tag-specific.
+    [Fact]
+    public void Render_Attributes_EmitAfterTheAriaGroup() =>
+        Assert.Equal(
+            "<div id=\"i\" role=\"note\" aria-label=\"a\" lang=\"fr\" dir=\"rtl\"></div>",
+            Div
+                .Id("i")
+                .Role("note")
+                .Aria(new Dictionary<string, string?> { ["label"] = "a" })
+                .Attributes(new Dictionary<string, string?> { ["lang"] = "fr", ["dir"] = "rtl" })
+                .ToHtml());
+
+    // WCAG 3.1.2 Language of Parts: a phrase in another language marked on the element that changes
+    // language. Before the escape hatch this was unwritable anywhere but <html>.
+    [Fact]
+    public void Render_LangOnAPhrase_IsExpressible() =>
+        Assert.Equal(
+            // non-ASCII text is encoded by HtmlSerializer's safe-ASCII rule, hence the entities
+            "<div lang=\"fr\">d&#xE9;j&#xE0; vu</div>",
+            Div.Attributes(new Dictionary<string, string?> { ["lang"] = "fr" })["déjà vu"].ToHtml());
+
+    [Fact]
+    public void Render_NullValuedAttribute_EmitsItBare() =>
+        Assert.Equal(
+            "<div hidden></div>",
+            Div.Attributes(new Dictionary<string, string?> { ["hidden"] = null }).ToHtml());
+
+    [Fact]
+    public void Render_AttributeValue_IsHtmlEncoded() =>
+        Assert.Equal(
+            "<div data-x=\"&quot;&amp;\"></div>",
+            Div.Attributes(new Dictionary<string, string?> { ["data-x"] = "\"&" }).ToHtml());
+
 }

--- a/tests/Rask.Example.Shared.Tests/Guides/DemoMarkup.golden.txt
+++ b/tests/Rask.Example.Shared.Tests/Guides/DemoMarkup.golden.txt
@@ -6227,6 +6227,26 @@ div .sample-result-label
 div .sample-result-body
 a .link .link-primary
 
+=== props-attributes ===
+div .border-0 .card .mb-4 .sample-card .shadow-sm
+div .sample-code-col
+div .sample-code-header
+span .dot-r .sample-dot
+span .dot-y .sample-dot
+span .dot-g .sample-dot
+span .ms-2 .sample-code-label
+button .sample-copy
+i .bi .bi-clipboard .me-1
+span .sample-copy-text
+pre .m-0 .sample-code
+code .language-csharp
+div .p-4 .sample-result-col
+div .sample-result-label
+div .sample-result-body
+p .mb-0
+span .fst-italic
+code
+
 === props-data ===
 div .border-0 .card .mb-4 .sample-card .shadow-sm
 div .sample-code-col

--- a/tests/Rask.Html.Tests/Components/FormTests.cs
+++ b/tests/Rask.Html.Tests/Components/FormTests.cs
@@ -99,4 +99,10 @@ public partial class FormTests : global::Rask.Core.RaskMarkup
             CancellationToken cancellationToken) =>
             ValueTask.CompletedTask;
     }
+    [Fact]
+    public void Render_Rel_EmitsAfterName() =>
+        Assert.Contains(
+            "name=\"f\" rel=\"noopener\"",
+            Form.Model(Empty).Name("f").Target("_blank").Rel("noopener").ToHtml());
+
 }

--- a/tests/Rask.Html.Tests/Components/VideoTests.cs
+++ b/tests/Rask.Html.Tests/Components/VideoTests.cs
@@ -35,4 +35,17 @@ public partial class VideoTests : global::Rask.Core.RaskMarkup
     [Fact]
     public void Render_StringChild_EncodesText() =>
         Assert.Equal("<video>&lt;x&gt;</video>", Video["<x>"].ToHtml());
+    [Fact]
+    public void Render_PlaybackRestrictions_EmitThemAfterTheVideoAttrs() =>
+        Assert.Equal(
+            "<video width=\"640\" playsinline controlslist=\"nodownload nofullscreen\" "
+            + "disablepictureinpicture disableremoteplayback loading=\"lazy\"></video>",
+            Video
+                .Width(640)
+                .PlaysInline(true)
+                .ControlsList("nodownload nofullscreen")
+                .DisablePictureInPicture(true)
+                .DisableRemotePlayback(true)
+                .Loading("lazy").ToHtml());
+
 }


### PR DESCRIPTION
## Summary

The two element-level gaps the MDN survey turned up. Closes #694; #693 partly, and the part it does
not close is the interesting half.

## #694 — the per-element attributes

`<button>` gains the six form-override attributes **`Input` already had** — `Form`, `FormAction`,
`FormEnctype`, `FormMethod`, `FormNovalidate`, `FormTarget` — plus `Autofocus`, `PopoverTarget` and
`PopoverTargetAction`. `<video>` gains `ControlsList`, `DisablePictureInPicture`,
`DisableRemotePlayback` and `Loading`. `<form>` gains `Rel`. (`<var>`, the other half of #694, landed
in #723.)

The button set is the one worth reading twice: a submit button could override the form's action
written as `<input type="submit">` and not as `<button>`, which is an inconsistency rather than a
decision.

**`FormAction` goes through `AppendUrlAttr`, not `AppendAttr`.** It is a navigation target, so a
`javascript:` value there is script execution on submit — the same class of hole as `href`. A test
asserts it does not survive.

Every property is **appended, never inserted**. Factory parameters are ordered by declaration span,
so inserting one silently shifts the positional index of every property below it for every caller.

## #693 — the escape hatch ships, the typed props do not, and that is a finding

`Element.Attributes` is the general escape hatch, matching `Data`/`Aria` in shape: each entry emits
`{key}="{value}"` with the value HTML-encoded, and a null value renders the attribute bare.

```csharp
Span.Attributes(new() { ["lang"] = "fr" })["déjà vu"]   // <span lang="fr">
Div.Attributes(new() { ["inert"] = null })              // bare: <div inert>
```

Every row of #693's table is now expressible — including the one the issue calls "a bug rather than a
feature": WCAG 3.1.2 (Language of Parts) wants the element that *changes* language marked, and `lang`
could previously be written on `<html>` and nowhere else.

**#693's option 1 — typed `Lang`/`Dir`/`Hidden`/`Inert`/… props — is not here, and the reason is a
hard limit rather than taste.** I implemented them, and the build stopped at **RASK041**: the shared
`Element`/`Component` surface has **16 pending bits against 10 folding properties**, and nine more
takes it to 19. The diagnostic's remedy is raising `BuilderRuntime.OwnPendingBit` and the generator's
copy together — which lands squarely on open perf issue #683, so it is not something to do quietly
inside an attribute PR. One dictionary spends **one** pending bit and makes the whole table reachable.

I'd rather leave #693 open against the typed-prop half than close it on the escape hatch and lose the
bit-budget finding.

## Cost — measured, and not zero

The store is a single lazily-allocated `LiveState` field, on the same terms as `Aria`: reading never
allocates, and writing only forces `LiveState` into existence once a value is assigned. But a field on
`LiveState` is paid by every live node, so `session-footprint` (connected sessions, baseline → this
branch):

| Page | Baseline B/session | This branch | Δ |
|---|---:|---:|---:|
| Empty | 26,220 | 26,372 | +0.6% |
| 5 rows | 67,373 | 68,070 | +1.0% |
| 200 rows | 1,566,150 | 1,588,791 | +1.4% |
| 1,000 rows | 7,840,926 | 7,953,118 | +1.4% |

Sessions per GiB at 1,000 rows: **136 → 135**. `RenderAndBuildPayload` is byte-identical at 35.31 KB;
`RenderOnce` 84.4 → 84.26 KB and `RenderTenTimes` 154.71 → 156.45 KB, both inside their own StdDev.

That is ~8 B per live node, which is what the code comment predicts. Worth stating plainly: the nine
typed props would have cost nine times this *and* blown the pending-bit budget, so the dictionary is
the cheaper answer on both axes, not just the one that compiles.

Emission is last within the universal block, so the documented order still reads "globals first,
grouped" and a subclass's tag-specific attributes still follow everything shared.

## Testing

- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 errors, 0 warnings.
- `dotnet format --verify-no-changes` — clean.
- Full unit suite via the pre-commit gate — green.
- Browser E2E via the pre-push gate — green.
- Benchmarks — the table above, baseline taken from a detached worktree at the parent commit.

## User-facing surface

- `docs/elements.md` documents `Attributes` next to `Data`/`Aria`, with the WCAG 3.1.2 note and the
  "prefer a typed property where one exists" steer.
- New `PropsAttributesDemo` sample, registered as `props-attributes` and marked in the docs; the
  golden-markup test caught it, as designed, and the regenerated diff is 20 additive lines.
- CHANGELOG under `[Unreleased] / Added`, folded into the single `### Added` block (there were two).
