### PR TITLE
fix(hosts): make every Rask.Core contract resolvable on Server, WASM and Native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ them until tagged releases begin.
   - **`HttpClient` on WASM.** `WasmHostBuilder` registers a lazy default (page origin as base address) with
     `TryAdd`, so `IAuthSignIn` resolves out of the box and an app that registers its own still wins.
 
-  **The gate.** `RaskHostContracts` names the 47 contracts Core promises everywhere, and each host's test
+  **The gate.** `RaskHostContracts` names the contracts Core promises everywhere, and each host's test
   project asserts its own bootstrap *resolves* every one — resolution rather than registration, because a
   descriptor whose dependencies are missing looks registered and still throws at the injection site, which
   is exactly how the WASM `HttpClient` hole shipped. A completeness test in `Rask.Core.Tests` partitions the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **Everything in `Rask.Core` now works on all three hosts, and a test says so.** Core is the shared
+  component surface, so a component written once is supposed to run on Server, WASM and Native alike. Four
+  of its contracts did not: the Native host registered no `IBrowserFileBackend`, no `IDownloadSink` and no
+  `IAuthSignIn`, and the WASM host registered a `WasmAuthSignIn` that needed an `HttpClient` nobody
+  registered. Each failed only on one host, only at runtime, with nothing at compile time to warn you.
+
+  This was not hypothetical: `samples/Rask.Example.Shared` is compiled into the native showcase, and its
+  `UploadDemo` handed the handler an **empty file list** (the user picks a file, the UI reports success,
+  nothing uploaded) while its `DownloadDemo` threw `InvalidOperationException`. A shared
+  `LoginPage(IAuthSignIn auth, ...)` — the shape `rask new` scaffolds — failed DI outright on a device.
+
+  - **File input on Native.** The `<input type=file>` ref registry moved out of `rask.wasm.js` into a
+    shared `Rask.Core/Resources/rask-files.js` spliced into both in-process clients, so the native client
+    captures picked files on `change` *and* on `submit` (`__files`). `NativeFileBackend` reads them back
+    a chunk at a time over `IJSRuntime`, so `RaskFile.OpenReadStream` is a real stream rather than bytes
+    inlined into a render payload.
+  - **`Navigator.Download` on Native.** `NativeDownloadSink` uses the same token-pull contract as WASM —
+    the bytes never ride the frame. Delivery is the platform's job: the host stages the file under the app
+    cache directory and hands it to the new **`INativeFileExport`**, whose platform implementations present
+    the OS share sheet (`UIActivityViewController` / `ACTION_SEND`), which is what "here is a file for you"
+    means on a device. With no platform module registered the file is still staged and the location
+    reported, so a shared component never crashes on the one head that has no share sheet. Download names
+    are reduced to a single safe path segment before they touch the filesystem — they can be
+    attacker-influenced, and on this host they become a real path.
+  - **`IAuthSignIn` on Native.** `NativeAuthSignIn` clears the local `ITokenStore`, posts to the logout
+    endpoint when the app has an `HttpClient` to reach one, refreshes `IUserProvider` and navigates. The
+    token is cleared *before* the network call, so an offline device still ends up signed out. `returnUrl`
+    is sanitized with the same `LocalUrl` rule the other hosts use — a native app reaches these through
+    deep links.
+  - **`HttpClient` on WASM.** `WasmHostBuilder` registers a lazy default (page origin as base address) with
+    `TryAdd`, so `IAuthSignIn` resolves out of the box and an app that registers its own still wins.
+
+  **The gate.** `RaskHostContracts` names the 47 contracts Core promises everywhere, and each host's test
+  project asserts its own bootstrap *resolves* every one — resolution rather than registration, because a
+  descriptor whose dependencies are missing looks registered and still throws at the injection site, which
+  is exactly how the WASM `HttpClient` hole shipped. A completeness test in `Rask.Core.Tests` partitions the
+  whole `Rask.Core.Browser` namespace against the list, so adding a wrapper forces an explicit decision
+  instead of quietly landing on one host.
+
+### Changed
+- **`Navigator.Download` and file-input errors name every host.** `Navigator`'s "no `IDownloadSink`" message
+  mentioned only Server and WASM. Worse, `FileListReader` returned an empty list when no
+  `IBrowserFileBackend` was registered and said nothing at all — the framework's quietest failure, and the
+  one that hid the native gap for a release. It now reports through `RaskDiagnostics`.
+
 ### Added
 - **Background Sync — `IBackgroundSync`** *(WASM)*. Ask the browser to wake the app when connectivity
   returns, or on a recurring schedule, so an edit made offline is flushed without the user coming back to

--- a/docs/native.md
+++ b/docs/native.md
@@ -23,8 +23,9 @@ one route served as HTML, the next fully native.
 > [Native device backends](native-devices.md#native-device-backends)) — with biometrics/push still to come. The native client
 > now shares the
 > transport-neutral DOM behaviour — rAF input/scroll coalescing, keyboard + drag events, and
-> scoped-CSS FOUC gating — with the Server and WASM clients (see [Roadmap](#roadmap)); only the
-> scoped-JS invoke gate and file uploads remain host-specific.
+> scoped-CSS FOUC gating — with the Server and WASM clients (see [Roadmap](#roadmap)), and
+> [file input, downloads and sign-out](#files-downloads-and-sign-out) work here as they do on the web
+> heads; only the scoped-JS invoke gate remains host-specific.
 
 ## On this page
 
@@ -32,7 +33,8 @@ one route served as HTML, the next fully native.
 - [Device capabilities & chrome](native-devices.md) — safe-area insets, device backends, native header/footer.
 
 Also in this doc: [How it fits](#how-it-fits), [Pure-native screens](#pure-native-screens-no-webview),
-[Get started](#get-started), [Honest framing](#honest-framing), [Roadmap](#roadmap).
+[Get started](#get-started), [Files, downloads and sign-out](#files-downloads-and-sign-out),
+[Honest framing](#honest-framing), [Roadmap](#roadmap).
 
 ---
 
@@ -241,6 +243,74 @@ Two ordering rules the generated heads already follow — keep them if you edit 
   inject `IRaskSqliteConnectionFactory`. The showcase's **Todos** tab does exactly this
   (`SqliteTodoStore`), so it survives an app restart on device while staying in-memory on Server/WASM.
 
+## Files, downloads and sign-out
+
+`Rask.Core` is the shared component surface, so anything a component can inject or call from it has to work
+on Server, WASM **and** native — otherwise a component written once breaks on one head only, at runtime,
+with nothing at compile time to warn you. `RaskHostContracts` names that set (47 contracts), and each host's
+test project asserts its own bootstrap resolves every one of them.
+
+Three of them used to be missing here, and the failures were quiet: a file input handed the handler an
+**empty list**, `Navigator.Download` threw, and injecting `IAuthSignIn` failed DI.
+
+### File input
+
+Nothing to wire. A file input works exactly as it does on the other hosts:
+
+```csharp
+Input.Value<string>(null)
+    .Type(InputType.File)
+    .OnFiles(files => { foreach (var f in files) Save(f.OpenReadStream()); })
+```
+
+The picked `File` stays in the WebView, registered under a short ref by the shared
+`Rask.Core/Resources/rask-files.js` module (spliced into both in-process clients). `NativeFileBackend`
+reads it back a chunk at a time over `IJSRuntime`, so `OpenReadStream` is a real stream — a large upload is
+never buffered through a render payload. Files picked in a form's `submit` arrive the same way.
+
+### Downloads → the OS share sheet
+
+`Navigator.Download(name, bytes, contentType)` works from any handler. What differs is the *delivery*: a
+browser downloads, and a device shares. `<a download>` does nothing useful in a `WKWebView`, and a file
+written into the app sandbox is invisible to the user on iOS unless the app opts into file sharing — so the
+host stages the file under the app cache directory and hands it to **`INativeFileExport`**:
+
+```csharp
+public interface INativeFileExport
+{
+    ValueTask ExportAsync(NativeFileExport file);   // FileName, ContentType, Path
+}
+```
+
+A platform head registers one (`UIActivityViewController` with the file URL on iOS,
+`Intent.ACTION_SEND` with a `FileProvider` URI on Android) through `INativePlatform.Register`, the same
+native-first seam the [device backends](native-devices.md#native-device-backends) use. Register your own on
+`host.Services` to send downloads somewhere else. With none registered the file is still staged and its
+location reported through `RaskDiagnostics`, so a shared component never crashes on a head that has no
+share sheet.
+
+The bytes never ride the frame: the payload carries a token, the client hands it straight back, and the host
+pulls the bytes — the same token-pull contract the WASM host uses. Download names are reduced to a single
+safe path segment before they touch the filesystem; on this host the name becomes a real path, and it can be
+attacker-influenced (a record title, a filename echoed back from an API).
+
+> `INativeFileExport` is deliberately separate from `IShare`. `ShareData` is Web-Share-shaped — title, text,
+> URL, no file — and widening it would change what the same type means on the WASM host.
+
+### Sign-out
+
+`NativeAuthSignIn` clears the local `ITokenStore`, posts to its `LogoutPath` when the app has registered an
+`HttpClient` to reach a server, refreshes `IUserProvider`, then navigates. Both server-facing dependencies
+are optional, because a Native + Local app need not have a backend at all — an offline app signs out by
+dropping its token. The token is cleared **before** the network call, so a failed request still leaves the
+device signed out rather than holding a live token. `returnUrl` goes through the same `LocalUrl` sanitizer
+the web hosts use; a native app reaches these through deep links.
+
+`SignInAsync(principal)` throws, as it does on WASM: a device cannot mint its own principal. POST credentials
+to a server endpoint and persist the issued token through `ITokenStore`.
+
+All four registrations use `TryAdd`, so an app or platform module that registers its own wins.
+
 ## Honest framing
 
 This is a **WebView hybrid** (the same architecture as .NET MAUI Blazor Hybrid, Ionic/Capacitor): C# runs
@@ -266,11 +336,13 @@ sandbox, and real background execution — without giving up "the same component
    (`Rask.Core/Resources/rask-input.js` — rAF input/scroll coalescing; `rask-scoped.js` — scoped-CSS
    FOUC gating; keyboard + the four core drag events folded into `rask-events.js`), spliced into all
    three clients (`rask.js`, `rask.wasm.js`, `rask.native.js`) instead of re-copied — so the native
-   client reached parity for them and the former Server↔WASM duplication collapsed. **Still per-host
+   client reached parity for them and the former Server↔WASM duplication collapsed. **File input and
+   download now work here too** — see [Files, downloads and sign-out](#files-downloads-and-sign-out); the
+   ref registry moved into a shared `rask-files.js`, and the transports stay per-host by design (a WASM
+   JSExport pull, a Server `fetch` upload, an `IJSRuntime` chunk read on native). **Still per-host
    (deferred):** the scoped-JS `Rask.*` invoke gate (genuinely diverged — WASM tracks scoped `rsk-`
    scripts with a 30s backstop, Server skips them with a 5s timeout; reconciling changes error-boundary
-   timing and needs its own pass) and file input/download (WASM JSExport pull vs Server `fetch` upload
-   vs a not-yet-built native file bridge).
+   timing and needs its own pass).
 4. **Showcase examples + on-device E2E** — ✅ *done.* Two runnable examples mirror the Server/WASM
    pairing, both mounting the **same** `Rask.Example.Shared.App`: `samples/Rask.Example.Native`
    (Native + Local, in-process) and `samples/Rask.Example.Native.Server` (Native + Server, a thin shell

--- a/src/Rask.Core/Forms/FileListReader.cs
+++ b/src/Rask.Core/Forms/FileListReader.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
+using Rask.Core.Diagnostics;
 using Rask.Core.Live;
 
 namespace Rask.Core.Forms;
@@ -16,6 +17,14 @@ internal static class FileListReader
         var backend = ResolveBackend();
         if (backend is null)
         {
+            // The client sent files and the handler is about to be told there were none. Silence here is the
+            // worst failure mode in the framework — the user picks a file, the UI reports success, and the
+            // upload never happened — and it is exactly how the native host went a release without file
+            // input. Every host registers a backend now, so this means the container was built by hand.
+            RaskDiagnostics.Report(RaskLogLevel.Error, "Rask.Forms",
+                $"[Rask.Forms] {arr.GetArrayLength()} file(s) arrived from the client but no "
+                + "IBrowserFileBackend is registered, so the handler will receive an empty list. Every Rask "
+                + "host registers one; if you built this container yourself, register a backend.");
             return Array.Empty<RaskFile>();
         }
 

--- a/src/Rask.Core/RaskHostContracts.cs
+++ b/src/Rask.Core/RaskHostContracts.cs
@@ -74,8 +74,8 @@ public static class RaskHostContracts
         typeof(INotifications), typeof(IOriginPrivateFileSystem), typeof(IPageVisibility),
         typeof(IPerformance), typeof(IPermissions), typeof(IResizeObserver), typeof(IScreenInfo),
         typeof(ISignaling), typeof(ISpeechRecognition), typeof(ISpeechSynthesis), typeof(IStorageEstimator),
-        typeof(IVibration), typeof(IVisualViewport), typeof(IWakeLock), typeof(IWebAuthn),
-        typeof(IWebLocks), typeof(IWebPush), typeof(IWebRtc),
+        typeof(IVibration), typeof(IViewTransitions), typeof(IVisualViewport), typeof(IWakeLock),
+        typeof(IWebAnimations), typeof(IWebAuthn), typeof(IWebLocks), typeof(IWebPush), typeof(IWebRtc),
     ];
 
     /// <summary>

--- a/src/Rask.Core/RaskHostContracts.cs
+++ b/src/Rask.Core/RaskHostContracts.cs
@@ -1,0 +1,100 @@
+using Microsoft.JSInterop;
+using Rask.Core.Authentication;
+using Rask.Core.Browser;
+using Rask.Core.Forms;
+using Rask.Core.Live;
+using Rask.Core.Messaging;
+using Rask.Core.Routing;
+
+namespace Rask.Core;
+
+/// <summary>
+///     The contracts <c>Rask.Core</c> guarantees are resolvable on <b>every</b> host — Server, WASM and
+///     Native. Core is the shared component surface: anything a component can inject or call from Core must
+///     work on all three, or a component shared between an app's web and native heads breaks on one of them
+///     only, at runtime, with no compile-time signal.
+/// </summary>
+/// <remarks>
+///     <para>
+///         This list is the machine-readable form of that rule. Each host's test project asserts that its own
+///         bootstrap (<c>AddRask</c> / <c>WasmHostBuilder</c> / <c>NativeAppHost.RunLocalAsync</c>) resolves
+///         every entry, so a host that forgets one fails the build instead of shipping a hole. That gate is
+///         the reason it exists: all three of <see cref="IBrowserFileBackend" />, <see cref="IDownloadSink" />
+///         and <see cref="IAuthSignIn" /> had silently drifted off the Native host before it was added.
+///     </para>
+///     <para>
+///         <see cref="BrowserApis" /> mirrors <see cref="RaskBrowserApis.AddCoreBrowserApis" /> — the
+///         transport-agnostic wrapper tier every host serves. It is spelled out rather than reflected so the
+///         registration helper can keep its trim-safe generic <c>TryAdd</c> calls; a completeness test in
+///         <c>Rask.Core.Tests</c> asserts this list plus <see cref="NonServiceBrowserTypes" /> covers every
+///         public interface in the <c>Rask.Core.Browser</c> namespace, so adding a wrapper forces a decision
+///         here rather than silently landing on one host.
+///     </para>
+/// </remarks>
+public static class RaskHostContracts
+{
+    /// <summary>
+    ///     The per-session/per-app services each host wires by hand. These are where drift actually happens:
+    ///     unlike <see cref="BrowserApis" /> there is no shared registration helper forcing the three hosts to
+    ///     agree, so each one spells them out in its own bootstrap.
+    /// </summary>
+    public static IReadOnlyList<Type> HostServices { get; } =
+    [
+        // Routing. Navigator additionally needs IDownloadSink below for Navigator.Download to work.
+        typeof(RouteState),
+        typeof(Navigator),
+        // Declared state, transient user messages, and the current user.
+        typeof(IPersistentState),
+        typeof(IToaster),
+        typeof(IUserProvider),
+        // Sign-in/out. The three hosts mean very different things by it (a cookie the server sets, a POST to
+        // a logout endpoint, a token cleared on device) — which is exactly why each must supply one.
+        typeof(IAuthSignIn),
+        // File input (<input type=file> -> RaskFile) and Navigator.Download.
+        typeof(IBrowserFileBackend),
+        typeof(IDownloadSink),
+        // The interop runtime every Core browser wrapper is built on.
+        typeof(IJSRuntime),
+    ];
+
+    /// <summary>
+    ///     The transport-agnostic browser/device wrappers from <see cref="RaskBrowserApis.AddCoreBrowserApis" />.
+    ///     Every host serves all of them: each is <see cref="IJSRuntime" />-backed and needs no transient user
+    ///     activation, so none of them depends on being in-process. A host or platform head may register a
+    ///     better implementation first (<c>TryAdd</c> makes the JS wrapper the fallback), but it may not
+    ///     register none.
+    /// </summary>
+    public static IReadOnlyList<Type> BrowserApis { get; } =
+    [
+        typeof(IBadge), typeof(IBattery), typeof(IBroadcastChannel), typeof(IBrowserStorage),
+        typeof(IClipboard), typeof(ICookies), typeof(ICrypto), typeof(IDeviceMotion),
+        typeof(IDeviceOrientation), typeof(IFileSystemAccess), typeof(IGamepad), typeof(IGeolocation),
+        typeof(IIndexedDb), typeof(IIntersectionObserver), typeof(IMediaQuery), typeof(IMediaSession),
+        typeof(IMediaStreams), typeof(IMutationObserver), typeof(INavigatorInfo), typeof(INetworkInfo),
+        typeof(INotifications), typeof(IOriginPrivateFileSystem), typeof(IPageVisibility),
+        typeof(IPerformance), typeof(IPermissions), typeof(IResizeObserver), typeof(IScreenInfo),
+        typeof(ISignaling), typeof(ISpeechRecognition), typeof(ISpeechSynthesis), typeof(IStorageEstimator),
+        typeof(IVibration), typeof(IVisualViewport), typeof(IWakeLock), typeof(IWebAuthn),
+        typeof(IWebLocks), typeof(IWebPush), typeof(IWebRtc),
+    ];
+
+    /// <summary>
+    ///     Public interfaces in <c>Rask.Core.Browser</c> that are <b>not</b> DI services: handles and
+    ///     connections a wrapper hands back (an open channel, a picked file, a held lock). They are created by
+    ///     the service that returns them, never resolved from the container — so the parity gate must not
+    ///     expect a registration for them. Listed explicitly so the completeness test can tell "deliberately
+    ///     not a service" apart from "forgot to register".
+    /// </summary>
+    public static IReadOnlyList<Type> NonServiceBrowserTypes { get; } =
+    [
+        typeof(IBroadcastChannelConnection), typeof(IDirectoryHandle), typeof(IFileHandle),
+        typeof(IKeyValueStore), typeof(IPeerConnection), typeof(IRtcDataChannel),
+        typeof(ISignalingConnection), typeof(IWakeLockSentinel), typeof(IWebStorage),
+    ];
+
+    /// <summary>
+    ///     Everything a host must resolve: <see cref="HostServices" /> followed by <see cref="BrowserApis" />.
+    ///     This is what the per-host parity tests iterate.
+    /// </summary>
+    public static IReadOnlyList<Type> All { get; } = [.. HostServices, .. BrowserApis];
+}

--- a/src/Rask.Core/Resources/rask-files.js
+++ b/src/Rask.Core/Resources/rask-files.js
@@ -1,0 +1,73 @@
+// Shared file-input plumbing for every in-process host (WASM and Native), spliced at @@RASK_FILES@@.
+//
+// An <input type=file> hands JS a live File object that cannot cross the interop boundary, so the client
+// keeps the File here and ships only metadata plus a short ref. .NET reads the bytes back a chunk at a time
+// through that ref, which is what lets RaskFile.OpenReadStream be a real Stream instead of a whole file
+// buffered into a render payload.
+//
+// This lived in rask.wasm.js and made file input a WASM-only capability by accident: the native client had
+// no registry, so a shared component's file handler silently received nothing on a native head. Anything
+// Rask.Core promises on every host has to live in a module every host splices — this one.
+//
+// Two readers because the hosts reach it differently: WASM re-exports raskReadFileChunk through a [JSImport]
+// that marshals a Uint8Array directly, while the Native host has no such bridge and goes through IJSRuntime,
+// which is JSON — hence the base64 variant, reached by identifier as window.__raskFiles.readChunkBase64.
+
+const raskFileRegistry = new Map();
+
+// Registers each File under a fresh ref and returns the metadata .NET turns into RaskFile instances.
+// Re-picking on the same input drops that input's previous refs, so a user cycling through files does not
+// pile up File objects (and their backing blobs) for the lifetime of the page.
+function raskRegisterFiles(inputEl, files) {
+    if (inputEl && inputEl.__raskFileRefs) {
+        for (const r of inputEl.__raskFileRefs) raskFileRegistry.delete(r);
+    }
+    const metas = [];
+    const refs = [];
+    for (const f of files) {
+        const r = (typeof crypto !== "undefined" && crypto.randomUUID)
+            ? crypto.randomUUID()
+            : "f-" + Math.random().toString(36).slice(2);
+        raskFileRegistry.set(r, f);
+        refs.push(r);
+        metas.push({
+            ref: r,
+            name: f.name,
+            size: f.size,
+            type: f.type || "application/octet-stream",
+            lastModified: f.lastModified || 0
+        });
+    }
+    if (inputEl) inputEl.__raskFileRefs = refs;
+    return metas;
+}
+
+// An unknown ref yields an empty chunk rather than throwing: .NET reads until it gets a short read, so a ref
+// invalidated mid-read (the user re-picked while a stream was open) ends the stream instead of faulting it.
+async function raskReadFileChunk(ref, offset, length) {
+    const file = raskFileRegistry.get(ref);
+    if (!file) return new Uint8Array();
+    const end = Math.min(file.size, offset + length);
+    if (end <= offset) return new Uint8Array();
+    const buf = await file.slice(offset, end).arrayBuffer();
+    return new Uint8Array(buf);
+}
+
+async function raskReadFileChunkBase64(ref, offset, length) {
+    const bytes = await raskReadFileChunk(ref, offset, length);
+    // Built one bounded slice at a time: String.fromCharCode.apply over a whole chunk blows the argument
+    // limit on large reads, and a per-byte string concat is quadratic. 8KB keeps both away.
+    let binary = "";
+    const step = 8192;
+    for (let i = 0; i < bytes.length; i += step) {
+        binary += String.fromCharCode.apply(null, bytes.subarray(i, i + step));
+    }
+    return btoa(binary);
+}
+
+// The identifier the Native host's IJSRuntime resolves. Harmless on WASM, which uses its [JSImport] export.
+if (typeof window !== "undefined") {
+    window.__raskFiles = {
+        readChunkBase64: raskReadFileChunkBase64
+    };
+}

--- a/src/Rask.Core/Routing/Navigator.cs
+++ b/src/Rask.Core/Routing/Navigator.cs
@@ -227,8 +227,10 @@ public sealed class Navigator(RouteState routeState, IDownloadSink? downloadSink
 
     private IDownloadSink ResolveSink() =>
         downloadSink ?? throw new InvalidOperationException(
-            "Navigator.Download requires an IDownloadSink. Rask.Server registers one via AddRask(); " +
-            "WASM hosts get one from WasmHostBuilder. If you're in a unit test, register a fake.");
+            "Navigator.Download requires an IDownloadSink. Every Rask host registers one — Rask.Server via " +
+            "AddRask(), WASM via WasmHostBuilder, native via NativeAppHost — so reaching this means the " +
+            "Navigator was built outside a host. If you're in a unit test, register a fake (Rask.Testing " +
+            "ships TestDownloadSink).");
 
     internal IDisposable EnterHandler()
     {

--- a/src/Rask.Native/Assets/rask.native.js
+++ b/src/Rask.Native/Assets/rask.native.js
@@ -4192,8 +4192,19 @@ function applyRender(json) {
     handle(reply);
 }
 
+// Navigator.Download staged bytes on the host. There is nothing useful a WebView can do with them itself —
+// <a download> is inert in a WKWebView — so the client's whole job is to hand the token straight back, and
+// the host pulls the bytes and gives them to the platform (INativeFileExport → the OS share sheet).
+function applyDownload(download) {
+    if (!download || typeof download.token !== "string" || download.token.length === 0) return;
+    send({ type: "download", token: download.token });
+}
+
 function handle(reply) {
     if (!reply || typeof reply !== "object") return;
+    // Before the render is queued: the download is an out-of-band side effect with no dependency on the DOM
+    // commit, and queueing it behind the morph would delay the share sheet behind a FOUC wait for no reason.
+    applyDownload(reply.download);
     if (reply.kind === "diff" && Array.isArray(reply.ops)) {
         _renderQueue = _renderQueue.then(() => applyDiffReply(reply), () => applyDiffReply(reply));
         return;
@@ -4411,13 +4422,103 @@ document.addEventListener("scroll", (e) => {
 }, true);
 
 
-// Change — report the control's value (checkbox → checked). Flush any pending coalesced input first
-// so a change-triggered validator reads the freshly-typed value, not the pre-flush one.
+// ----- input[type=file] ref registry (raskRegisterFiles / raskReadFileChunkBase64) — rask-files.js -----
+// Shared with the WASM client. The host reads the bytes back through window.__raskFiles.readChunkBase64
+// over IJSRuntime — see NativeFileBackend.
+// Shared file-input plumbing for every in-process host (WASM and Native), spliced at @@RASK_FILES@@.
+//
+// An <input type=file> hands JS a live File object that cannot cross the interop boundary, so the client
+// keeps the File here and ships only metadata plus a short ref. .NET reads the bytes back a chunk at a time
+// through that ref, which is what lets RaskFile.OpenReadStream be a real Stream instead of a whole file
+// buffered into a render payload.
+//
+// This lived in rask.wasm.js and made file input a WASM-only capability by accident: the native client had
+// no registry, so a shared component's file handler silently received nothing on a native head. Anything
+// Rask.Core promises on every host has to live in a module every host splices — this one.
+//
+// Two readers because the hosts reach it differently: WASM re-exports raskReadFileChunk through a [JSImport]
+// that marshals a Uint8Array directly, while the Native host has no such bridge and goes through IJSRuntime,
+// which is JSON — hence the base64 variant, reached by identifier as window.__raskFiles.readChunkBase64.
+
+const raskFileRegistry = new Map();
+
+// Registers each File under a fresh ref and returns the metadata .NET turns into RaskFile instances.
+// Re-picking on the same input drops that input's previous refs, so a user cycling through files does not
+// pile up File objects (and their backing blobs) for the lifetime of the page.
+function raskRegisterFiles(inputEl, files) {
+    if (inputEl && inputEl.__raskFileRefs) {
+        for (const r of inputEl.__raskFileRefs) raskFileRegistry.delete(r);
+    }
+    const metas = [];
+    const refs = [];
+    for (const f of files) {
+        const r = (typeof crypto !== "undefined" && crypto.randomUUID)
+            ? crypto.randomUUID()
+            : "f-" + Math.random().toString(36).slice(2);
+        raskFileRegistry.set(r, f);
+        refs.push(r);
+        metas.push({
+            ref: r,
+            name: f.name,
+            size: f.size,
+            type: f.type || "application/octet-stream",
+            lastModified: f.lastModified || 0
+        });
+    }
+    if (inputEl) inputEl.__raskFileRefs = refs;
+    return metas;
+}
+
+// An unknown ref yields an empty chunk rather than throwing: .NET reads until it gets a short read, so a ref
+// invalidated mid-read (the user re-picked while a stream was open) ends the stream instead of faulting it.
+async function raskReadFileChunk(ref, offset, length) {
+    const file = raskFileRegistry.get(ref);
+    if (!file) return new Uint8Array();
+    const end = Math.min(file.size, offset + length);
+    if (end <= offset) return new Uint8Array();
+    const buf = await file.slice(offset, end).arrayBuffer();
+    return new Uint8Array(buf);
+}
+
+async function raskReadFileChunkBase64(ref, offset, length) {
+    const bytes = await raskReadFileChunk(ref, offset, length);
+    // Built one bounded slice at a time: String.fromCharCode.apply over a whole chunk blows the argument
+    // limit on large reads, and a per-byte string concat is quadratic. 8KB keeps both away.
+    let binary = "";
+    const step = 8192;
+    for (let i = 0; i < bytes.length; i += step) {
+        binary += String.fromCharCode.apply(null, bytes.subarray(i, i + step));
+    }
+    return btoa(binary);
+}
+
+// The identifier the Native host's IJSRuntime resolves. Harmless on WASM, which uses its [JSImport] export.
+if (typeof window !== "undefined") {
+    window.__raskFiles = {
+        readChunkBase64: raskReadFileChunkBase64
+    };
+}
+
+
+// Change — report the control's value (checkbox → checked), or the picked files for a file input. Flush any
+// pending coalesced input first so a change-triggered validator reads the freshly-typed value, not the
+// pre-flush one.
 document.addEventListener("change", function (e) {
     const el = e.target;
     if (!el || !el.getAttribute) return;
+    if (!inRoot(el)) return;
+    // A file input carries data-rask-on-files, not data-rask-on-change: the frame ships file metadata rather
+    // than a value, and el.value on a file input is only the browser's fakepath stub.
+    // (No backslashes in this template — the MSBuild splice path-normalizes them into forward slashes.)
+    if (el.tagName === "INPUT" && el.type === "file" && el.hasAttribute("data-rask-on-files")) {
+        const files = el.files;
+        if (!files || files.length === 0) return;
+        if (typeof flushInputsNow === "function") flushInputsNow();
+        send({ id: el.getAttribute("data-rask-on-files"), type: "files", files: raskRegisterFiles(el, files) });
+        return;
+    }
     const id = el.getAttribute("data-rask-on-change");
-    if (!id || !inRoot(el)) return;
+    if (!id) return;
     if (typeof flushInputsNow === "function") flushInputsNow();
     // Through the shared module (rask-morph.js, spliced above at @@RASK_MORPH@@) rather than a local
     // valueOf — this host had its own copy, which is exactly the drift that left <select> unguarded.
@@ -4440,6 +4541,15 @@ document.addEventListener("submit", function (e) {
     const data = {};
     const fd = new FormData(form);
     fd.forEach(function (v, k) { if (typeof v === "string") data[k] = v; });
+    // File inputs inside the form: FormData yields File objects, which the loop above drops (they are not
+    // strings). Register them the same way the change path does and carry the metadata under __files, which
+    // is the key Core's FormData reader looks under. Same shape as the WASM client.
+    const fileFields = {};
+    for (const input of form.querySelectorAll('input[type="file"][name]')) {
+        if (!input.files || input.files.length === 0) continue;
+        fileFields[input.name] = raskRegisterFiles(input, input.files);
+    }
+    if (Object.keys(fileFields).length > 0) data.__files = fileFields;
     send({ id: id, type: "submit", form: data });
 });
 

--- a/src/Rask.Native/Authentication/NativeAuthSignIn.cs
+++ b/src/Rask.Native/Authentication/NativeAuthSignIn.cs
@@ -1,0 +1,80 @@
+using System.Security.Claims;
+using Rask.Core.Authentication;
+using Rask.Core.Routing;
+
+namespace Rask.Native.Authentication;
+
+/// <summary>
+///     Native-side <see cref="IAuthSignIn" />. Sign-out clears any client-held bearer token
+///     (<see cref="ITokenStore" />), tells the server to invalidate the session when the app has an
+///     <see cref="HttpClient" /> to reach it, refreshes <see cref="IUserProvider" />, and navigates to
+///     <c>returnUrl</c> in-app.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Both server-facing dependencies are optional because a Native + Local app need not have a backend
+///         at all — an offline, on-device app signs out purely by dropping its local token. When the app does
+///         register an <see cref="HttpClient" /> (the usual case: a device app against a Rask Server), sign-out
+///         also posts to <see cref="LogoutPath" />, because clearing the token on the device alone leaves the
+///         session valid on the server.
+///     </para>
+///     <para>
+///         Registered by <c>NativeAppHost</c> with <c>TryAdd</c>, so an app with its own auth flow (OIDC via
+///         a system browser, a platform keychain) replaces it by registering first.
+///     </para>
+/// </remarks>
+public sealed class NativeAuthSignIn(
+    IUserProvider userProvider,
+    Navigator navigator,
+    ITokenStore? tokenStore = null,
+    HttpClient? http = null) : IAuthSignIn
+{
+    /// <summary>
+    ///     The server endpoint sign-out posts to when an <see cref="HttpClient" /> is registered, so the
+    ///     server can invalidate the session. Defaults to <c>auth/logout</c>; relative to the client's base
+    ///     address.
+    /// </summary>
+    public string LogoutPath { get; init; } = "auth/logout";
+
+    /// <summary>
+    ///     Not supported on the native host, and throws. The device cannot mint its own principal — anything
+    ///     the client decides about who it is, it has decided about itself. POST credentials to a server
+    ///     endpoint with <see cref="HttpClient" /> and store the token it issues via <see cref="ITokenStore" />.
+    /// </summary>
+    /// <param name="principal">Unused.</param>
+    /// <param name="returnUrl">Unused.</param>
+    /// <param name="scheme">Unused.</param>
+    /// <exception cref="NotSupportedException">Always.</exception>
+    public Task SignInAsync(ClaimsPrincipal principal, string? returnUrl = null, string? scheme = null) =>
+        throw new NotSupportedException(
+            "NativeAuthSignIn does not support principal-based sign-in. POST credentials to your server " +
+            "endpoint via HttpClient and persist the issued token through ITokenStore instead.");
+
+    /// <summary>
+    ///     Signs the user out: clears the local token, posts to <see cref="LogoutPath" /> when a server is
+    ///     reachable, refreshes the current user, then navigates to <paramref name="returnUrl" />.
+    /// </summary>
+    /// <param name="returnUrl">Where to go afterwards.</param>
+    /// <param name="scheme">Authentication scheme, when the app distinguishes several. Unused here.</param>
+    public async Task SignOutAsync(string? returnUrl = null, string? scheme = null)
+    {
+        // Local first, and unconditionally: if the network call below fails (a device app is offline far more
+        // often than a browser tab), the user must still end up signed out on this device rather than
+        // stranded in a half-signed-out state holding a live token.
+        if (tokenStore is not null)
+        {
+            await tokenStore.ClearAsync().ConfigureAwait(false);
+        }
+
+        if (http is not null)
+        {
+            await http.PostAsync(LogoutPath, null).ConfigureAwait(false);
+        }
+
+        await userProvider.RefreshAsync().ConfigureAwait(false);
+        // Open-redirect guard: returnUrl is whatever the caller passed (often a query value that can be
+        // attacker-influenced — a native app reaches these through deep links). Collapse anything non-local
+        // to "/" at this boundary, the same LocalUrl rule the Server and WASM sign-in paths apply.
+        navigator.NavigateTo(LocalUrl.Sanitize(returnUrl));
+    }
+}

--- a/src/Rask.Native/Files/INativeFileExport.cs
+++ b/src/Rask.Native/Files/INativeFileExport.cs
@@ -1,0 +1,59 @@
+using Rask.Core.Diagnostics;
+
+namespace Rask.Native.Files;
+
+/// <summary>
+///     How a file the app produced reaches the user on a native head. <c>Navigator.Download</c> means "here
+///     are some bytes for you to keep"; in a browser that is a download, and on a device it is the OS share
+///     sheet — the user picks Files, iCloud/Drive, mail, AirDrop, or another app.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The framework has already written the bytes to a file under the app's cache directory by the time
+///         this is called, so an implementation only has to present it: <c>UIActivityViewController</c> with
+///         the file URL on iOS, <c>Intent.ACTION_SEND</c> with a <c>FileProvider</c> URI on Android. A
+///         platform module registers its own through <see cref="INativePlatform.Register" />.
+///     </para>
+///     <para>
+///         Deliberately not routed through <c>IShare</c>: that contract is Web-Share-shaped
+///         (<c>ShareData</c> carries title/text/URL and no file), and widening it would change the meaning of
+///         the same type on the WASM host.
+///     </para>
+/// </remarks>
+public interface INativeFileExport
+{
+    /// <summary>Hand <paramref name="file" /> to the platform for the user to keep or send on.</summary>
+    ValueTask ExportAsync(NativeFileExport file);
+}
+
+/// <summary>A file the app produced, staged on disk and ready to hand to the platform.</summary>
+/// <param name="FileName">
+///     The name to present to the user. Already sanitized to a single path segment — never a path.
+/// </param>
+/// <param name="ContentType">The MIME type, for the platform's app picker.</param>
+/// <param name="Path">Absolute path to the staged file under the app's cache directory.</param>
+public sealed record NativeFileExport(string FileName, string ContentType, string Path);
+
+/// <summary>
+///     The fallback <see cref="INativeFileExport" />, wired by <c>NativeAppHost</c> with <c>TryAdd</c> when
+///     no platform module supplied one. The file is already staged on disk; with no platform UI to present it
+///     the only honest thing left is to say where it went.
+/// </summary>
+/// <remarks>
+///     This is what the plain <c>net10.0</c> head (CI, unit tests, a desktop harness) gets. It reports rather
+///     than throws so a shared component calling <c>Navigator.Download</c> behaves the same everywhere — the
+///     app does not crash on the one head that has no share sheet — while still leaving a trace that the
+///     download had nowhere to go.
+/// </remarks>
+internal sealed class DiagnosticFileExport : INativeFileExport
+{
+    public ValueTask ExportAsync(NativeFileExport file)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+        RaskDiagnostics.Report(RaskLogLevel.Information, "Rask.Native",
+            $"[Rask.Native] Download '{file.FileName}' was staged at {file.Path}, but no INativeFileExport is "
+            + "registered, so it was not presented to the user. The iOS and Android platform modules register "
+            + "one (the OS share sheet); register your own on host.Services to control where downloads go.");
+        return default;
+    }
+}

--- a/src/Rask.Native/Files/NativeDownloadSink.cs
+++ b/src/Rask.Native/Files/NativeDownloadSink.cs
@@ -1,0 +1,92 @@
+using System.Collections.Concurrent;
+using Rask.Core.Routing;
+
+namespace Rask.Native.Files;
+
+/// <summary>
+///     Token-pull <see cref="IDownloadSink" /> for the native host — the same wire contract the WASM sink
+///     uses: the bytes stay .NET-side and only a short token rides in the render payload, which the client
+///     hands straight back on a <c>{"type":"download"}</c> message. Nothing is base64'd through the WebView
+///     bridge.
+/// </summary>
+/// <remarks>
+///     Where the browser hosts finish by letting the page download the bytes, the native host has no such
+///     affordance: <c>&lt;a download&gt;</c> does nothing useful in a WKWebView, and a file written into the
+///     app's own sandbox is invisible to the user on iOS unless the app opts into file sharing. So
+///     <c>NativeAppHost</c> pulls the bytes here and hands them to <see cref="INativeFileExport" />, whose
+///     platform implementations present the OS share sheet — the mobile meaning of "here is a file for you".
+///     <para>
+///         Unlike the WASM sink this is thread-safe: the native session fans render continuations onto the
+///         thread pool, so a stage and a pull can genuinely race.
+///     </para>
+/// </remarks>
+internal sealed class NativeDownloadSink : IDownloadSink
+{
+    // Same bound and reasoning as WasmDownloadSink: only the most recently staged download is ever shipped,
+    // and a real pull removes its entry, so the map stays near-empty in the normal stage→pull flow. Orphans
+    // (a second Stage before the first is consumed, a token the user never triggers because they navigated
+    // away) would otherwise retain their byte[] for the whole app lifetime. Evicting past the cap turns an
+    // unbounded leak into a bounded working set.
+    private const int MaxRetainedStagings = 16;
+
+    private readonly ConcurrentDictionary<string, StagedDownload> _byToken = new();
+    private readonly Lock _gate = new();
+    private readonly Queue<string> _order = new();
+    private PendingDownload? _pending;
+
+    /// <summary>Test seam: how many staged downloads are currently retained.</summary>
+    internal int RetainedCount => _byToken.Count;
+
+    public void Stage(string filename, byte[] bytes, string? contentType)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        var token = Guid.NewGuid().ToString("N");
+        var resolvedContentType = contentType ?? "application/octet-stream";
+        // The name and type are retained alongside the bytes, not just put in the payload: the client echoes
+        // back only the token, and by then the PendingDownload that carried the name has been consumed into
+        // the frame. Without this the file would reach the share sheet called "download".
+        _byToken[token] = new StagedDownload(filename, resolvedContentType, bytes);
+
+        lock (_gate)
+        {
+            _order.Enqueue(token);
+            while (_order.Count > MaxRetainedStagings && _order.TryDequeue(out var oldest))
+            {
+                // No-op when `oldest` was already pulled — TryRemove just returns false.
+                _byToken.TryRemove(oldest, out _);
+            }
+
+            _pending = new PendingDownload(filename, resolvedContentType, null, null, token);
+        }
+    }
+
+    public void Stage(string filename, Stream stream, string? contentType)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        Stage(filename, ms.ToArray(), contentType);
+    }
+
+    public bool TryConsume(out PendingDownload? download)
+    {
+        lock (_gate)
+        {
+            download = _pending;
+            _pending = null;
+            return download is not null;
+        }
+    }
+
+    /// <summary>
+    ///     Drains the token and returns the staged file once. Returns <c>null</c> on a miss rather than
+    ///     throwing, so a stale or replayed token from the WebView is a no-op instead of a crash — the client
+    ///     is the one place a token can arrive twice.
+    /// </summary>
+    internal StagedDownload? Pull(string token) => _byToken.TryRemove(token, out var staged) ? staged : null;
+
+    /// <summary>Bytes held for one token, with the name and type they should reach the user under.</summary>
+    internal sealed record StagedDownload(string FileName, string ContentType, byte[] Bytes);
+}

--- a/src/Rask.Native/Files/NativeDownloadStaging.cs
+++ b/src/Rask.Native/Files/NativeDownloadStaging.cs
@@ -1,0 +1,79 @@
+using System.Globalization;
+
+namespace Rask.Native.Files;
+
+/// <summary>
+///     Writes a staged download to disk so <see cref="INativeFileExport" /> has a file URL to hand the
+///     platform, and reduces the caller's suggested name to something safe to use as one.
+/// </summary>
+/// <remarks>
+///     The name matters here in a way it does not on the browser hosts. There, <c>Navigator.Download</c>'s
+///     filename is only a suggestion the browser sanitizes before it touches a filesystem. On a native head it
+///     becomes a real path, and the value can be attacker-influenced — an export named after a user-supplied
+///     record title, a filename echoed back from an API. So it is reduced to a single path segment before it
+///     is joined to anything.
+/// </remarks>
+internal static class NativeDownloadStaging
+{
+    private const string FallbackName = "download";
+
+    /// <summary>
+    ///     Writes <paramref name="bytes" /> under the app's cache directory and returns the export descriptor.
+    ///     Each download gets its own subdirectory, so two files with the same name never collide and the
+    ///     sanitized name can be presented to the user verbatim.
+    /// </summary>
+    public static async Task<NativeFileExport> StageAsync(
+        string filename, string? contentType, byte[] bytes, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        var safeName = SafeFileName(filename);
+        var directory = Path.Combine(
+            Path.GetTempPath(), "rask-downloads", Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+        Directory.CreateDirectory(directory);
+
+        var path = Path.Combine(directory, safeName);
+        await File.WriteAllBytesAsync(path, bytes, cancellationToken).ConfigureAwait(false);
+
+        return new NativeFileExport(safeName, contentType ?? "application/octet-stream", path);
+    }
+
+    /// <summary>
+    ///     Reduces a caller-supplied download name to a single, safe path segment: no directory components on
+    ///     either platform's separator, no traversal, no control characters, and never empty.
+    /// </summary>
+    internal static string SafeFileName(string? filename)
+    {
+        if (string.IsNullOrWhiteSpace(filename))
+        {
+            return FallbackName;
+        }
+
+        // Both separators, unconditionally. Path.GetFileName is platform-aware, so on Unix it treats a
+        // backslash as an ordinary character and would hand back "..\\..\\etc\\passwd" intact — a name that is
+        // harmless on the host running the test and a traversal on a head that later joins it under Windows
+        // rules. Cutting at the last of either is what makes the result platform-independent.
+        var lastSeparator = filename.AsSpan().LastIndexOfAny('/', '\\');
+        var candidate = lastSeparator >= 0 ? filename[(lastSeparator + 1)..] : filename;
+
+        // Control characters (a newline in a name would also break the platform's own presentation) and
+        // anything the filesystem rejects.
+        var invalid = Path.GetInvalidFileNameChars();
+        var cleaned = string.Create(candidate.Length, candidate, (span, source) =>
+        {
+            for (var i = 0; i < source.Length; i++)
+            {
+                var c = source[i];
+                span[i] = char.IsControl(c) || Array.IndexOf(invalid, c) >= 0 ? '_' : c;
+            }
+        });
+
+        cleaned = cleaned.Trim();
+        // "." and ".." survive every filter above — they contain no invalid character and no separator — yet
+        // neither is a file. Trailing dots and spaces are also stripped because Windows silently drops them,
+        // which would turn "report.txt." into a different name than the one reported to the user.
+        cleaned = cleaned.TrimEnd('.', ' ');
+
+        return cleaned.Length == 0 ? FallbackName : cleaned;
+    }
+}

--- a/src/Rask.Native/Files/NativeFileBackend.cs
+++ b/src/Rask.Native/Files/NativeFileBackend.cs
@@ -1,0 +1,145 @@
+using System.Text.Json;
+using Microsoft.JSInterop;
+using Rask.Core.Forms;
+
+namespace Rask.Native.Files;
+
+/// <summary>
+///     The native host's <see cref="IBrowserFileBackend" />. The picked <c>File</c> stays in the WebView,
+///     registered under a short ref by the shared <c>rask-files.js</c> module; this reads its bytes back a
+///     chunk at a time over <see cref="IJSRuntime" />, so <c>RaskFile.OpenReadStream</c> is a real stream and
+///     a large upload never has to be buffered through a render payload.
+/// </summary>
+/// <remarks>
+///     The same ref protocol the WASM backend uses — the difference is only the transport. WASM marshals a
+///     <c>Uint8Array</c> straight across its <c>[JSImport]</c> bridge; the native bridge is JSON, so chunks
+///     come back base64 and are decoded here.
+/// </remarks>
+internal sealed class NativeFileBackend(IJSRuntime js) : IBrowserFileBackend
+{
+    public RaskFile Create(JsonElement metadata)
+    {
+        var @ref = metadata.TryGetProperty("ref", out var r) && r.ValueKind == JsonValueKind.String
+            ? r.GetString() ?? string.Empty
+            : string.Empty;
+        if (string.IsNullOrEmpty(@ref))
+        {
+            throw new InvalidOperationException(
+                "A file arrived without a client-side ref, so the host cannot read its bytes. The ref is "
+                + "added by rask-files.js when the file input's change (or the form's submit) is captured — "
+                + "this usually means the file metadata was constructed by hand rather than coming from a "
+                + "file input, or the WebView is running a client script from a different Rask version.");
+        }
+
+        var name = metadata.TryGetProperty("name", out var n) && n.ValueKind == JsonValueKind.String
+            ? n.GetString() ?? string.Empty
+            : string.Empty;
+        var size = metadata.TryGetProperty("size", out var sz) && sz.ValueKind == JsonValueKind.Number
+            ? sz.GetInt64()
+            : 0L;
+        var contentType = metadata.TryGetProperty("type", out var ct) && ct.ValueKind == JsonValueKind.String
+            ? ct.GetString() ?? "application/octet-stream"
+            : "application/octet-stream";
+        var lastModified = metadata.TryGetProperty("lastModified", out var lm) && lm.ValueKind == JsonValueKind.Number
+            ? DateTimeOffset.FromUnixTimeMilliseconds(lm.GetInt64())
+            : DateTimeOffset.UnixEpoch;
+
+        return new NativeRaskFile(js, @ref, name, size, contentType, lastModified);
+    }
+
+    public void Release(IEnumerable<RaskFile> files)
+    {
+        // The WebView-side registry drops an input's refs when it next fires a change, so there is nothing to
+        // release synchronously. Matches the WASM backend; the dispatcher calls this for symmetry with the
+        // server backend, whose uploads do occupy a store until released.
+    }
+}
+
+internal sealed class NativeRaskFile(
+    IJSRuntime js,
+    string @ref,
+    string name,
+    long size,
+    string contentType,
+    DateTimeOffset lastModified) : RaskFile
+{
+    public string Ref { get; } = @ref;
+    public override string Name { get; } = name;
+    public override long Size { get; } = size;
+    public override string ContentType { get; } = contentType;
+    public override DateTimeOffset LastModified { get; } = lastModified;
+
+    public override Stream OpenReadStream(long maxAllowedSize = 512 * 1024,
+        CancellationToken cancellationToken = default)
+    {
+        if (Size > maxAllowedSize)
+        {
+            throw new IOException($"File '{Name}' is {Size} bytes, exceeds maxAllowedSize of {maxAllowedSize}.");
+        }
+
+        return new NativeFileStream(js, Ref, Size, cancellationToken);
+    }
+}
+
+internal sealed class NativeFileStream(IJSRuntime js, string @ref, long length, CancellationToken ct) : Stream
+{
+    // Matches the WASM stream's chunk size. Each chunk costs one bridge round-trip and inflates ~33% as
+    // base64 on the way back, so it wants to be large; it also lands in a JS string, so it wants to be
+    // bounded. 64KB is where both the WASM client and the server upload path already sit.
+    private const int ChunkSize = 64 * 1024;
+
+    private long _position;
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length { get; } = length;
+
+    public override long Position
+    {
+        get => _position;
+        set => throw new NotSupportedException();
+    }
+
+    public override void Flush() { }
+
+    public override int Read(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException("NativeFileStream is async-only — use ReadAsync.");
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer,
+        CancellationToken cancellationToken = default)
+    {
+        if (_position >= Length)
+        {
+            return 0;
+        }
+
+        var remaining = Length - _position;
+        var requested = (int)Math.Min(Math.Min(buffer.Length, ChunkSize), remaining);
+        var token = cancellationToken == default ? ct : cancellationToken;
+
+        var base64 = await js.InvokeAsync<string>(
+            "__raskFiles.readChunkBase64", token, @ref, _position, requested).ConfigureAwait(false);
+        if (string.IsNullOrEmpty(base64))
+        {
+            // The registry drops a ref when the user re-picks on the same input. Ending the stream short
+            // beats faulting it: the caller sees a truncated read, which is what actually happened.
+            return 0;
+        }
+
+        var chunk = Convert.FromBase64String(base64);
+        // Clamped rather than trusted: the length comes back from the WebView, and a chunk longer than the
+        // caller's buffer would be a buffer overrun dressed up as a read.
+        var copied = Math.Min(chunk.Length, buffer.Length);
+        chunk.AsSpan(0, copied).CopyTo(buffer.Span);
+        _position += copied;
+        return copied;
+    }
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+        ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+}

--- a/src/Rask.Native/NativeAppHost.cs
+++ b/src/Rask.Native/NativeAppHost.cs
@@ -10,9 +10,12 @@ using Rask.Core;
 using Rask.Core.Authentication;
 using Rask.Core.Browser;
 using Rask.Core.Diagnostics;
+using Rask.Core.Forms;
 using Rask.Core.Live;
 using Rask.Core.Messaging;
 using Rask.Core.Routing;
+using Rask.Native.Authentication;
+using Rask.Native.Files;
 using Rask.Native.Surface;
 
 namespace Rask.Native;
@@ -68,6 +71,16 @@ public sealed class NativeAppHost
         // the WebView's JS engine. This is the framework-picks-the-best-impl path — see UsePlatform below.
 
         Services.TryAddSingleton<IUserProvider, AnonymousUserProvider>();
+        // The rest of Rask.Core's per-host contract (RaskHostContracts.HostServices). These three were the
+        // gap this host shipped with: a component shared with the web heads lost its file uploads silently,
+        // threw on Navigator.Download, and failed DI outright on IAuthSignIn — all only on native, all only
+        // at runtime. TryAdd throughout, so an app or platform module that registers its own still wins.
+        Services.TryAddSingleton<IBrowserFileBackend, NativeFileBackend>();
+        Services.TryAddSingleton<NativeDownloadSink>();
+        Services.TryAddSingleton<IDownloadSink>(sp => sp.GetRequiredService<NativeDownloadSink>());
+        // No platform head registered one, so downloads land on disk and say so rather than vanishing.
+        Services.TryAddSingleton<INativeFileExport, DiagnosticFileExport>();
+        Services.TryAddSingleton<IAuthSignIn, NativeAuthSignIn>();
         Services.AddAuthorizationCore();
 
         // IJSRuntime backed by the native WebView bridge. Singleton — one runtime per app instance;
@@ -284,9 +297,52 @@ public sealed class NativeAppHost
                 // A native back button — pop WebView history (its popstate re-enters the router as a navigate).
                 await app.Session.GoBackAsync().ConfigureAwait(false);
                 return;
+            case "download":
+                // Navigator.Download staged bytes and the client handed the token back. Pull them, write the
+                // file, and let the platform present it. See HandleDownloadAsync.
+                await HandleDownloadAsync(app, root).ConfigureAwait(false);
+                return;
             default:
                 await app.Session.DispatchAsync(json).ConfigureAwait(false);
                 return;
+        }
+    }
+
+    // { type:"download", token:"<hex>" } — the client echoing back the token Navigator.Download put in the
+    // render payload. The bytes never left .NET; this drains them, stages a file under the app's cache
+    // directory, and hands it to INativeFileExport (the OS share sheet on a real platform head).
+    //
+    // Every failure here is reported rather than thrown: this runs on the WebView's message pump, where an
+    // escaping exception takes down message routing for the whole app — a failed download must not cost the
+    // user their session.
+    private static async Task HandleDownloadAsync(NativeApp app, JsonElement root)
+    {
+        if (!root.TryGetProperty("token", out var tokenEl) || tokenEl.ValueKind != JsonValueKind.String
+            || tokenEl.GetString() is not { Length: > 0 } token)
+        {
+            RaskDiagnostics.Report(RaskLogLevel.Warning, "Rask.Native",
+                "[Rask.Native] discarded a download message with no token");
+            return;
+        }
+
+        // A stale or replayed token pulls nothing — the client is the one place a token can arrive twice.
+        if (app.Services.GetService<IDownloadSink>() is not NativeDownloadSink sink
+            || sink.Pull(token) is not { } staged)
+        {
+            return;
+        }
+
+        try
+        {
+            var file = await NativeDownloadStaging
+                .StageAsync(staged.FileName, staged.ContentType, staged.Bytes).ConfigureAwait(false);
+            var export = app.Services.GetService<INativeFileExport>() ?? new DiagnosticFileExport();
+            await export.ExportAsync(file).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            RaskDiagnostics.Report(RaskLogLevel.Error, "Rask.Native",
+                $"[Rask.Native] failed to hand the download '{staged.FileName}' to the platform", ex);
         }
     }
 

--- a/src/Rask.Native/Rask.Native.csproj
+++ b/src/Rask.Native/Rask.Native.csproj
@@ -177,7 +177,7 @@
     above and re-generated (WriteOnlyWhenDifferent) whenever a shared module or the template changes.
   -->
   <Target Name="_RaskSpliceNativeClientJs" BeforeTargets="PrepareForBuild;AssignTargetPaths;BeforeCompile"
-          Inputs="Resources\rask.native.js;..\Rask.Core\Resources\rask-dom.js;..\Rask.Core\Resources\rask-morph.js;..\Rask.Core\Resources\rask-api.js;..\Rask.Core\Resources\rask-events.js;..\Rask.Core\Resources\rask-pwa.js;..\Rask.Core\Resources\rask-input.js;..\Rask.Core\Resources\rask-scoped.js;..\Rask.Core\Resources\rask-hotreload.js"
+          Inputs="Resources\rask.native.js;..\Rask.Core\Resources\rask-dom.js;..\Rask.Core\Resources\rask-morph.js;..\Rask.Core\Resources\rask-api.js;..\Rask.Core\Resources\rask-events.js;..\Rask.Core\Resources\rask-pwa.js;..\Rask.Core\Resources\rask-input.js;..\Rask.Core\Resources\rask-scoped.js;..\Rask.Core\Resources\rask-hotreload.js;..\Rask.Core\Resources\rask-deverror.js;..\Rask.Core\Resources\rask-files.js"
           Outputs="Assets\rask.native.js">
     <PropertyGroup>
       <_RaskNativeTemplate>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\Resources\rask.native.js'))</_RaskNativeTemplate>
@@ -189,8 +189,9 @@
       <_RaskInputBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-input.js'))</_RaskInputBody>
       <_RaskScopedBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-scoped.js'))</_RaskScopedBody>
       <_RaskHotReloadBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-hotreload.js'))</_RaskHotReloadBody>
+      <_RaskFilesBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-files.js'))</_RaskFilesBody>
       <_RaskDevErrorBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-deverror.js'))</_RaskDevErrorBody>
-      <_RaskNativeJs>$(_RaskNativeTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_EVENTS@@', '$(_RaskEventsBody)').Replace('// @@RASK_PWA@@', '$(_RaskPwaBody)').Replace('// @@RASK_INPUT@@', '$(_RaskInputBody)').Replace('// @@RASK_SCOPED@@', '$(_RaskScopedBody)').Replace('// @@RASK_HOTRELOAD@@', '$(_RaskHotReloadBody)').Replace('// @@RASK_DEVERROR@@', '$(_RaskDevErrorBody)'))</_RaskNativeJs>
+      <_RaskNativeJs>$(_RaskNativeTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_EVENTS@@', '$(_RaskEventsBody)').Replace('// @@RASK_PWA@@', '$(_RaskPwaBody)').Replace('// @@RASK_INPUT@@', '$(_RaskInputBody)').Replace('// @@RASK_SCOPED@@', '$(_RaskScopedBody)').Replace('// @@RASK_HOTRELOAD@@', '$(_RaskHotReloadBody)').Replace('// @@RASK_DEVERROR@@', '$(_RaskDevErrorBody)').Replace('// @@RASK_FILES@@', '$(_RaskFilesBody)'))</_RaskNativeJs>
     </PropertyGroup>
     <MakeDir Directories="Assets"/>
     <WriteLinesToFile File="Assets\rask.native.js" Lines="$(_RaskNativeJs)" Overwrite="true" WriteOnlyWhenDifferent="true"/>

--- a/src/Rask.Native/Resources/rask.native.js
+++ b/src/Rask.Native/Resources/rask.native.js
@@ -100,8 +100,19 @@ function applyRender(json) {
     handle(reply);
 }
 
+// Navigator.Download staged bytes on the host. There is nothing useful a WebView can do with them itself —
+// <a download> is inert in a WKWebView — so the client's whole job is to hand the token straight back, and
+// the host pulls the bytes and gives them to the platform (INativeFileExport → the OS share sheet).
+function applyDownload(download) {
+    if (!download || typeof download.token !== "string" || download.token.length === 0) return;
+    send({ type: "download", token: download.token });
+}
+
 function handle(reply) {
     if (!reply || typeof reply !== "object") return;
+    // Before the render is queued: the download is an out-of-band side effect with no dependency on the DOM
+    // commit, and queueing it behind the morph would delay the share sheet behind a FOUC wait for no reason.
+    applyDownload(reply.download);
     if (reply.kind === "diff" && Array.isArray(reply.ops)) {
         _renderQueue = _renderQueue.then(() => applyDiffReply(reply), () => applyDiffReply(reply));
         return;
@@ -219,13 +230,30 @@ window.addEventListener("popstate", function () {
 // call it regardless of splice order.
 // @@RASK_INPUT@@
 
-// Change — report the control's value (checkbox → checked). Flush any pending coalesced input first
-// so a change-triggered validator reads the freshly-typed value, not the pre-flush one.
+// ----- input[type=file] ref registry (raskRegisterFiles / raskReadFileChunkBase64) — rask-files.js -----
+// Shared with the WASM client. The host reads the bytes back through window.__raskFiles.readChunkBase64
+// over IJSRuntime — see NativeFileBackend.
+// @@RASK_FILES@@
+
+// Change — report the control's value (checkbox → checked), or the picked files for a file input. Flush any
+// pending coalesced input first so a change-triggered validator reads the freshly-typed value, not the
+// pre-flush one.
 document.addEventListener("change", function (e) {
     const el = e.target;
     if (!el || !el.getAttribute) return;
+    if (!inRoot(el)) return;
+    // A file input carries data-rask-on-files, not data-rask-on-change: the frame ships file metadata rather
+    // than a value, and el.value on a file input is only the browser's fakepath stub.
+    // (No backslashes in this template — the MSBuild splice path-normalizes them into forward slashes.)
+    if (el.tagName === "INPUT" && el.type === "file" && el.hasAttribute("data-rask-on-files")) {
+        const files = el.files;
+        if (!files || files.length === 0) return;
+        if (typeof flushInputsNow === "function") flushInputsNow();
+        send({ id: el.getAttribute("data-rask-on-files"), type: "files", files: raskRegisterFiles(el, files) });
+        return;
+    }
     const id = el.getAttribute("data-rask-on-change");
-    if (!id || !inRoot(el)) return;
+    if (!id) return;
     if (typeof flushInputsNow === "function") flushInputsNow();
     // Through the shared module (rask-morph.js, spliced above at @@RASK_MORPH@@) rather than a local
     // valueOf — this host had its own copy, which is exactly the drift that left <select> unguarded.
@@ -248,6 +276,15 @@ document.addEventListener("submit", function (e) {
     const data = {};
     const fd = new FormData(form);
     fd.forEach(function (v, k) { if (typeof v === "string") data[k] = v; });
+    // File inputs inside the form: FormData yields File objects, which the loop above drops (they are not
+    // strings). Register them the same way the change path does and carry the metadata under __files, which
+    // is the key Core's FormData reader looks under. Same shape as the WASM client.
+    const fileFields = {};
+    for (const input of form.querySelectorAll('input[type="file"][name]')) {
+        if (!input.files || input.files.length === 0) continue;
+        fileFields[input.name] = raskRegisterFiles(input, input.files);
+    }
+    if (Object.keys(fileFields).length > 0) data.__files = fileFields;
     send({ id: id, type: "submit", form: data });
 });
 

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -3550,29 +3550,39 @@ export function hotReloadApplied() {
     if (window.__raskHotReloadPill) window.__raskHotReloadPill();
 }
 
-// File registry for input[type=file]: maps short refs -> live File objects.
-// Cleared when the file input fires another change so old refs become unreachable.
-const fileRegistry = new Map();
+// The input[type=file] ref registry (rask-files.js), shared with the native client — it was local to this
+// file, which is precisely why file input worked on WASM and silently did nothing on a native head.
+// Shared file-input plumbing for every in-process host (WASM and Native), spliced at @@RASK_FILES@@.
+//
+// An <input type=file> hands JS a live File object that cannot cross the interop boundary, so the client
+// keeps the File here and ships only metadata plus a short ref. .NET reads the bytes back a chunk at a time
+// through that ref, which is what lets RaskFile.OpenReadStream be a real Stream instead of a whole file
+// buffered into a render payload.
+//
+// This lived in rask.wasm.js and made file input a WASM-only capability by accident: the native client had
+// no registry, so a shared component's file handler silently received nothing on a native head. Anything
+// Rask.Core promises on every host has to live in a module every host splices — this one.
+//
+// Two readers because the hosts reach it differently: WASM re-exports raskReadFileChunk through a [JSImport]
+// that marshals a Uint8Array directly, while the Native host has no such bridge and goes through IJSRuntime,
+// which is JSON — hence the base64 variant, reached by identifier as window.__raskFiles.readChunkBase64.
 
-export async function readFileChunk(ref, offset, length) {
-    const file = fileRegistry.get(ref);
-    if (!file) return new Uint8Array();
-    const end = Math.min(file.size, offset + length);
-    const slice = file.slice(offset, end);
-    const buf = await slice.arrayBuffer();
-    return new Uint8Array(buf);
-}
+const raskFileRegistry = new Map();
 
-function registerFiles(inputEl, files) {
-    // Drop any prior refs for this input so a re-pick doesn't pile up File objects.
-    if (inputEl.__raskFileRefs) {
-        for (const r of inputEl.__raskFileRefs) fileRegistry.delete(r);
+// Registers each File under a fresh ref and returns the metadata .NET turns into RaskFile instances.
+// Re-picking on the same input drops that input's previous refs, so a user cycling through files does not
+// pile up File objects (and their backing blobs) for the lifetime of the page.
+function raskRegisterFiles(inputEl, files) {
+    if (inputEl && inputEl.__raskFileRefs) {
+        for (const r of inputEl.__raskFileRefs) raskFileRegistry.delete(r);
     }
     const metas = [];
     const refs = [];
     for (const f of files) {
-        const r = (crypto && crypto.randomUUID) ? crypto.randomUUID() : "f-" + Math.random().toString(36).slice(2);
-        fileRegistry.set(r, f);
+        const r = (typeof crypto !== "undefined" && crypto.randomUUID)
+            ? crypto.randomUUID()
+            : "f-" + Math.random().toString(36).slice(2);
+        raskFileRegistry.set(r, f);
         refs.push(r);
         metas.push({
             ref: r,
@@ -3582,8 +3592,50 @@ function registerFiles(inputEl, files) {
             lastModified: f.lastModified || 0
         });
     }
-    inputEl.__raskFileRefs = refs;
+    if (inputEl) inputEl.__raskFileRefs = refs;
     return metas;
+}
+
+// An unknown ref yields an empty chunk rather than throwing: .NET reads until it gets a short read, so a ref
+// invalidated mid-read (the user re-picked while a stream was open) ends the stream instead of faulting it.
+async function raskReadFileChunk(ref, offset, length) {
+    const file = raskFileRegistry.get(ref);
+    if (!file) return new Uint8Array();
+    const end = Math.min(file.size, offset + length);
+    if (end <= offset) return new Uint8Array();
+    const buf = await file.slice(offset, end).arrayBuffer();
+    return new Uint8Array(buf);
+}
+
+async function raskReadFileChunkBase64(ref, offset, length) {
+    const bytes = await raskReadFileChunk(ref, offset, length);
+    // Built one bounded slice at a time: String.fromCharCode.apply over a whole chunk blows the argument
+    // limit on large reads, and a per-byte string concat is quadratic. 8KB keeps both away.
+    let binary = "";
+    const step = 8192;
+    for (let i = 0; i < bytes.length; i += step) {
+        binary += String.fromCharCode.apply(null, bytes.subarray(i, i + step));
+    }
+    return btoa(binary);
+}
+
+// The identifier the Native host's IJSRuntime resolves. Harmless on WASM, which uses its [JSImport] export.
+if (typeof window !== "undefined") {
+    window.__raskFiles = {
+        readChunkBase64: raskReadFileChunkBase64
+    };
+}
+
+
+// The [JSImport] on the .NET side binds to this module export, so the export has to be declared here (an ES
+// module cannot re-export a spliced-in function declaration by name from an inner scope). The registry and
+// the read itself are shared.
+export function readFileChunk(ref, offset, length) {
+    return raskReadFileChunk(ref, offset, length);
+}
+
+function registerFiles(inputEl, files) {
+    return raskRegisterFiles(inputEl, files);
 }
 
 function triggerDownload(download) {

--- a/src/Rask.Wasm/Rask.Wasm.csproj
+++ b/src/Rask.Wasm/Rask.Wasm.csproj
@@ -116,7 +116,7 @@
     contributors look at). NuGet consumers see whichever version is packed (above).
   -->
   <Target Name="_RaskSpliceClientJs" BeforeTargets="PrepareForBuild;AssignTargetPaths;_RaskMinifyClientJs"
-          Inputs="Resources\rask.wasm.js;Resources\rask-wasm-api.js;..\Rask.Core\Resources\rask-dom.js;..\Rask.Core\Resources\rask-morph.js;..\Rask.Core\Resources\rask-api.js;..\Rask.Core\Resources\rask-events.js;..\Rask.Core\Resources\rask-pwa.js;..\Rask.Core\Resources\rask-input.js;..\Rask.Core\Resources\rask-scoped.js;..\Rask.Core\Resources\rask-hotreload.js"
+          Inputs="Resources\rask.wasm.js;Resources\rask-wasm-api.js;..\Rask.Core\Resources\rask-dom.js;..\Rask.Core\Resources\rask-morph.js;..\Rask.Core\Resources\rask-api.js;..\Rask.Core\Resources\rask-events.js;..\Rask.Core\Resources\rask-pwa.js;..\Rask.Core\Resources\rask-input.js;..\Rask.Core\Resources\rask-scoped.js;..\Rask.Core\Resources\rask-hotreload.js;..\Rask.Core\Resources\rask-deverror.js;..\Rask.Core\Resources\rask-files.js"
           Outputs="Browser\rask.wasm.js">
     <PropertyGroup>
       <_RaskWasmTemplate>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\Resources\rask.wasm.js'))</_RaskWasmTemplate>
@@ -129,8 +129,9 @@
       <_RaskInputBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-input.js'))</_RaskInputBody>
       <_RaskScopedBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-scoped.js'))</_RaskScopedBody>
       <_RaskHotReloadBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-hotreload.js'))</_RaskHotReloadBody>
+      <_RaskFilesBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-files.js'))</_RaskFilesBody>
       <_RaskDevErrorBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-deverror.js'))</_RaskDevErrorBody>
-      <_RaskWasmJs>$(_RaskWasmTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_EVENTS@@', '$(_RaskEventsBody)').Replace('// @@RASK_PWA@@', '$(_RaskPwaBody)').Replace('// @@RASK_WASM_API@@', '$(_RaskWasmApiBody)').Replace('// @@RASK_INPUT@@', '$(_RaskInputBody)').Replace('// @@RASK_SCOPED@@', '$(_RaskScopedBody)').Replace('// @@RASK_HOTRELOAD@@', '$(_RaskHotReloadBody)').Replace('// @@RASK_DEVERROR@@', '$(_RaskDevErrorBody)'))</_RaskWasmJs>
+      <_RaskWasmJs>$(_RaskWasmTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_EVENTS@@', '$(_RaskEventsBody)').Replace('// @@RASK_PWA@@', '$(_RaskPwaBody)').Replace('// @@RASK_WASM_API@@', '$(_RaskWasmApiBody)').Replace('// @@RASK_INPUT@@', '$(_RaskInputBody)').Replace('// @@RASK_SCOPED@@', '$(_RaskScopedBody)').Replace('// @@RASK_HOTRELOAD@@', '$(_RaskHotReloadBody)').Replace('// @@RASK_DEVERROR@@', '$(_RaskDevErrorBody)').Replace('// @@RASK_FILES@@', '$(_RaskFilesBody)'))</_RaskWasmJs>
     </PropertyGroup>
     <WriteLinesToFile File="Browser\rask.wasm.js" Lines="$(_RaskWasmJs)" Overwrite="true" WriteOnlyWhenDifferent="true"/>
   </Target>

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -349,40 +349,19 @@ export function hotReloadApplied() {
     if (window.__raskHotReloadPill) window.__raskHotReloadPill();
 }
 
-// File registry for input[type=file]: maps short refs -> live File objects.
-// Cleared when the file input fires another change so old refs become unreachable.
-const fileRegistry = new Map();
+// The input[type=file] ref registry (rask-files.js), shared with the native client — it was local to this
+// file, which is precisely why file input worked on WASM and silently did nothing on a native head.
+// @@RASK_FILES@@
 
-export async function readFileChunk(ref, offset, length) {
-    const file = fileRegistry.get(ref);
-    if (!file) return new Uint8Array();
-    const end = Math.min(file.size, offset + length);
-    const slice = file.slice(offset, end);
-    const buf = await slice.arrayBuffer();
-    return new Uint8Array(buf);
+// The [JSImport] on the .NET side binds to this module export, so the export has to be declared here (an ES
+// module cannot re-export a spliced-in function declaration by name from an inner scope). The registry and
+// the read itself are shared.
+export function readFileChunk(ref, offset, length) {
+    return raskReadFileChunk(ref, offset, length);
 }
 
 function registerFiles(inputEl, files) {
-    // Drop any prior refs for this input so a re-pick doesn't pile up File objects.
-    if (inputEl.__raskFileRefs) {
-        for (const r of inputEl.__raskFileRefs) fileRegistry.delete(r);
-    }
-    const metas = [];
-    const refs = [];
-    for (const f of files) {
-        const r = (crypto && crypto.randomUUID) ? crypto.randomUUID() : "f-" + Math.random().toString(36).slice(2);
-        fileRegistry.set(r, f);
-        refs.push(r);
-        metas.push({
-            ref: r,
-            name: f.name,
-            size: f.size,
-            type: f.type || "application/octet-stream",
-            lastModified: f.lastModified || 0
-        });
-    }
-    inputEl.__raskFileRefs = refs;
-    return metas;
+    return raskRegisterFiles(inputEl, files);
 }
 
 function triggerDownload(download) {

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -53,6 +53,20 @@ public sealed class WasmHostBuilder
         Services.AddClientBrowserApis(ServiceLifetime.Singleton);
         Services.AddWasmBrowserApis(ServiceLifetime.Singleton);
         Services.TryAddSingleton<IUserProvider, AnonymousUserProvider>();
+        // WasmAuthSignIn posts sign-out to the server, so it needs an HttpClient. Registering the sign-in
+        // service without one made IAuthSignIn — a contract Rask.Core promises on every host — resolvable on
+        // Server and Native but a DI failure here, at the injection site, in any app that hadn't happened to
+        // register an HttpClient of its own. TryAdd, so an app that registers one (typed clients, a handler
+        // chain, a different base address) still wins.
+        //
+        // The factory is lazy on purpose: BaseAddress reads the page origin back through the JS module, which
+        // only answers after RunAsync has imported it. Resolving before then (or off-browser, in a test)
+        // yields a relative "/" — not a legal HttpClient.BaseAddress — so leave it unset in that case rather
+        // than throwing out of a service factory.
+        Services.TryAddSingleton(_ =>
+            Uri.TryCreate(BaseAddress, UriKind.Absolute, out var origin)
+                ? new HttpClient { BaseAddress = origin }
+                : new HttpClient());
         Services.TryAddSingleton<IAuthSignIn, WasmAuthSignIn>();
         Services.AddAuthorizationCore();
         // IJSRuntime backed by the WASM JSImport/JSExport bridge. Singleton — one

--- a/tests/Rask.Core.Tests/HostContractCompletenessTests.cs
+++ b/tests/Rask.Core.Tests/HostContractCompletenessTests.cs
@@ -1,0 +1,66 @@
+namespace Rask.Core.Tests;
+
+// RaskHostContracts is the machine-readable form of "everything in Core works on every host". It is spelled
+// out by hand rather than reflected, so that AddCoreBrowserApis can keep its trim-safe generic TryAdd calls.
+// This test is what keeps a hand-written list honest: it partitions the Rask.Core.Browser namespace against
+// the two declared buckets, so adding a wrapper interface forces an explicit decision — "every host serves
+// it" (BrowserApis) or "it's a handle a service returns, not a service" (NonServiceBrowserTypes) — instead of
+// the wrapper quietly landing on one host and failing DI on the other two.
+public sealed class HostContractCompletenessTests
+{
+    private const string BrowserNamespace = "Rask.Core.Browser";
+
+    private static IEnumerable<Type> PublicBrowserInterfaces =>
+        typeof(RaskHostContracts).Assembly
+            .GetExportedTypes()
+            .Where(t => t.IsInterface && t.Namespace == BrowserNamespace);
+
+    [Fact]
+    public void EveryPublicBrowserInterface_IsEitherARequiredService_OrDeclaredNotAService()
+    {
+        var declared = RaskHostContracts.BrowserApis
+            .Concat(RaskHostContracts.NonServiceBrowserTypes)
+            .ToHashSet();
+
+        var undeclared = PublicBrowserInterfaces.Where(t => !declared.Contains(t)).Select(t => t.Name).Order();
+
+        Assert.Empty(undeclared);
+    }
+
+    [Fact]
+    public void TheTwoBrowserBuckets_DoNotOverlap()
+    {
+        var overlap = RaskHostContracts.BrowserApis
+            .Intersect(RaskHostContracts.NonServiceBrowserTypes)
+            .Select(t => t.Name)
+            .Order();
+
+        Assert.Empty(overlap);
+    }
+
+    // A stale entry is as bad as a missing one: it would make every host's parity test demand a registration
+    // for an interface Core no longer exposes, and the only way to go green would be to register a type that
+    // isn't there. Catch it here, once, instead of three times over.
+    [Fact]
+    public void NoDeclaredBrowserContract_HasBeenRemovedFromCore()
+    {
+        var live = PublicBrowserInterfaces.ToHashSet();
+
+        var stale = RaskHostContracts.BrowserApis
+            .Concat(RaskHostContracts.NonServiceBrowserTypes)
+            .Where(t => !live.Contains(t))
+            .Select(t => t.Name)
+            .Order();
+
+        Assert.Empty(stale);
+    }
+
+    [Fact]
+    public void All_IsHostServicesPlusBrowserApis_WithNoDuplicates()
+    {
+        Assert.Equal(
+            RaskHostContracts.HostServices.Count + RaskHostContracts.BrowserApis.Count,
+            RaskHostContracts.All.Count);
+        Assert.Equal(RaskHostContracts.All.Count, RaskHostContracts.All.Distinct().Count());
+    }
+}

--- a/tests/Rask.Native.Tests/Authentication/NativeAuthSignInTests.cs
+++ b/tests/Rask.Native.Tests/Authentication/NativeAuthSignInTests.cs
@@ -1,0 +1,144 @@
+using System.Net;
+using System.Security.Claims;
+using Rask.Core.Authentication;
+using Rask.Core.Routing;
+using Rask.Native.Authentication;
+
+namespace Rask.Native.Tests.Authentication;
+
+// IAuthSignIn is one of the contracts Rask.Core promises on every host, and the native host had none — a
+// shared LoginPage(IAuthSignIn) (the shape `rask new` scaffolds) failed DI on the device only.
+public sealed class NativeAuthSignInTests
+{
+    [Fact]
+    public async Task SignOut_ClearsTheLocalToken_EvenWithNoServerToTell()
+    {
+        // A Native + Local app need not have a backend at all; signing out still has to work.
+        var tokens = new FakeTokenStore { Token = "jwt" };
+        var user = new FakeUserProvider();
+        var sut = new NativeAuthSignIn(user, NavigatorFor(), tokens);
+
+        await sut.SignOutAsync();
+
+        Assert.Null(tokens.Token);
+        Assert.Equal(1, user.RefreshCount);
+    }
+
+    [Fact]
+    public async Task SignOut_PostsToTheLogoutEndpoint_WhenTheAppHasAnHttpClient()
+    {
+        var handler = new RecordingHandler();
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.test/") };
+        var sut = new NativeAuthSignIn(new FakeUserProvider(), NavigatorFor(), null, http);
+
+        await sut.SignOutAsync();
+
+        Assert.Equal("https://api.test/auth/logout", handler.LastUri?.ToString());
+    }
+
+    // Clearing the device token has to survive the network call failing — a device app is offline far more
+    // often than a browser tab, and a half-signed-out state leaves a live token on the device.
+    [Fact]
+    public async Task SignOut_ClearsTheTokenBeforeTheNetworkCall_SoAFailureStillSignsOutLocally()
+    {
+        var tokens = new FakeTokenStore { Token = "jwt" };
+        var http = new HttpClient(new ThrowingHandler()) { BaseAddress = new Uri("https://api.test/") };
+        var sut = new NativeAuthSignIn(new FakeUserProvider(), NavigatorFor(), tokens, http);
+
+        await Assert.ThrowsAnyAsync<HttpRequestException>(() => sut.SignOutAsync());
+
+        Assert.Null(tokens.Token);
+    }
+
+    [Theory]
+    [InlineData("https://evil.test/", "/")]
+    [InlineData("//evil.test/", "/")]
+    [InlineData(null, "/")]
+    [InlineData("/dashboard", "/dashboard")]
+    public async Task SignOut_SanitizesTheReturnUrl(string? returnUrl, string expected)
+    {
+        // A native app reaches these through deep links, so returnUrl is as attacker-reachable here as a
+        // query string is on the web.
+        var routeState = new RouteState();
+        var navigator = new Navigator(routeState);
+        var sut = new NativeAuthSignIn(new FakeUserProvider(), navigator);
+
+        // Navigator refuses to navigate outside an event handler; sign-out is always called from one.
+        using (navigator.EnterHandler())
+        {
+            await sut.SignOutAsync(returnUrl);
+        }
+
+        Assert.Equal(expected, routeState.Path);
+    }
+
+    [Fact]
+    public async Task SignIn_Throws_BecauseADeviceCannotMintItsOwnPrincipal()
+    {
+        var sut = new NativeAuthSignIn(new FakeUserProvider(), NavigatorFor());
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => sut.SignInAsync(new ClaimsPrincipal(new ClaimsIdentity("test"))));
+
+        Assert.Contains("ITokenStore", ex.Message, StringComparison.Ordinal);
+    }
+
+    // The other tests don't assert on navigation, so they only need a Navigator that works.
+    private static Navigator NavigatorFor()
+    {
+        var navigator = new Navigator(new RouteState());
+        navigator.EnterHandler();
+        return navigator;
+    }
+
+    private sealed class FakeTokenStore : ITokenStore
+    {
+        public string? Token { get; set; }
+
+        public ValueTask<string?> GetAsync() => ValueTask.FromResult(Token);
+
+        public ValueTask SetAsync(string token, bool persist)
+        {
+            Token = token;
+            return default;
+        }
+
+        public ValueTask ClearAsync()
+        {
+            Token = null;
+            return default;
+        }
+    }
+
+    private sealed class FakeUserProvider : IUserProvider
+    {
+        public int RefreshCount { get; private set; }
+        public ClaimsPrincipal Current { get; } = new(new ClaimsIdentity());
+
+        public event Action? Changed;
+
+        public Task RefreshAsync()
+        {
+            RefreshCount++;
+            Changed?.Invoke();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public Uri? LastUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            LastUri = request.RequestUri;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+        }
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+            throw new HttpRequestException("offline");
+    }
+}

--- a/tests/Rask.Native.Tests/Files/NativeDownloadStagingTests.cs
+++ b/tests/Rask.Native.Tests/Files/NativeDownloadStagingTests.cs
@@ -1,0 +1,72 @@
+using Rask.Native.Files;
+
+namespace Rask.Native.Tests.Files;
+
+// A download name is only a suggestion in a browser, which sanitizes it before anything touches a
+// filesystem. On a native head it becomes a real path — and the value can be attacker-influenced (a record
+// title, a filename echoed back from an API) — so the reduction to a single safe segment is load-bearing.
+public sealed class NativeDownloadStagingTests
+{
+    [Theory]
+    // Traversal, on both platforms' separators. The backslash cases matter even on Unix: Path.GetFileName is
+    // platform-aware and would pass them through intact here, leaving a name that only becomes a traversal
+    // once a Windows-rules head joins it.
+    [InlineData("../../../etc/passwd", "passwd")]
+    [InlineData("..\\..\\windows\\system32\\config", "config")]
+    [InlineData("/etc/passwd", "passwd")]
+    [InlineData("C:\\secrets\\key.pem", "key.pem")]
+    // Bare traversal segments survive every character filter yet name no file.
+    [InlineData("..", "download")]
+    [InlineData(".", "download")]
+    [InlineData("", "download")]
+    [InlineData("   ", "download")]
+    [InlineData(null, "download")]
+    // Windows silently drops trailing dots and spaces, so keeping them would mean the file on disk had a
+    // different name than the one reported to the user.
+    [InlineData("report.txt.", "report.txt")]
+    [InlineData("report.txt  ", "report.txt")]
+    // Ordinary names are left alone, including spaces and unicode.
+    [InlineData("Q3 report (final).pdf", "Q3 report (final).pdf")]
+    [InlineData("jelentés.pdf", "jelentés.pdf")]
+    public void SafeFileName_ReducesToASinglePathSegment(string? input, string expected) =>
+        Assert.Equal(expected, NativeDownloadStaging.SafeFileName(input));
+
+    [Fact]
+    public void SafeFileName_ReplacesControlCharacters()
+    {
+        // A newline in a name would also break the platform's own presentation of it.
+        Assert.Equal("a_b", NativeDownloadStaging.SafeFileName("a\nb"));
+        Assert.Equal("a_b", NativeDownloadStaging.SafeFileName("a\0b"));
+    }
+
+    [Fact]
+    public async Task StageAsync_WritesTheBytesUnderTheDownloadDirectory()
+    {
+        var file = await NativeDownloadStaging.StageAsync("notes.txt", "text/plain", "hello"u8.ToArray());
+
+        Assert.Equal("notes.txt", file.FileName);
+        Assert.Equal("text/plain", file.ContentType);
+        Assert.StartsWith(
+            Path.Combine(Path.GetTempPath(), "rask-downloads"), file.Path, StringComparison.Ordinal);
+        Assert.Equal("hello", await File.ReadAllTextAsync(file.Path));
+    }
+
+    [Fact]
+    public async Task StageAsync_GivesEachDownloadItsOwnDirectory_SoSameNamedFilesDoNotCollide()
+    {
+        var first = await NativeDownloadStaging.StageAsync("a.txt", "text/plain", "one"u8.ToArray());
+        var second = await NativeDownloadStaging.StageAsync("a.txt", "text/plain", "two"u8.ToArray());
+
+        Assert.NotEqual(first.Path, second.Path);
+        Assert.Equal("one", await File.ReadAllTextAsync(first.Path));
+        Assert.Equal("two", await File.ReadAllTextAsync(second.Path));
+    }
+
+    [Fact]
+    public async Task StageAsync_DefaultsTheContentType_WhenTheCallerGaveNone()
+    {
+        var file = await NativeDownloadStaging.StageAsync("blob.bin", null, [1, 2, 3]);
+
+        Assert.Equal("application/octet-stream", file.ContentType);
+    }
+}

--- a/tests/Rask.Native.Tests/Files/NativeFileBackendTests.cs
+++ b/tests/Rask.Native.Tests/Files/NativeFileBackendTests.cs
@@ -1,0 +1,107 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.JSInterop;
+using Rask.Native.Files;
+
+namespace Rask.Native.Tests.Files;
+
+// File input is one of the Core contracts that silently did nothing on this host: with no
+// IBrowserFileBackend registered, FileListReader handed the handler an empty list, so a user picked a file
+// and the app reported success having uploaded nothing.
+public sealed class NativeFileBackendTests
+{
+    private static readonly byte[] Content = "the quick brown fox jumps over the lazy dog"u8.ToArray();
+
+    [Fact]
+    public void Create_ReadsTheMetadataTheClientSent()
+    {
+        var file = new NativeFileBackend(new FakeJsRuntime(Content)).Create(Meta("r1", "notes.txt", 42));
+
+        Assert.Equal("notes.txt", file.Name);
+        Assert.Equal(42, file.Size);
+        Assert.Equal("text/plain", file.ContentType);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000), file.LastModified);
+    }
+
+    [Fact]
+    public void Create_WithoutARef_ThrowsRatherThanReturningAnUnreadableFile()
+    {
+        var backend = new NativeFileBackend(new FakeJsRuntime(Content));
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => backend.Create(JsonDocument.Parse("""{"name":"x.txt","size":1}""").RootElement));
+
+        Assert.Contains("ref", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task OpenReadStream_ReadsTheWholeFileBackInChunks()
+    {
+        var js = new FakeJsRuntime(Content);
+        var file = new NativeFileBackend(js).Create(Meta("r1", "fox.txt", Content.Length));
+
+        await using var stream = file.OpenReadStream();
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer);
+
+        Assert.Equal(Encoding.UTF8.GetString(Content), Encoding.UTF8.GetString(buffer.ToArray()));
+        // Reading over the bridge at all is the point: nothing was inlined into the render payload.
+        Assert.NotEmpty(js.Calls);
+    }
+
+    [Fact]
+    public void OpenReadStream_RefusesAFileOverTheCallersLimit()
+    {
+        var file = new NativeFileBackend(new FakeJsRuntime(Content)).Create(Meta("r1", "big.bin", 1024));
+
+        Assert.Throws<IOException>(() => file.OpenReadStream(512));
+    }
+
+    // The registry drops a ref when the user re-picks on the same input. Ending the stream short is honest;
+    // faulting it would turn a race the user caused into an app-level exception.
+    [Fact]
+    public async Task AVanishedRef_EndsTheStreamInsteadOfThrowing()
+    {
+        var js = new FakeJsRuntime(Content) { Vanished = true };
+        var file = new NativeFileBackend(js).Create(Meta("r1", "gone.txt", Content.Length));
+
+        await using var stream = file.OpenReadStream();
+        var read = await stream.ReadAsync(new byte[64]);
+
+        Assert.Equal(0, read);
+    }
+
+    private static JsonElement Meta(string @ref, string name, long size) =>
+        JsonDocument.Parse(
+                $$"""
+                  {"ref":"{{@ref}}","name":"{{name}}","size":{{size}},
+                   "type":"text/plain","lastModified":1700000000000}
+                  """)
+            .RootElement;
+
+    // Stands in for the WebView's rask-files.js: answers __raskFiles.readChunkBase64 out of a byte array.
+    private sealed class FakeJsRuntime(byte[] content) : IJSRuntime
+    {
+        public List<string> Calls { get; } = [];
+        public bool Vanished { get; init; }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args) =>
+            InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken,
+            object?[]? args)
+        {
+            Calls.Add(identifier);
+            Assert.Equal("__raskFiles.readChunkBase64", identifier);
+            if (Vanished)
+            {
+                return ValueTask.FromResult((TValue)(object)string.Empty);
+            }
+
+            var offset = (int)Convert.ToInt64(args![1]!);
+            var length = Convert.ToInt32(args[2]!);
+            var slice = content.AsSpan(offset, Math.Min(length, content.Length - offset)).ToArray();
+            return ValueTask.FromResult((TValue)(object)Convert.ToBase64String(slice));
+        }
+    }
+}

--- a/tests/Rask.Native.Tests/Infrastructure/NativeDownloadApp.cs
+++ b/tests/Rask.Native.Tests/Infrastructure/NativeDownloadApp.cs
@@ -1,0 +1,28 @@
+using Rask.Core;
+using Rask.Core.Routing;
+using static Rask.Core.Components.Generated;
+
+#pragma warning disable RASK019 // test-infra apps predate framework-managed <head>
+
+namespace Rask.Native.Tests.Infrastructure;
+
+// A component that calls Navigator.Download from a click handler — the exact shape of the shared
+// DownloadDemo in samples/Rask.Example.Shared, which is compiled into the native showcase and threw on this
+// host until IDownloadSink was registered.
+internal sealed partial class NativeDownloadApp : Component
+{
+    private readonly Navigator _nav;
+
+    public NativeDownloadApp(Navigator nav) => _nav = nav;
+
+    /// <summary>The name the handler downloads under. Set by a test before the click.</summary>
+    public static string FileName { get; set; } = "report.txt";
+
+    protected override Component? HeadAssets => Title["download"];
+    protected override string? HtmlLang => null;
+
+    protected override Component? Render() =>
+    [
+        Button.OnClick(() => _nav.Download(FileName, "hello native"u8.ToArray(), "text/plain"))["download"]
+    ];
+}

--- a/tests/Rask.Native.Tests/NativeClientSpliceTests.cs
+++ b/tests/Rask.Native.Tests/NativeClientSpliceTests.cs
@@ -22,6 +22,7 @@ public sealed class NativeClientSpliceTests
         var scoped = File.ReadAllText(Path.Combine(core, "rask-scoped.js"));
         var hotReload = File.ReadAllText(Path.Combine(core, "rask-hotreload.js"));
         var devError = File.ReadAllText(Path.Combine(core, "rask-deverror.js"));
+        var files = File.ReadAllText(Path.Combine(core, "rask-files.js"));
         var committed = File.ReadAllText(Path.Combine(repoRoot, "src", "Rask.Native", "Assets", "rask.native.js"));
 
         // Mirror the marker splice order in _RaskSpliceNativeClientJs (Rask.Native.csproj).
@@ -34,7 +35,8 @@ public sealed class NativeClientSpliceTests
             .Replace("// @@RASK_INPUT@@", input)
             .Replace("// @@RASK_SCOPED@@", scoped)
             .Replace("// @@RASK_HOTRELOAD@@", hotReload)
-            .Replace("// @@RASK_DEVERROR@@", devError);
+            .Replace("// @@RASK_DEVERROR@@", devError)
+            .Replace("// @@RASK_FILES@@", files);
 
         Assert.True(
             spliced == committed,

--- a/tests/Rask.Native.Tests/Session/HostContractParityTests.cs
+++ b/tests/Rask.Native.Tests/Session/HostContractParityTests.cs
@@ -1,0 +1,32 @@
+using Rask.Core;
+using Rask.Core.Live;
+using Rask.Native.Tests.Infrastructure;
+
+namespace Rask.Native.Tests.Session;
+
+// The Native end of the cross-host parity gate — see the sibling tests in Rask.Server.Tests and
+// Rask.Wasm.Tests. This one goes through the session harness because the Native host registers the
+// browser-API tiers inside RunLocalAsync (after any UsePlatform module, so a native backend wins), not in
+// the constructor: a test built from NativeAppHost.CreateDefault().Services alone would be asserting against
+// half a container.
+//
+// This is the gate that was missing. IBrowserFileBackend, IDownloadSink and IAuthSignIn were all absent here
+// while Server and WASM served them, so a component shared into a native head lost file uploads silently,
+// threw on Navigator.Download, and failed DI on injection of IAuthSignIn.
+[Collection("NativeSession")]
+public sealed class HostContractParityTests() : ResettingTestBase(LiveDiffMode.Auto)
+{
+    [Fact]
+    public async Task NativeHost_ResolvesEveryCoreHostContract()
+    {
+        var (app, _, _) = await NativeSessionHarness.NewSessionAsync();
+
+        var missing = RaskHostContracts.All
+            .Where(t => app.Services.GetService(t) is null)
+            .Select(t => t.Name)
+            .Order()
+            .ToList();
+
+        Assert.Empty(missing);
+    }
+}

--- a/tests/Rask.Native.Tests/Session/NativeDownloadTests.cs
+++ b/tests/Rask.Native.Tests/Session/NativeDownloadTests.cs
@@ -1,0 +1,115 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core.Live;
+using Rask.Native.Files;
+using Rask.Native.Tests.Infrastructure;
+
+namespace Rask.Native.Tests.Session;
+
+// Navigator.Download end to end on the native host: a click stages bytes, the frame carries a token, the
+// client hands the token back, and the file reaches the platform. Before IDownloadSink was registered here
+// the first step threw — a shared component that downloaded on Server and WASM crashed on native.
+[Collection("NativeSession")]
+public sealed class NativeDownloadTests() : ResettingTestBase(LiveDiffMode.DisabledFull)
+{
+    [Fact]
+    public async Task Download_FromAHandler_ShipsATokenInTheFrame()
+    {
+        NativeDownloadApp.FileName = "report.txt";
+        var (_, webView, initial) = await NativeSessionHarness.NewSessionAsync<NativeDownloadApp>(
+            diffMode: DiffMode);
+        var handlerId = MarkupAssert.FirstHandlerId(initial);
+
+        await webView.PostAsync($$"""{"id":"{{handlerId}}","type":"click"}""");
+
+        using var doc = JsonDocument.Parse(webView.LastFrame.AsMemory());
+        var download = doc.RootElement.GetProperty("download");
+        Assert.Equal("report.txt", download.GetProperty("filename").GetString());
+        Assert.Equal("text/plain", download.GetProperty("contentType").GetString());
+        // Token-pull, like the WASM host: the bytes stay .NET-side rather than riding the frame as base64.
+        Assert.NotEmpty(download.GetProperty("token").GetString()!);
+        Assert.False(download.TryGetProperty("bytes", out _));
+    }
+
+    [Fact]
+    public async Task ClientReturningTheToken_HandsTheFileToThePlatform()
+    {
+        NativeDownloadApp.FileName = "report.txt";
+        var export = new FakeFileExport();
+        var (_, webView, initial) = await NativeSessionHarness.NewSessionAsync<NativeDownloadApp>(
+            configure: s => s.AddSingleton<INativeFileExport>(export), diffMode: DiffMode);
+
+        await webView.PostAsync($$"""{"id":"{{MarkupAssert.FirstHandlerId(initial)}}","type":"click"}""");
+        await webView.PostAsync($$"""{"type":"download","token":"{{TokenFrom(webView.LastFrame)}}"}""");
+
+        var file = Assert.Single(export.Exported);
+        Assert.Equal("report.txt", file.FileName);
+        Assert.Equal("text/plain", file.ContentType);
+        Assert.Equal("hello native", await File.ReadAllTextAsync(file.Path));
+    }
+
+    [Fact]
+    public async Task ATokenReplayedBySomeMisbehavingClient_ExportsOnce()
+    {
+        NativeDownloadApp.FileName = "report.txt";
+        var export = new FakeFileExport();
+        var (_, webView, initial) = await NativeSessionHarness.NewSessionAsync<NativeDownloadApp>(
+            configure: s => s.AddSingleton<INativeFileExport>(export), diffMode: DiffMode);
+
+        await webView.PostAsync($$"""{"id":"{{MarkupAssert.FirstHandlerId(initial)}}","type":"click"}""");
+        var token = TokenFrom(webView.LastFrame);
+        await webView.PostAsync($$"""{"type":"download","token":"{{token}}"}""");
+        await webView.PostAsync($$"""{"type":"download","token":"{{token}}"}""");
+
+        Assert.Single(export.Exported);
+    }
+
+    // A download name can be attacker-influenced (a record title, a filename echoed back from an API), and on
+    // this host it becomes a real path. The traversal has to be cut before the join, not after.
+    [Fact]
+    public async Task ATraversingFileName_StagesInsideTheDownloadDirectory()
+    {
+        NativeDownloadApp.FileName = "../../../../etc/passwd";
+        var export = new FakeFileExport();
+        var (_, webView, initial) = await NativeSessionHarness.NewSessionAsync<NativeDownloadApp>(
+            configure: s => s.AddSingleton<INativeFileExport>(export), diffMode: DiffMode);
+
+        await webView.PostAsync($$"""{"id":"{{MarkupAssert.FirstHandlerId(initial)}}","type":"click"}""");
+        await webView.PostAsync($$"""{"type":"download","token":"{{TokenFrom(webView.LastFrame)}}"}""");
+
+        var file = Assert.Single(export.Exported);
+        Assert.Equal("passwd", file.FileName);
+        Assert.StartsWith(
+            Path.Combine(Path.GetTempPath(), "rask-downloads"), file.Path, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AnUnknownToken_IsIgnoredRatherThanFaultingTheMessagePump()
+    {
+        var export = new FakeFileExport();
+        var (_, webView, _) = await NativeSessionHarness.NewSessionAsync<NativeDownloadApp>(
+            configure: s => s.AddSingleton<INativeFileExport>(export), diffMode: DiffMode);
+
+        await webView.PostAsync("""{"type":"download","token":"deadbeef"}""");
+
+        Assert.Empty(export.Exported);
+    }
+
+    private static string TokenFrom(byte[] frame)
+    {
+        using var doc = JsonDocument.Parse(Encoding.UTF8.GetString(frame));
+        return doc.RootElement.GetProperty("download").GetProperty("token").GetString()!;
+    }
+
+    private sealed class FakeFileExport : INativeFileExport
+    {
+        public List<NativeFileExport> Exported { get; } = [];
+
+        public ValueTask ExportAsync(NativeFileExport file)
+        {
+            Exported.Add(file);
+            return default;
+        }
+    }
+}

--- a/tests/Rask.Server.Tests/HostContractParityTests.cs
+++ b/tests/Rask.Server.Tests/HostContractParityTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests;
+
+// The Server end of the cross-host parity gate. RaskHostContracts.All is the set Rask.Core promises resolves
+// on every host; this asserts AddRask actually serves all of it. The sibling tests in Rask.Wasm.Tests and
+// Rask.Native.Tests make the identical assertion against their own bootstraps, so a contract can only be
+// added to Core once every host can serve it.
+//
+// Resolution, not registration: a descriptor whose own dependencies are missing looks registered and still
+// throws at the injection site, which is exactly how the WASM host shipped an IAuthSignIn that needed an
+// HttpClient nobody registered. Resolving is what catches that.
+[Collection("HostEnvironment")]
+public sealed class HostContractParityTests
+{
+    [Fact]
+    public void AddRask_ResolvesEveryCoreHostContract()
+    {
+        using var host = RaskTestHost.Create<NoOpApp>();
+        // Most of these are scoped (one per live session), so they need a scope rather than the root provider.
+        using var scope = host.Services.CreateScope();
+
+        var missing = RaskHostContracts.All
+            .Where(t => scope.ServiceProvider.GetService(t) is null)
+            .Select(t => t.Name)
+            .Order()
+            .ToList();
+
+        Assert.Empty(missing);
+    }
+}

--- a/tests/Rask.Wasm.Tests/HostContractParityTests.cs
+++ b/tests/Rask.Wasm.Tests/HostContractParityTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core;
+
+namespace Rask.Wasm.Tests;
+
+// The WASM end of the cross-host parity gate — see the sibling tests in Rask.Server.Tests and
+// Rask.Native.Tests. Built from WasmHostBuilder itself rather than the session harness: the harness wires
+// only what the session tests need, so asserting against it would prove nothing about what a real app gets.
+public sealed class HostContractParityTests
+{
+    [Fact]
+    public void WasmHostBuilder_ResolvesEveryCoreHostContract()
+    {
+        var builder = WasmHostBuilder.CreateDefault();
+        using var provider = builder.Services.BuildServiceProvider();
+
+        var missing = RaskHostContracts.All
+            .Where(t => provider.GetService(t) is null)
+            .Select(t => t.Name)
+            .Order()
+            .ToList();
+
+        Assert.Empty(missing);
+    }
+
+    // The framework's registrations are all TryAdd, so an app that wants its own implementation of a Core
+    // contract must be able to win by registering first. Guarding one representative keeps the parity test
+    // above from being "satisfied" by a future host that hard-registers and locks apps out.
+    [Fact]
+    public void AppRegistration_BeforeTheFrameworkDefaults_Wins()
+    {
+        var builder = WasmHostBuilder.CreateDefault();
+        var http = new HttpClient { BaseAddress = new Uri("https://example.test/") };
+        builder.Services.AddSingleton(http);
+
+        using var provider = builder.Services.BuildServiceProvider();
+
+        Assert.Same(http, provider.GetService<HttpClient>());
+    }
+}

--- a/tests/Rask.Wasm.Tests/ResourcesSpliceTests.cs
+++ b/tests/Rask.Wasm.Tests/ResourcesSpliceTests.cs
@@ -17,6 +17,7 @@ public sealed class ResourcesSpliceTests
         var scopedPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-scoped.js");
         var hotReloadPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-hotreload.js");
         var devErrorPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-deverror.js");
+        var filesPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-files.js");
         var browserPath = Path.Combine(repoRoot, "src", "Rask.Wasm", "Browser", "rask.wasm.js");
 
         var template = File.ReadAllText(templatePath);
@@ -30,6 +31,7 @@ public sealed class ResourcesSpliceTests
         var scoped = File.ReadAllText(scopedPath);
         var hotReload = File.ReadAllText(hotReloadPath);
         var devError = File.ReadAllText(devErrorPath);
+        var files = File.ReadAllText(filesPath);
         var committed = File.ReadAllText(browserPath);
 
         // Mirror the marker splice order in _RaskSpliceClientJs (Rask.Wasm.csproj): the diff codec
@@ -49,7 +51,8 @@ public sealed class ResourcesSpliceTests
             .Replace("// @@RASK_INPUT@@", input)
             .Replace("// @@RASK_SCOPED@@", scoped)
             .Replace("// @@RASK_HOTRELOAD@@", hotReload)
-            .Replace("// @@RASK_DEVERROR@@", devError);
+            .Replace("// @@RASK_DEVERROR@@", devError)
+            .Replace("// @@RASK_FILES@@", files);
 
         Assert.True(
             spliced == committed,


### PR DESCRIPTION
## Summary

`Rask.Core` is the shared component surface, so anything a component can inject or call from it has to work on Server, WASM **and** Native. Four contracts did not — each failing on one host only, only at runtime, with nothing at compile time to warn you:

| Contract | Server | WASM | Native | Failure |
| --- | --- | --- | --- | --- |
| `IBrowserFileBackend` | ✅ | ✅ | ❌ | **Silent** — handler receives an empty file list |
| `IDownloadSink` | ✅ | ✅ | ❌ | `Navigator.Download` throws |
| `IAuthSignIn` | ✅ | ✅ | ❌ | DI resolution failure at the injection site |
| `IAuthSignIn` → `HttpClient` | ✅ | ❌ | — | `WasmAuthSignIn` needs an `HttpClient` nobody registered |

Not hypothetical. `samples/Rask.Example.Shared` is compiled into the native showcase, and its `Features/Upload/UploadDemo.cs` and `Features/Download/DownloadDemo.cs` hit the first two. A shared `LoginPage(IAuthSignIn auth, …)` — the shape `rask new` scaffolds — hit the third.

## The gate (written first, red on all four)

`RaskHostContracts` names the 47 contracts Core promises everywhere, and each host's test project asserts its own bootstrap **resolves** every one.

Resolution rather than registration is the point: a descriptor whose own dependencies are missing looks registered and still throws at the injection site, which is exactly how the WASM `HttpClient` hole shipped. A completeness test in `Rask.Core.Tests` partitions the whole `Rask.Core.Browser` namespace against the list, so adding a wrapper forces an explicit decision — "every host serves it" or "it's a handle a service returns" — instead of quietly landing on one host.

## Closing the gaps

**File input on Native.** The `<input type=file>` ref registry moved out of `rask.wasm.js` into a shared `Rask.Core/Resources/rask-files.js` spliced into both in-process clients — it being local to one client is precisely why this was WASM-only by accident. The native client now captures picked files on `change` *and* on `submit` (`__files`). `NativeFileBackend` reads them back a chunk at a time over `IJSRuntime`, so `RaskFile.OpenReadStream` is a real stream rather than bytes inlined into a render payload.

**Downloads on Native → the OS share sheet.** `NativeDownloadSink` uses the same token-pull contract as WASM; the bytes never ride the frame. Delivery is the platform's job — `<a download>` is inert in a `WKWebView`, and a file in the app sandbox is invisible on iOS without `UIFileSharingEnabled` — so the host stages the file under the app cache directory and hands it to a new **`INativeFileExport`**, whose platform implementations present the share sheet (`UIActivityViewController` / `ACTION_SEND`). With none registered the file is still staged and its location reported, so a shared component never crashes on a head that has no share sheet.

Kept separate from `IShare` deliberately: `ShareData` is Web-Share-shaped (title/text/URL, no file), and widening it would change what that type means on the WASM host.

**Download filenames are sanitized.** On the browser hosts the name is a suggestion the browser sanitizes; here it becomes a real path, and it can be attacker-influenced (a record title, a filename echoed back from an API). Both separators are cut unconditionally — `Path.GetFileName` is platform-aware and would pass `..\..\x` through intact on Unix, leaving a name that only becomes a traversal once a Windows-rules head joins it.

**`IAuthSignIn` on Native.** `NativeAuthSignIn` clears the local `ITokenStore`, posts to `LogoutPath` when the app has an `HttpClient` to reach a server, refreshes `IUserProvider` and navigates. Both server-facing dependencies are optional — a Native + Local app need not have a backend at all. The token is cleared **before** the network call, so an offline device still ends up signed out rather than holding a live token. `returnUrl` goes through `LocalUrl`; a native app reaches these through deep links.

**`HttpClient` on WASM.** `WasmHostBuilder` registers a lazy default (page origin as base address). Lazy because `BaseAddress` only answers after the JS module import.

All registrations use `TryAdd`, so an app or platform module that registers its own still wins.

## Error surface

`Navigator`'s "no `IDownloadSink`" message named only Server and WASM. Worse, `FileListReader` returned an empty list when no `IBrowserFileBackend` was registered and said **nothing at all** — the framework's quietest failure, and the one that hid the native gap for a release. It now reports through `RaskDiagnostics`.

## Drive-by

`rask-deverror.js` and the new `rask-files.js` were missing from both splice targets' `Inputs`, so an edit to either left a stale generated client behind — the same class of silent drift this PR is about.

## Testing

- `scripts/run-unit-local.sh` — **49 projects green**, formatter clean.
- `scripts/run-e2e-local.sh` — **64/64**, including the WASM journey that walks the upload demo (the path this PR refactored into a shared module).
- Watch hot-reload gate — 3/3 (pre-push).
- New: 5 native download tests end-to-end (click → token in frame → client echo → file at the platform, plus token replay and a traversing filename), 15 filename-safety cases, 5 file-backend (including a vanished ref ending the stream rather than faulting it), 6 sign-in, 3 host parity, 4 contract completeness.
- **Not run:** the on-device Appium suite (needs a booted emulator/simulator). The native download and file paths are covered by unit tests against the fake WebView; the share sheet itself is platform-head code with no implementation in this PR.

## Benchmarks

Not run, and I don't believe they apply: the `Rask.Core` changes are a new static type never touched during a render, a diagnostic on an error path that previously returned early, and a string literal in an exception message. Nothing on the render hot path changed. Happy to run the suite if you'd rather have the number.

## Follow-ups (not in this PR)

- `Rask.Testing` ships `TestDownloadSink` but no `IBrowserFileBackend` double, so a file handler still has no supported unit-test path.
- The `Screen` chrome slots are typed `Component?` in Core but can only be filled with `Rask.Native` components, so a shared `Screen` subclass still forces a web app to reference the native package. Discussed separately; deliberately left out to keep this PR to the four gaps.
