### PR TITLE
feat(html): add button command/commandfor and the loading-priority attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **`Button` gained `command`/`commandfor`, and four elements gained the loading-priority attributes.**
+  `command`/`commandfor` generalise what `popovertarget` does for popovers: the button names the element
+  it acts on and the action to invoke — `show-modal`, `close`, `request-close`, `toggle-popover`,
+  `show-popover`, `hide-popover`, or a custom `--name` that dispatches a `CommandEvent` — so a
+  `<dialog>` opens and closes with no script on either side. Declared beside `PopoverTarget` and
+  **appended** after it, because factory parameters are ordered by declaration span.
+
+  `FetchPriority` lands on `Img`, `Link`, `Script` and `Iframe`; `Blocking` on `Link` and `Script`; and
+  `ImageSrcset`/`ImageSizes` on `Link`, for `rel="preload" as="image"`. The one with a measurable story
+  is `fetchpriority="high"` on the LCP image — the browser discovers it at the same moment either way,
+  this moves it ahead in the queue. `blocking="render"` is the odd one out among loading knobs: an
+  opt-**in** to blocking rather than the usual opt-out. And a responsive-image preload without
+  `imagesrcset` fetches the wrong candidate, so the page pays for two downloads — the opposite of what
+  the preload was for.
+
+  `interestfor` is deliberately excluded: still experimental and Chromium-only, the same bar #694 used
+  to leave out `<fencedframe>` and `<selectedcontent>`. Closes #729.
 - **Every HTML global attribute is now reachable, and there is an escape hatch for the rest.** `Element`
   exposed `Id`/`Class`/`Style`/`Title`/`Data`/`Role`/`TabIndex`/`Aria`/`Ref`/`Draggable` and nothing else,
   so the remainder of MDN's global attributes were not verbose — they were **impossible**.

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -185,6 +185,39 @@ reference. `Element.WriteAttributes` reads the side object once into a local rat
 attribute, so an element naming no global does *less* work than a typed-field-each layout would have.
 
 
+### Commands and loading priority
+
+`Button.Command` and `Button.CommandFor` generalise what `PopoverTarget` does for popovers: the button
+names the element it acts on and the action to invoke, and the browser does the rest with no script on
+either side. Built-in actions are `show-modal`, `close`, `request-close`, `toggle-popover`,
+`show-popover` and `hide-popover`; a custom `--name` dispatches a `CommandEvent` instead.
+
+```csharp
+Button.Command("show-modal").CommandFor("edit-dialog")["Edit"]
+Button.Command("--spin").CommandFor("widget")["Spin"]     // dispatches a CommandEvent
+```
+
+<!-- demo:props-command -->
+
+`FetchPriority` (`high`, `low`, `auto`) is on `Img`, `Link`, `Script` and `Iframe`. The use with a
+measurable story behind it is `high` on the LCP image — the browser discovers it at the same moment
+either way, this moves it ahead of the other images in the queue. Marking everything high marks nothing
+high.
+
+`Blocking` on `Link` and `Script` takes `render`, and is the one loading knob that works the other way
+round: an opt **in** to blocking rendering until the resource loads, for when a flash of unstyled or
+un-scripted content is worse than the delay.
+
+`ImageSrcset` and `ImageSizes` belong on `Link.Rel("preload").As("image")`. Without them a responsive
+image preloads the wrong candidate and the page pays for two downloads, which is the opposite of what
+preloading it was for.
+
+```csharp
+Img.Src("/hero.png").Alt("Hero").FetchPriority("high")
+Link.Rel("preload").Href("/hero.png").As("image")
+    .ImageSrcset("/hero.png 1x, /hero@2x.png 2x").ImageSizes("100vw")
+```
+
 **Attribute order** is fixed: `id`, `class`, `style`, `title`, the plain globals (`lang`, `dir`,
 `hidden`, `inert`, `popover`, `contenteditable`, `spellcheck`, `translate`), `data-*`, `role`,
 `tabindex`, `aria-*`, then `Attributes`, then tag-specific. Tests enforce it, so the output is

--- a/samples/Rask.Example.Shared/Features/Props/PropsCommandDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Props/PropsCommandDemo.cs
@@ -1,0 +1,23 @@
+namespace Rask.Example.Shared.Features;
+
+public sealed partial class PropsCommandDemo : Component
+{
+    // command/commandfor generalise what popovertarget does for popovers: the button names the element
+    // it acts on and the action to invoke, and the browser does the rest. There is no OnClick here and
+    // no JavaScript anywhere — opening and closing the dialog is entirely declarative.
+    //
+    // `show-modal` and `close` are two of the built-in actions; a custom `--name` would dispatch a
+    // CommandEvent instead of invoking one.
+    protected override Component? Render() =>
+        Div[
+            Button
+                .Class("btn btn-outline-primary")
+                .Command("show-modal")
+                .CommandFor("props-command-dialog")["Open the dialog"],
+            Dialog.Id("props-command-dialog").Class("p-3 border-0 rounded shadow")[
+                P.Class("mb-3")["Opened by ", Code["command"], ", with no handler on either side."],
+                Button
+                    .Class("btn btn-sm btn-secondary")
+                    .Command("close")
+                    .CommandFor("props-command-dialog")["Close"]]];
+}

--- a/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
+++ b/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
@@ -390,6 +390,7 @@ public static class DemoRegistry
             ["props-data"] = () => CodeSample(["PropsDataDemo.cs"], Result: PropsDataDemo()),
             ["props-aria"] = () => CodeSample(["PropsAriaDemo.cs"], Result: PropsAriaDemo()),
             ["props-attributes"] = () => CodeSample(["PropsAttributesDemo.cs"], Result: PropsAttributesDemo()),
+            ["props-command"] = () => CodeSample(["PropsCommandDemo.cs"], Result: PropsCommandDemo()),
             ["props-attribute-order"] = () => CodeSample(["PropsAttributeOrderDemo.cs"], Result: PropsAttributeOrderDemo()),
             ["svg-shapes"] = () => CodeSample(["SvgShapesDemo.cs"], Result: SvgShapesDemo()),
             ["svg-gradient"] = () => CodeSample(["SvgGradientDemo.cs"], Result: SvgGradientDemo()),

--- a/src/Rask.Core/Components/Button.cs
+++ b/src/Rask.Core/Components/Button.cs
@@ -64,6 +64,31 @@ public sealed class Button : Element
     /// <summary><c>toggle</c> (the default), <c>show</c> or <c>hide</c> for <see cref="PopoverTarget" />.</summary>
     public string? PopoverTargetAction { get; set; }
 
+    // command/commandfor generalise what popovertarget does for popovers, so they are declared next to
+    // it — and APPENDED after it, never inserted, because factory parameters are ordered by declaration
+    // span and inserting here would shift the positional index of every parameter below.
+    //
+    // `interestfor` is deliberately absent: still experimental and Chromium-only, the same bar #694 used
+    // to leave out <fencedframe> and <selectedcontent>.
+
+    /// <summary>
+    ///     The action this button invokes on <see cref="CommandFor" />: <c>show-modal</c>, <c>close</c>,
+    ///     <c>request-close</c>, <c>toggle-popover</c>, <c>show-popover</c>, <c>hide-popover</c>, or a
+    ///     custom <c>--name</c> that dispatches a <c>CommandEvent</c> instead.
+    ///     <para>
+    ///         This is <see cref="PopoverTarget" /> generalised past popovers — it drives a
+    ///         <c>&lt;dialog&gt;</c> the same way, with no script on either side.
+    ///     </para>
+    ///     <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#command">MDN</see>
+    /// </summary>
+    public string? Command { get; set; }
+
+    /// <summary>
+    ///     The <c>id</c> of the element <see cref="Command" /> acts on.
+    ///     <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#commandfor">MDN</see>
+    /// </summary>
+    public string? CommandFor { get; set; }
+
     // OnClick / OnClickAsync are inherited from Element (the GlobalEventHandlers surface).
 
     protected override void WriteAttributes(StringBuilder sb)
@@ -134,6 +159,16 @@ public sealed class Button : Element
         if (PopoverTargetAction is not null)
         {
             AppendAttr(sb, "popovertargetaction", PopoverTargetAction);
+        }
+
+        if (Command is not null)
+        {
+            AppendAttr(sb, "command", Command);
+        }
+
+        if (CommandFor is not null)
+        {
+            AppendAttr(sb, "commandfor", CommandFor);
         }
     }
 }

--- a/src/Rask.Html/Components/Iframe.cs
+++ b/src/Rask.Html/Components/Iframe.cs
@@ -48,6 +48,17 @@ public sealed partial class Iframe : Element
     /// <summary>How much of the referrer to send when fetching the framed document.</summary>
     public string? ReferrerPolicy { get; set; }
 
+    /// <summary>
+    ///     The <c>fetchpriority</c> hint — <c>high</c>, <c>low</c>, or <c>auto</c> (the default).
+    ///     <para>
+    ///         The load-bearing use is <c>high</c> on the LCP image: the browser discovers it at the same
+    ///         moment either way, but this moves it ahead of the other images in the queue. Marking
+    ///         everything high marks nothing high.
+    ///     </para>
+    ///     <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#fetchpriority">MDN</see>
+    /// </summary>
+    public string? FetchPriority { get; set; }
+
     protected override void WriteAttributes(StringBuilder sb)
     {
         base.WriteAttributes(sb);
@@ -94,6 +105,11 @@ public sealed partial class Iframe : Element
         if (ReferrerPolicy is not null)
         {
             AppendAttr(sb, "referrerpolicy", ReferrerPolicy);
+        }
+
+        if (FetchPriority is not null)
+        {
+            AppendAttr(sb, "fetchpriority", FetchPriority);
         }
     }
 }

--- a/src/Rask.Html/Components/Img.cs
+++ b/src/Rask.Html/Components/Img.cs
@@ -75,6 +75,17 @@ public sealed partial class Img : Element
     /// </summary>
     public bool? Ismap { get; set; }
 
+    /// <summary>
+    ///     The <c>fetchpriority</c> hint — <c>high</c>, <c>low</c>, or <c>auto</c> (the default).
+    ///     <para>
+    ///         The load-bearing use is <c>high</c> on the LCP image: the browser discovers it at the same
+    ///         moment either way, but this moves it ahead of the other images in the queue. Marking
+    ///         everything high marks nothing high.
+    ///     </para>
+    ///     <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#fetchpriority">MDN</see>
+    /// </summary>
+    public string? FetchPriority { get; set; }
+
     protected override void WriteAttributes(StringBuilder sb)
     {
         base.WriteAttributes(sb);
@@ -136,6 +147,11 @@ public sealed partial class Img : Element
         if (Ismap is true)
         {
             AppendAttr(sb, "ismap", null);
+        }
+
+        if (FetchPriority is not null)
+        {
+            AppendAttr(sb, "fetchpriority", FetchPriority);
         }
     }
 }

--- a/src/Rask.Html/Components/Link.cs
+++ b/src/Rask.Html/Components/Link.cs
@@ -55,6 +55,39 @@ public sealed partial class Link : Element
     /// <summary>The colour for a <c>mask-icon</c>. Safari-specific.</summary>
     public string? Color { get; set; }
 
+    /// <summary>
+    ///     The <c>fetchpriority</c> hint — <c>high</c>, <c>low</c>, or <c>auto</c> (the default).
+    ///     <para>
+    ///         The load-bearing use is <c>high</c> on the LCP image: the browser discovers it at the same
+    ///         moment either way, but this moves it ahead of the other images in the queue. Marking
+    ///         everything high marks nothing high.
+    ///     </para>
+    ///     <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#fetchpriority">MDN</see>
+    /// </summary>
+    public string? FetchPriority { get; set; }
+
+    /// <summary>
+    ///     The <c>blocking</c> attribute — currently only <c>render</c>, which makes this an
+    ///     opt-IN to blocking rendering until it loads, rather than the opt-out everything else is.
+    ///     Reach for it when a flash of unstyled or un-scripted content is worse than the delay.
+    ///     <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#blocking">MDN</see>
+    /// </summary>
+    public string? Blocking { get; set; }
+
+    /// <summary>
+    ///     For <c>rel="preload" as="image"</c>: the <c>srcset</c> the preload should honour. Without it a
+    ///     responsive-image preload fetches the wrong candidate and the page pays for two downloads —
+    ///     which is the opposite of what preloading it was for.
+    ///     <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#imagesrcset">MDN</see>
+    /// </summary>
+    public string? ImageSrcset { get; set; }
+
+    /// <summary>
+    ///     The <c>sizes</c> that pairs with <see cref="ImageSrcset" /> on an image preload.
+    ///     <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#imagesizes">MDN</see>
+    /// </summary>
+    public string? ImageSizes { get; set; }
+
     protected override void WriteAttributes(StringBuilder sb)
     {
         base.WriteAttributes(sb);
@@ -111,6 +144,26 @@ public sealed partial class Link : Element
         if (Color is not null)
         {
             AppendAttr(sb, "color", Color);
+        }
+
+        if (FetchPriority is not null)
+        {
+            AppendAttr(sb, "fetchpriority", FetchPriority);
+        }
+
+        if (Blocking is not null)
+        {
+            AppendAttr(sb, "blocking", Blocking);
+        }
+
+        if (ImageSrcset is not null)
+        {
+            AppendAttr(sb, "imagesrcset", ImageSrcset);
+        }
+
+        if (ImageSizes is not null)
+        {
+            AppendAttr(sb, "imagesizes", ImageSizes);
         }
     }
 }

--- a/src/Rask.Html/Components/Script.cs
+++ b/src/Rask.Html/Components/Script.cs
@@ -55,6 +55,25 @@ public sealed partial class Script : Element
     /// <summary>The script's encoding. Deprecated: serve UTF-8 and omit this.</summary>
     public string? Charset { get; set; }
 
+    /// <summary>
+    ///     The <c>fetchpriority</c> hint — <c>high</c>, <c>low</c>, or <c>auto</c> (the default).
+    ///     <para>
+    ///         The load-bearing use is <c>high</c> on the LCP image: the browser discovers it at the same
+    ///         moment either way, but this moves it ahead of the other images in the queue. Marking
+    ///         everything high marks nothing high.
+    ///     </para>
+    ///     <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#fetchpriority">MDN</see>
+    /// </summary>
+    public string? FetchPriority { get; set; }
+
+    /// <summary>
+    ///     The <c>blocking</c> attribute — currently only <c>render</c>, which makes this an
+    ///     opt-IN to blocking rendering until it loads, rather than the opt-out everything else is.
+    ///     Reach for it when a flash of unstyled or un-scripted content is worse than the delay.
+    ///     <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#blocking">MDN</see>
+    /// </summary>
+    public string? Blocking { get; set; }
+
     protected override void WriteAttributes(StringBuilder sb)
     {
         base.WriteAttributes(sb);
@@ -101,6 +120,16 @@ public sealed partial class Script : Element
         if (Charset is not null)
         {
             AppendAttr(sb, "charset", Charset);
+        }
+
+        if (FetchPriority is not null)
+        {
+            AppendAttr(sb, "fetchpriority", FetchPriority);
+        }
+
+        if (Blocking is not null)
+        {
+            AppendAttr(sb, "blocking", Blocking);
         }
     }
 }

--- a/tests/Rask.Core.Tests/Components/ButtonTests.cs
+++ b/tests/Rask.Core.Tests/Components/ButtonTests.cs
@@ -189,4 +189,32 @@ public partial class ButtonTests : global::Rask.Core.RaskMarkup
             "<button popovertarget=\"menu\" popovertargetaction=\"toggle\">Open</button>",
             Button.PopoverTarget("menu").PopoverTargetAction("toggle")["Open"].ToHtml());
 
+    [Fact]
+    public void Render_Command_EmitsBothHalves() =>
+        // command/commandfor generalise popovertarget past popovers — this drives a <dialog> with no
+        // script on either side.
+        Assert.Equal(
+            "<button command=\"show-modal\" commandfor=\"edit\">Edit</button>",
+            Button.Command("show-modal").CommandFor("edit")["Edit"].ToHtml());
+
+    [Fact]
+    public void Render_CustomCommand_IsEmittedVerbatim() =>
+        // A `--name` command dispatches a CommandEvent rather than invoking a built-in action; the
+        // leading dashes are part of the value and must survive.
+        Assert.Equal(
+            "<button command=\"--spin\" commandfor=\"w\">Go</button>",
+            Button.Command("--spin").CommandFor("w")["Go"].ToHtml());
+
+    [Fact]
+    public void Render_Command_EmitsAfterThePopoverPair() =>
+        // Appended after popovertarget/popovertargetaction, not inserted among them — the order is the
+        // declaration order, and inserting would have shifted every factory parameter below.
+        Assert.Equal(
+            "<button popovertarget=\"m\" popovertargetaction=\"toggle\" command=\"close\" "
+            + "commandfor=\"d\">x</button>",
+            Button
+                .CommandFor("d")
+                .Command("close")
+                .PopoverTargetAction("toggle")
+                .PopoverTarget("m")["x"].ToHtml());
 }

--- a/tests/Rask.Example.Shared.Tests/Guides/DemoMarkup.golden.txt
+++ b/tests/Rask.Example.Shared.Tests/Guides/DemoMarkup.golden.txt
@@ -6247,6 +6247,29 @@ p .mb-0
 span .fst-italic
 code
 
+=== props-command ===
+div .border-0 .card .mb-4 .sample-card .shadow-sm
+div .sample-code-col
+div .sample-code-header
+span .dot-r .sample-dot
+span .dot-y .sample-dot
+span .dot-g .sample-dot
+span .ms-2 .sample-code-label
+button .sample-copy
+i .bi .bi-clipboard .me-1
+span .sample-copy-text
+pre .m-0 .sample-code
+code .language-csharp
+div .p-4 .sample-result-col
+div .sample-result-label
+div .sample-result-body
+div
+button .btn .btn-outline-primary
+dialog .border-0 .p-3 .rounded .shadow
+p .mb-3
+code
+button .btn .btn-secondary .btn-sm
+
 === props-data ===
 div .border-0 .card .mb-4 .sample-card .shadow-sm
 div .sample-code-col

--- a/tests/Rask.Html.Tests/Components/IframeTests.cs
+++ b/tests/Rask.Html.Tests/Components/IframeTests.cs
@@ -30,4 +30,9 @@ public partial class IframeTests : global::Rask.Core.RaskMarkup
     [Fact]
     public void Render_StringChild_EncodesText() =>
         Assert.Equal("<iframe>&lt;x&gt;</iframe>", Iframe["<x>"].ToHtml());
+
+    [Fact]
+    public void Render_FetchPriority_EmitsAfterTheOtherIframeAttrs() =>
+        Assert.Equal("<iframe src=\"/a\" loading=\"lazy\" fetchpriority=\"low\"></iframe>",
+            Iframe.Src("/a").Loading("lazy").FetchPriority("low").ToHtml());
 }

--- a/tests/Rask.Html.Tests/Components/ImgTests.cs
+++ b/tests/Rask.Html.Tests/Components/ImgTests.cs
@@ -30,4 +30,11 @@ public partial class ImgTests : global::Rask.Core.RaskMarkup
                 .Style("s")
                 .Data(new Dictionary<string, string?> { ["k"] = "v" }).ToHtml());
     }
+
+    [Fact]
+    public void Render_FetchPriority_EmitsAfterTheOtherImgAttrs() =>
+        // `high` on the LCP image is the one use with a measurable story: the browser discovers it at
+        // the same moment either way, this just moves it ahead in the queue.
+        Assert.Equal("<img src=\"/hero.png\" alt=\"Hero\" fetchpriority=\"high\" />",
+            Img.Src("/hero.png").Alt("Hero").FetchPriority("high").ToHtml());
 }

--- a/tests/Rask.Html.Tests/Components/LinkTests.cs
+++ b/tests/Rask.Html.Tests/Components/LinkTests.cs
@@ -27,4 +27,24 @@ public partial class LinkTests : global::Rask.Core.RaskMarkup
                 .Style("s")
                 .Data(new Dictionary<string, string?> { ["k"] = "v" }).ToHtml());
     }
+
+    [Fact]
+    public void Render_FetchPriorityAndBlocking_EmitAfterTheOtherLinkAttrs() =>
+        Assert.Equal(
+            "<link href=\"/a.css\" rel=\"stylesheet\" fetchpriority=\"high\" blocking=\"render\" />",
+            Link.Rel("stylesheet").Href("/a.css").FetchPriority("high").Blocking("render").ToHtml());
+
+    [Fact]
+    public void Render_ImagePreloadCarriesItsOwnSrcsetAndSizes() =>
+        // Preloading a responsive image without these fetches the wrong candidate and the page pays for
+        // two downloads — the opposite of what the preload was for.
+        Assert.Equal(
+            "<link href=\"/a.png\" rel=\"preload\" as=\"image\" "
+            + "imagesrcset=\"/a.png 1x, /a@2x.png 2x\" imagesizes=\"100vw\" />",
+            Link
+                .Rel("preload")
+                .Href("/a.png")
+                .As("image")
+                .ImageSrcset("/a.png 1x, /a@2x.png 2x")
+                .ImageSizes("100vw").ToHtml());
 }

--- a/tests/Rask.Html.Tests/Components/ScriptTests.cs
+++ b/tests/Rask.Html.Tests/Components/ScriptTests.cs
@@ -30,4 +30,12 @@ public partial class ScriptTests : global::Rask.Core.RaskMarkup
     [Fact]
     public void Render_StringChild_EncodesText() =>
         Assert.Equal("<script>&lt;x&gt;</script>", Script["<x>"].ToHtml());
+
+    [Fact]
+    public void Render_FetchPriorityAndBlocking_EmitAfterTheOtherScriptAttrs() =>
+        // `blocking="render"` is an opt-IN to blocking, which is the reverse of every other loading
+        // knob on this element.
+        Assert.Equal(
+            "<script src=\"/a.js\" fetchpriority=\"low\" blocking=\"render\"></script>",
+            Script.Src("/a.js").FetchPriority("low").Blocking("render").ToHtml());
 }


### PR DESCRIPTION
Closes #729.

The MDN leftovers carved out of #694. Neither group was a correctness gap — `Element.Attributes` has
reached all of them since #727 — so this is about **typed, discoverable, documented** properties rather
than possibility.

## `Button.Command` / `Button.CommandFor`

These generalise what `popovertarget` does for popovers: the button names the element it acts on and
the action to invoke, and the browser does the rest. Built-ins are `show-modal`, `close`,
`request-close`, `toggle-popover`, `show-popover` and `hide-popover`; a custom `--name` dispatches a
`CommandEvent` instead.

```csharp
Button.Command("show-modal").CommandFor("edit-dialog")["Edit"]
```

Declared beside `PopoverTarget` and **appended** after it — factory parameters are ordered by
declaration span, so inserting there would shift the positional index of everything below. One of the
tests asserts they emit *after* the popover pair, which pins that rather than merely documenting it.

`interestfor` is deliberately excluded: still experimental and Chromium-only, the same bar #694 used to
leave out `<fencedframe>` and `<selectedcontent>`.

## Loading priority

| Attribute | Elements |
|---|---|
| `FetchPriority` | `Img`, `Link`, `Script`, `Iframe` |
| `Blocking` | `Link`, `Script` |
| `ImageSrcset` / `ImageSizes` | `Link` |

`fetchpriority="high"` on the LCP image is the one with a measurable story: the browser discovers it at
the same moment either way, this moves it ahead in the queue — and marking everything high marks
nothing high. `blocking="render"` is the odd one out among loading knobs, an opt-**in** to blocking
rather than the usual opt-out. And a responsive-image preload without `imagesrcset` fetches the wrong
candidate, so the page pays for two downloads — the opposite of what preloading it was for.

All appended after each file's last property and last emission, for the same parameter-ordering reason.

## Testing

- `scripts/run-unit-local.sh` — format, `-warnaserror` build, unit suite.
- New tests on `Button` (including the emit-order one), `Img`, `Link`, `Script` and `Iframe`.
- New `props-command` demo, with its golden entry regenerated — the diff is purely additive, one new
  entry matching the demo's skeleton.

One assertion caught a real mistake of mine rather than a bug in the change: I had written the expected
`<link>` markup as `rel` before `href`, and `Link` emits `href` first. The expectations were wrong, not
the code.

### A pre-existing red I did not cause

`ShutdownDrainTests.Readiness_goes_unhealthy_while_draining_but_capacity_still_reports_capacity` fails
in a full-suite run on a loaded machine and passes 12/12 standalone. `RaskLiveHealthCheck` judges
**machine memory load** first and lets it outrank the session count — by explicit design — so an empty
store reports `Degraded` once the machine is past 80%. This change touches no file under
`src/Rask.Server` (`git diff --stat origin/main -- src/Rask.Server tests/Rask.Server.Tests` is empty).
Filed separately as #732.

## Docs

`docs/elements.md` gains a *Commands and loading priority* section with the demo, and the CHANGELOG has
its `[Unreleased]` entry.
