### PR TITLE
fix(server): make the live health check's memory reading a test seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **The local unit gate went red on changes that touch no server code.**
+  `ShutdownDrainTests.Readiness_goes_unhealthy_while_draining_but_capacity_still_reports_capacity`
+  asserted that an empty session store reports `Healthy` — but `RaskLiveHealthCheck` judges **memory
+  load first** and lets it outrank the session count, deliberately, because what a session costs is a
+  property of the page rather than of the number of them. Memory load is a property of the *machine*,
+  so a full-suite run (parallel test hosts, WASM native relinks) pushed the process past
+  `DegradedMemoryLoad` and an empty store reported `Degraded`.
+
+  It passed standalone and failed in the full run, which is the wrong way round — the honest signal
+  was buried under a red gate, on a diff with no `src/Rask.Server` changes in it. Encountered three
+  times in one session, on three unrelated changes.
+
+  The memory reading is now a seam (`MemoryLoadReader`, defaulting to the real one), pinned by the
+  tests that are about the session branch. That also makes `DegradedMemoryLoad` and
+  `UnhealthyMemoryLoad` testable **at all** — both are load-bearing in production and had no coverage,
+  because the only input was whatever the host happened to be doing. Four tests added for them.
+  Closes #732.
+
 ### Added
 - **`Button` gained `command`/`commandfor`, and four elements gained the loading-priority attributes.**
   `command`/`commandfor` generalise what `popovertarget` does for popovers: the button names the element

--- a/src/Rask.Server/Diagnostics/RaskLiveHealthCheck.cs
+++ b/src/Rask.Server/Diagnostics/RaskLiveHealthCheck.cs
@@ -39,6 +39,23 @@ public sealed class RaskLiveHealthCheck(LiveSessionStore store) : IHealthCheck
     internal const double UnhealthyMemoryLoad = 0.92;
 
     /// <summary>
+    ///     How the memory load is read. Overridden only by tests.
+    /// </summary>
+    /// <remarks>
+    ///     The real reading is a property of the MACHINE, not of the store — which is correct for the
+    ///     product and awkward for a test: a suite that saturates the machine pushes the process past
+    ///     <see cref="DegradedMemoryLoad" />, and an assertion about the SESSION branch then fails on
+    ///     something it never meant to exercise. That is not hypothetical; it made the full local gate
+    ///     go red on changes that touch no server code at all (#732).
+    ///     <para>
+    ///         So the reading is a seam. Pinning it lets a test assert the session branch on its own —
+    ///         and, just as usefully, lets the memory thresholds be asserted at all, which they could
+    ///         not be while the only input was whatever the host happened to be doing.
+    ///     </para>
+    /// </remarks>
+    internal Func<double> MemoryLoadReader { get; init; } = MemoryLoad;
+
+    /// <summary>
     ///     Reports whether this host can still take live sessions: degraded as it fills, unhealthy once a
     ///     new visitor would be refused. Memory is judged first and outranks the session cap in both
     ///     directions — what a session costs depends on the page, not on how many there are — so an
@@ -56,7 +73,7 @@ public sealed class RaskLiveHealthCheck(LiveSessionStore store) : IHealthCheck
         var active = store.LiveCount;
         var max = store.MaxSessions;
         var connected = store.ConnectedCount;
-        var memoryLoad = MemoryLoad();
+        var memoryLoad = MemoryLoadReader();
         var data = new Dictionary<string, object>
         {
             ["activeSessions"] = active,

--- a/tests/Rask.Server.Tests/Diagnostics/RaskLiveHealthCheckTests.cs
+++ b/tests/Rask.Server.Tests/Diagnostics/RaskLiveHealthCheckTests.cs
@@ -60,9 +60,62 @@ public class RaskLiveHealthCheckTests
         Assert.Equal(HealthStatus.Unhealthy, await Status(store));
     }
 
-    private static async Task<HealthStatus> Status(LiveSessionStore store)
+    // ---- Memory, which outranks the session count in both directions -------------------------------
+    //
+    // None of these could be written before the reading became a seam: the only input was whatever the
+    // host happened to be doing, so the thresholds below — both load-bearing in production — had no
+    // coverage at all.
+
+    [Fact]
+    public async Task AtTheMemoryCeiling_IsUnhealthy_EvenWithAnEmptyStore()
     {
-        var result = await new RaskLiveHealthCheck(store)
+        var store = NewStore();
+        store.MaxSessions = 100;
+
+        Assert.Equal(HealthStatus.Unhealthy, await Status(store, memoryLoad: 0.95));
+    }
+
+    [Fact]
+    public async Task NearTheMemoryCeiling_IsDegraded_EvenWithAnEmptyStore()
+    {
+        // The point of watching memory at all: a session's cost is a property of the PAGE, so a host
+        // well under its session cap can still be in trouble.
+        var store = NewStore();
+        store.MaxSessions = 100;
+
+        Assert.Equal(HealthStatus.Degraded, await Status(store, memoryLoad: 0.85));
+    }
+
+    [Fact]
+    public async Task AnUncappedHostStillDegradesUnderMemoryPressure()
+    {
+        // Uncapped means "no session limit", not "never unhealthy".
+        var store = NewStore();
+        store.MaxSessions = 0;
+
+        Assert.Equal(HealthStatus.Degraded, await Status(store, memoryLoad: 0.85));
+        Assert.Equal(HealthStatus.Unhealthy, await Status(store, memoryLoad: 0.95));
+    }
+
+    [Fact]
+    public async Task AnUnreadableMemoryPositionIsNotAnUnhealthyOne()
+    {
+        // MemoryLoad() returns 0 when the runtime won't say, deliberately: a host must not shed load
+        // because it could not measure itself.
+        var store = NewStore();
+        store.MaxSessions = 100;
+
+        Assert.Equal(HealthStatus.Healthy, await Status(store, memoryLoad: 0.0));
+    }
+
+    // The memory reading defaults to PINNED, not to the real one. The check judges memory first and
+    // lets it outrank the session count — correct for the product, and fatal for a test about the
+    // SESSION branch, because a machine already past DegradedMemoryLoad makes every one of these
+    // report Degraded regardless of the store. That is what made the full local gate go red on
+    // unrelated changes (#732). Tests that are about memory pass their own value.
+    private static async Task<HealthStatus> Status(LiveSessionStore store, double memoryLoad = 0.0)
+    {
+        var result = await new RaskLiveHealthCheck(store) { MemoryLoadReader = () => memoryLoad }
             .CheckHealthAsync(new HealthCheckContext());
         return result.Status;
     }

--- a/tests/Rask.Server.Tests/WebSockets/ShutdownDrainTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/ShutdownDrainTests.cs
@@ -202,10 +202,15 @@ public class ShutdownDrainTests
         await host.StopAsync();
 
         Assert.Equal(HealthStatus.Unhealthy, (await readiness.CheckHealthAsync(context)).Status);
+
         // The capacity check keeps its own meaning — an empty store is not "at capacity".
-        Assert.Equal(
-            HealthStatus.Healthy,
-            (await new RaskLiveHealthCheck(host.Store).CheckHealthAsync(context)).Status);
+        //
+        // The memory reading is pinned because it is a property of the MACHINE, not of the store: the
+        // check judges memory FIRST and lets it outrank the session count, by design, so on a host
+        // already past DegradedMemoryLoad an empty store reports Degraded and this assertion failed on
+        // load rather than on anything it meant to test (#732).
+        var capacity = new RaskLiveHealthCheck(host.Store) { MemoryLoadReader = () => 0.0 };
+        Assert.Equal(HealthStatus.Healthy, (await capacity.CheckHealthAsync(context)).Status);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #732.

`ShutdownDrainTests.Readiness_goes_unhealthy_while_draining_but_capacity_still_reports_capacity`
failed in a full `scripts/run-unit-local.sh` run and passed standalone. I hit it three times in one
session, on three unrelated changes — one of which touched no file under `src/Rask.Server` at all.

## Why

`RaskLiveHealthCheck` judges **memory load first** and lets it outrank the session count. That is
deliberate and documented on the class: *"what a session costs depends on the page, not on how many
there are"* — the same host holds ~66,000 sessions of a trivial page or ~735 of a 200-row grid, so a
session cap alone cannot keep it healthy.

The consequence is that the status is a property of the **machine**, not only of the store a test
constructs:

```csharp
private static double MemoryLoad()
{
    var info = GC.GetGCMemoryInfo();
    return info.TotalAvailableMemoryBytes <= 0 ? 0
        : (double)info.MemoryLoadBytes / info.TotalAvailableMemoryBytes;
}
```

With `DegradedMemoryLoad = 0.80`, a full-suite run — parallel test hosts, WASM native relinks — pushes
the process past the threshold, and an **empty** store reports `Degraded`. The test asserted `Healthy`
with the comment *"an empty store is not at capacity"*, which is true of the session branch and not of
the check as a whole.

It was not only that one test. Every test in `RaskLiveHealthCheckTests` went through a `Status(store)`
helper that also used the real reading, so the whole class was load-sensitive — `Uncapped_IsAlwaysHealthy`
included, which asserts `Healthy` on a branch that degrades under memory pressure by design.

## The fix

The reading becomes a seam, `MemoryLoadReader`, defaulting to the real `MemoryLoad`. Tests that are
about the session branch pin it; the production path is unchanged.

That also makes the memory thresholds testable **at all**. `DegradedMemoryLoad` and
`UnhealthyMemoryLoad` are load-bearing in production and had no coverage, because the only input was
whatever the host happened to be doing. Four tests added:

- at the ceiling → `Unhealthy`, even with an empty store;
- near the ceiling → `Degraded`, even with an empty store (the whole point of watching memory);
- an **uncapped** host still degrades and still goes unhealthy — "no session limit" is not "never
  unhealthy";
- an unreadable reading (`0`) is **not** an unhealthy one — the deliberate choice that a host must not
  shed load because it could not measure itself.

## Testing

Full `scripts/run-unit-local.sh`, green — the first clean full run on this machine today. The
previously-failing test now passes **in the full run**, under the same load that broke it:

```
Passed Rask.Server.Tests.WebSockets.ShutdownDrainTests.Readiness_goes_unhealthy_while_draining_but_capacity_still_reports_capacity [73 ms]
```

That is the condition that matters — it passed standalone before the fix too.
