### PR TITLE
chore(deps): drop four package references no code compiles against

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,27 @@ them until tagged releases begin.
   conflates the two tells the user their preference was ignored. Part of #695.
 
 ### Changed
+- **Pruned four `PackageReference`s that no code was compiling against.** The audit was a full sweep —
+  every `PackageVersion` in `Directory.Packages.props` still has a referencing project, and every other
+  reference either has API usage behind it or a stated reason to exist. Only these four had neither:
+
+  `Rask.Html` carried `Microsoft.Extensions.Primitives`, `Microsoft.AspNetCore.Authorization` and
+  `Microsoft.JSInterop` because the element family had them when it lived in `Rask.Core`. The types
+  behind all three stayed in Core when the family moved out (#710), so the references have been dead
+  since. Nothing needs re-declaring at a package boundary either: the project is `IsPackable=false` and
+  every host references it with `PrivateAssets="all"`, so its dependencies never reached a nuspec —
+  `Rask.Wasm` and `Rask.Native` already surface Core's runtime deps themselves, which is why *their*
+  seemingly-unused copies of the same packages stay put.
+
+  `Rask.Example.Auth.WasmCookie` referenced `Microsoft.Extensions.Logging` without logging anything.
+
+- **`Rask.Example.Auth.Jwt` depends on the JWT token library instead of the bearer handler.** The
+  sample issues and validates its own tokens (`JwtSecurityTokenHandler`) and authenticates through
+  Rask's session pipeline — it never calls `AddJwtBearer`, and was reaching
+  `System.IdentityModel.Tokens.Jwt` transitively through
+  `Microsoft.AspNetCore.Authentication.JwtBearer`. It now references that package directly, pinned to
+  the same 8.19.2 the handler resolves, so the two JWT samples share one IdentityModel graph.
+  `Rask.Example.Auth.WasmJwt.Host` does wire the handler and keeps its `JwtBearer` reference.
 - **`VirtualizeModel<T>(…)` is now `Virtualize.Items<T>(…)`.** It is the one hand-written generic entry
   point on the surface — a chain infers its type argument from the step that opens it, and `T` here
   comes from the *render delegate* — and it was reachable by simple name only because it sat inside the

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,6 +66,12 @@
     -->
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageVersion Include="SQLitePCLRaw.core" Version="3.0.5" />
+    <!--
+      Rask.Example.Auth.Jwt signs and validates its own tokens without the ASP.NET Core bearer
+      handler. Keep this on the version Microsoft.AspNetCore.Authentication.JwtBearer resolves for
+      Rask.Example.Auth.WasmJwt.Host, so the two samples share one IdentityModel graph.
+    -->
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.2" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/samples/Rask.Example.Auth.Jwt/Rask.Example.Auth.Jwt.csproj
+++ b/samples/Rask.Example.Auth.Jwt/Rask.Example.Auth.Jwt.csproj
@@ -7,7 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer"/>
+    <!--
+      This sample issues and validates tokens itself (JwtSecurityTokenHandler in Shared/CredentialStore.cs)
+      and authenticates through Rask's own session pipeline — it never calls AddJwtBearer. So it wants the
+      token library, not the ASP.NET Core bearer authentication handler that used to drag it in transitively.
+      Rask.Example.Auth.WasmJwt.Host is the sample that does wire the handler; it keeps the JwtBearer reference.
+    -->
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Rask.Example.Auth.WasmCookie/Rask.Example.Auth.WasmCookie.csproj
+++ b/samples/Rask.Example.Auth.WasmCookie/Rask.Example.Auth.WasmCookie.csproj
@@ -27,7 +27,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.Extensions.Logging" />
     <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Html\Rask.Html.csproj"/>
     <!-- Rask.Client (IShare) is a runtime dep of the WASM host; surface it in the boot manifest in-repo

--- a/src/Rask.Html/Rask.Html.csproj
+++ b/src/Rask.Html/Rask.Html.csproj
@@ -65,13 +65,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Same set Rask.Core compiles against: the element family binds forms (DI abstractions), reads
-         IJSRuntime for the interop-backed components, and Authorize-adjacent components need the
-         authorization abstractions. -->
-    <PackageReference Include="Microsoft.Extensions.Primitives"/>
+    <!--
+      Only what the element family itself compiles against. Forms bind through IServiceProvider, so the DI
+      abstractions are a real dependency; the interop-, authorization- and Primitives-backed types all stayed
+      behind in Rask.Core when the family moved out, and nothing here references them any more.
+
+      Nothing needs re-declaring at a package boundary either: this project is IsPackable=false and every host
+      references it with PrivateAssets="all", so its deps never reach a nuspec. The host packages surface
+      Rask.Core's runtime deps (Microsoft.JSInterop, Primitives, ObjectPool, Authorization) themselves — see
+      the ItemGroup comments in Rask.Wasm and Rask.Native.
+    -->
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>
-    <PackageReference Include="Microsoft.AspNetCore.Authorization"/>
-    <PackageReference Include="Microsoft.JSInterop"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

A full audit of every `PackageReference` in the repo against actual API usage, removing the ones no
code compiles against.

The central file was already clean — every `PackageVersion` in `Directory.Packages.props` has a
referencing project, and nothing is referenced without a version entry — so all of this is at the
project level.

**`Rask.Html`** carried `Microsoft.Extensions.Primitives`, `Microsoft.AspNetCore.Authorization` and
`Microsoft.JSInterop` because the element family had them while it lived in `Rask.Core`. The types
behind all three stayed in Core when the family moved out (#710), so the references have been dead
since; the csproj comment claiming otherwise was stale and is rewritten. Nothing needs re-declaring
at a package boundary either: the project is `IsPackable=false` and every host references it with
`PrivateAssets="all"`, so its dependencies never reached a nuspec.

**`Rask.Example.Auth.WasmCookie`** referenced `Microsoft.Extensions.Logging` without logging anything.

**`Rask.Example.Auth.Jwt`** now depends on `System.IdentityModel.Tokens.Jwt` directly instead of
`Microsoft.AspNetCore.Authentication.JwtBearer`. It issues and validates its own tokens
(`JwtSecurityTokenHandler`) and authenticates through Rask's session pipeline — it never calls
`AddJwtBearer`, and was reaching the token library transitively through the bearer handler. Pinned to
the 8.19.2 the handler resolves, so the two JWT samples share one IdentityModel graph.
`Rask.Example.Auth.WasmJwt.Host` does wire the handler and keeps its `JwtBearer` reference.

### Deliberately kept

Several references look unused and are not:

- **`Rask.Wasm` / `Rask.Native`** re-declare the bundled `Rask.Core`'s runtime dependencies at the
  package boundary. `PrivateAssets="all"` keeps Core out of the nuspec, so without them a consumer
  gets `Rask.Core.dll` in `lib/` and no package to resolve its dependencies from. Both csproj files
  already document this.
- **`SQLitePCLRaw.bundle_e_sqlite3`** direct pins — the lever that moves the family off the
  CVE-2025-6965 2.1.x line.
- `TestHost`, `Microsoft.CodeAnalysis.CSharp` and `xunit` hits in several test projects were false
  positives: they are used through `<Compile Include="..\..." />` linked source files and global usings.

## Testing

- `dotnet format --verify-no-changes` (whitespace + style + analyzers): clean
- `dotnet build Rask.slnx -warnaserror`: succeeded, 0 warnings, 0 errors
- Unit gate: **6121 tests across 42 assemblies, 0 failures**
- Pre-push gates: browser journey E2E passed, CLI build gate passed

Verified by reading usage rather than by "does it still compile" — transitive availability would have
hidden every one of these.

## Changelog

`[Unreleased] → Changed`, two entries.
