### PR TITLE
feat(testing): add TestFileBackend + TestServiceProvider so OnFiles handlers are testable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **`TestFileBackend` + `TestServiceProvider` — an `OnFiles` handler can finally be unit-tested.** `Rask.Testing`
+  shipped a `TestDownloadSink` but no file backend, and the gap was worse than a missing helper: a handler
+  test could not fail. `FileListReader` resolves `IBrowserFileBackend` from the container and hands the
+  handler an **empty list** when there is none, so a test that rendered a file input and raised its event ran
+  the handler with nothing in it and passed on whatever it did. That is the same silent-empty failure the
+  native host shipped with (#736), reproduced in every test.
+
+  ```csharp
+  var files = new TestFileBackend();
+  var picked = files.Add("notes.txt", "hello world", "text/plain");
+
+  var page = RaskTest.Render(new UploadPage(), TestServiceProvider.With<IBrowserFileBackend>(files));
+  await page.On("#picker").FilesAsync(picked);
+  ```
+
+  The handler gets real files: `OpenReadStream()` returns the staged bytes and `maxAllowedSize` is enforced
+  exactly as the real backends enforce it, so a component that forgot to raise the limit for a large upload
+  fails in a unit test rather than on a real file. `.FormPayload(field, …)` covers a file inside a submitted
+  form (the `FormData.Files` shape), `.Staged` lists what was added, and `.Released` records the framework's
+  release call — the browser hosts drop their client-side references there and the server frees its upload
+  slot, so a component holding a `RaskFile` past the handler is holding something already gone. An unstaged
+  ref throws with the reason instead of quietly yielding an empty file.
+
+  `TestServiceProvider` is the provider that makes it a one-liner: `RaskTest.Render` takes an `IServiceProvider` and
+  `Rask.Testing` depends on no DI container, so every test needing one service had to pull in
+  `Microsoft.Extensions.DependencyInjection` or hand-roll one. Registrations are by exact type with no
+  lifetimes or scopes; pass a real container's provider when a test needs more.
+
+  `RenderedComponent` gained `FilesAsync` on both interaction surfaces (`page.On(selector).FilesAsync(...)`
+  and the first-handler shortcut), which builds the metadata payload a real client would send. Closes #737.
+
+### Changed
+- **The "no `IBrowserFileBackend`" diagnostic now names the fix.** It reported the silent-empty case (added
+  in #736) but could only say "register a backend", because none shipped. It now points at
+  `Rask.Testing`'s `TestFileBackend`.
+
 ### Fixed
 - **Everything in `Rask.Core` now works on all three hosts, and a test says so.** Core is the shared
   component surface, so a component written once is supposed to run on Server, WASM and Native alike. Four

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -121,6 +121,55 @@ Assert.Equal(["hello"], js.ArgsFor("raskApi.clipboard.write"));
 `.Calls` lists every call in order; `.ArgsFor(id)` is the single-call shorthand, `.CallCount(id)` counts, and
 `.SetException(id, ex)` faults one. An unconfigured call returns `default` — the same as a real absent value.
 
+### Components that take file uploads
+
+A file input's handler receives `RaskFile`s the host reads back from the browser, so a test has to supply
+that host half. `TestFileBackend` is it — stage the bytes, register it, pick the files:
+
+```csharp
+var files = new TestFileBackend();
+var picked = files.Add("notes.txt", "hello world", "text/plain");
+
+var page = RaskTest.Render(new UploadPage(), TestServiceProvider.With<IBrowserFileBackend>(files));
+await page.On("#picker").FilesAsync(picked);
+
+Assert.Equal("notes.txt", page.TextOf("[data-testid=name]"));
+```
+
+The handler gets real files: `OpenReadStream()` returns the staged bytes, `Size` is their length, and the
+`maxAllowedSize` limit is enforced exactly as the real backends enforce it — so a component that forgot to
+raise the limit for a large upload fails here rather than on a real file.
+
+> **Register the backend, or the test proves nothing.** Without one, `FileListReader` hands the handler an
+> **empty list** — the handler still fires, and a test that asserts "no crash" passes while exercising the
+> empty branch. That silence is why `Rask.Core` now reports it through `RaskDiagnostics`.
+
+`FilesAsync` takes either specific files or the whole backend (`FilesAsync(files)`) when there is one input.
+For a file inside a submitted form, use `FormPayload`, which shapes the payload the way `FormData.Files`
+reads it:
+
+```csharp
+await page.On("#form").SubmitAsync(files.FormPayload("attachment", files.Add("cv.pdf", "…")));
+```
+
+`.Staged` lists everything added; `.Released` records what the framework handed back after the handler
+returned — the browser hosts drop their client-side references at that point and the server frees its upload
+slot, so a component holding a `RaskFile` past the handler is holding something already gone.
+
+### Handing a component its services
+
+`RaskTest.Render` takes any `IServiceProvider`, and `Rask.Testing` depends on no DI container. `TestServiceProvider`
+is the one-liner for the common case of one or two services:
+
+```csharp
+var services = new TestServiceProvider()
+    .Add<IBrowserFileBackend>(files)
+    .Add<IDownloadSink>(downloads);
+```
+
+Registrations are by exact type with no lifetimes or scopes — whatever you put in is what comes out. When a
+test needs more than that, build a real container and pass its provider instead.
+
 ### Forms: asserting validation state
 
 Validation state (messages, `IsModified`, `IsValidating`) never reaches the markup, so reach the form's
@@ -192,7 +241,7 @@ Assert.Equal("<button data-rask-on-click=\"h0\">x</button>", view.RenderAsLiveRo
 
 `RenderAsLiveRoot(IServiceProvider)` takes a service provider when the component needs DI
 (`RenderHarness.EmptyServices()`, or a project-specific builder like the example suite's
-`TestServices.Default(...)`).
+`TestServiceProvider.Default(...)`).
 
 ---
 
@@ -338,7 +387,7 @@ it needs, then asserted on the resulting HTML:
 
 ```csharp
 var routeState = new RouteState { Path = "/" };
-var html = new App.RenderAsLiveRoot(TestServices.Default(routeState: routeState));
+var html = new App.RenderAsLiveRoot(TestServiceProvider.Default(routeState: routeState));
 Assert.Contains("Hello, world!", html);
 ```
 
@@ -347,7 +396,7 @@ assertion is about the *page* (the doctype, `<html lang>`, what landed in `<head
 through `RaskTest.RenderDocument` instead, which composes the document the way a host does:
 
 ```csharp
-var html = RaskTest.RenderDocument(new App, TestServices.Default(routeState: routeState)).Html;
+var html = RaskTest.RenderDocument(new App, TestServiceProvider.Default(routeState: routeState)).Html;
 Assert.StartsWith("<!DOCTYPE html>", html);
 ```
 

--- a/src/Rask.Core/Forms/FileListReader.cs
+++ b/src/Rask.Core/Forms/FileListReader.cs
@@ -24,7 +24,7 @@ internal static class FileListReader
             RaskDiagnostics.Report(RaskLogLevel.Error, "Rask.Forms",
                 $"[Rask.Forms] {arr.GetArrayLength()} file(s) arrived from the client but no "
                 + "IBrowserFileBackend is registered, so the handler will receive an empty list. Every Rask "
-                + "host registers one; if you built this container yourself, register a backend.");
+                + "host registers one; in a unit test register Rask.Testing's TestFileBackend.");
             return Array.Empty<RaskFile>();
         }
 

--- a/src/Rask.Testing/NUGET.md
+++ b/src/Rask.Testing/NUGET.md
@@ -91,6 +91,16 @@ test keeps passing. `.On(selector)` names the element instead. (It's a handle ra
 - **`TestDownloadSink`** — an `IDownloadSink` that records what a component staged. `Navigator.Download`
   refuses to run without one and tells you to "register a fake"; this is that fake. Assert on
   `.Staged` (`FileName`, `ContentType`, `Bytes`, `.Text`).
+- **`TestFileBackend`** — an `IBrowserFileBackend` serving files a test staged in memory, so an `OnFiles`
+  handler can be tested at all. Stage with `.Add("notes.txt", "hello")`, register it, then
+  `page.On("#picker").FilesAsync(file)`. The handler gets real files: `OpenReadStream()` returns the bytes
+  and `maxAllowedSize` is enforced as the real backends enforce it. **Without a backend registered the
+  handler is handed an empty list** — it still fires, so a test can pass while proving nothing.
+  `.FormPayload(field, …)` covers a file inside a submitted form; `.Released` records the framework's
+  release call.
+- **`TestServiceProvider`** — a minimal `IServiceProvider` for handing a component the one or two services it
+  resolves: `TestServiceProvider.With<IBrowserFileBackend>(files)`, or `.Add(...).Add(...)` for several. Exists
+  because `RaskTest.Render` takes an `IServiceProvider` and this package depends on no DI container.
 - **`TestRoute.At("/search?q=hello%20world")`** — a `RouteState` at a URL, query string parsed and
   decoded, repeated keys kept. `TestRoute.NavigatorFor(state, downloads)` wires the `Navigator`.
   Register the `Navigator` in the provider and event dispatch enters its handler scope, so a component

--- a/src/Rask.Testing/RenderedComponent.cs
+++ b/src/Rask.Testing/RenderedComponent.cs
@@ -302,6 +302,22 @@ public class RenderedComponent : IRenderHandle
         /// <summary>Dispatches this element's <c>submit</c> handler, then re-renders.</summary>
         public Task<string> SubmitAsync(string? jsonPayload = null) => Raise("submit", jsonPayload);
 
+        /// <summary>
+        ///     Picks <paramref name="files" /> on this file input: raises its <c>files</c> handler with the
+        ///     metadata a real client would send, so the handler receives real <c>RaskFile</c>s.
+        ///     Stage them with <c>TestFileBackend.Add(...)</c> and register that backend — without one the
+        ///     handler is handed an empty list and the test silently proves nothing.
+        /// </summary>
+        public Task<string> FilesAsync(params TestFile[] files) =>
+            Raise("files", TestFileBackend.PayloadFor(files));
+
+        /// <summary>Picks every file staged in <paramref name="backend" /> — the single-input case.</summary>
+        public Task<string> FilesAsync(TestFileBackend backend)
+        {
+            ArgumentNullException.ThrowIfNull(backend);
+            return Raise("files", backend.Payload());
+        }
+
         /// <summary>Dispatches an arbitrary DOM event by name, for anything without a helper above.</summary>
         public Task<string> RaiseAsync(string domEvent, string? jsonPayload = null) =>
             Raise(domEvent, jsonPayload);
@@ -456,6 +472,10 @@ public class RenderedComponent : IRenderHandle
 
     /// <summary>Dispatches the <b>first</b> <c>submit</c> handler, e.g. <c>SubmitAsync("{\"form\":{...}}")</c>.</summary>
     public Task<string> SubmitAsync(string? jsonPayload = null) => InvokeEventAsync("submit", jsonPayload);
+
+    /// <summary>Picks <paramref name="files" /> on the <b>first</b> file input in the current render.</summary>
+    public Task<string> FilesAsync(params TestFile[] files) =>
+        InvokeEventAsync("files", TestFileBackend.PayloadFor(files));
 
     // Resolves the event's handler id from the CURRENT render, then dispatches — so the id is never stale.
     private Task<string> InvokeEventAsync(string domEvent, string? jsonPayload)

--- a/src/Rask.Testing/TestFileBackend.cs
+++ b/src/Rask.Testing/TestFileBackend.cs
@@ -1,0 +1,252 @@
+using System.Text;
+using System.Text.Json;
+using Rask.Core.Forms;
+
+namespace Rask.Testing;
+
+/// <summary>
+///     An <see cref="IBrowserFileBackend" /> that serves files a test staged in memory, instead of reading
+///     them back from a browser.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Without one registered, an <c>OnFiles</c> handler cannot be unit-tested <b>at all</b>, and — worse
+///         — it looks like it can. <c>FileListReader</c> resolves the backend from the container and hands
+///         the handler an <b>empty list</b> when there is none, so a test that renders a file input and
+///         raises its event exercises the empty branch and passes on whatever the handler does with nothing.
+///         That is the same silent-empty failure the native host shipped with, reproduced in every test.
+///     </para>
+///     <para>
+///         Stage the files, register the backend, raise the event:
+///     </para>
+///     <code>
+///     var files = new TestFileBackend();
+///     files.Add("notes.txt", "hello", "text/plain");
+///
+///     var page = RaskTest.Render(new UploadPage(), TestServiceProvider.With&lt;IBrowserFileBackend&gt;(files));
+///     await page.On("#picker").FilesAsync(files);
+///
+///     Assert.Equal("notes.txt", page.TextOf("[data-testid=name]"));
+///     </code>
+///     <para>
+///         <see cref="Released" /> records what the framework handed back after the handler returned, so a
+///         test can assert the release half of the contract too.
+///     </para>
+/// </remarks>
+public sealed class TestFileBackend : IBrowserFileBackend
+{
+    private readonly Lock _gate = new();
+    private readonly List<string> _released = [];
+    private readonly List<TestFile> _staged = [];
+
+    /// <summary>Every file staged so far, in the order it was added.</summary>
+    public IReadOnlyList<TestFile> Staged
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _staged.ToArray();
+            }
+        }
+    }
+
+    /// <summary>
+    ///     The names of the files the framework released after a handler returned, oldest first. The browser
+    ///     hosts drop their references at this point and the server host frees its upload slot, so a
+    ///     component that holds a <see cref="RaskFile" /> past the handler is holding something already gone.
+    /// </summary>
+    public IReadOnlyList<string> Released
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _released.ToArray();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public RaskFile Create(JsonElement metadata)
+    {
+        var reference = metadata.TryGetProperty("ref", out var r) && r.ValueKind == JsonValueKind.String
+            ? r.GetString()
+            : null;
+
+        lock (_gate)
+        {
+            foreach (var file in _staged)
+            {
+                if (file.Ref == reference)
+                {
+                    return file;
+                }
+            }
+        }
+
+        // A ref the test never staged is a mistake in the test, not a condition to model: the real backends
+        // are handed refs their own client minted moments earlier. Saying so beats returning an empty file
+        // and letting the assertion fail somewhere else.
+        throw new InvalidOperationException(
+            $"No file staged under ref '{reference}'. Stage it with TestFileBackend.Add(...) and build the "
+            + "event payload from what Add returned (or from the backend's Payload()), rather than writing "
+            + "the JSON by hand.");
+    }
+
+    /// <inheritdoc />
+    public void Release(IEnumerable<RaskFile> files)
+    {
+        ArgumentNullException.ThrowIfNull(files);
+        lock (_gate)
+        {
+            foreach (var file in files)
+            {
+                _released.Add(file.Name);
+            }
+        }
+    }
+
+    /// <summary>Stages <paramref name="bytes" /> as a pickable file and returns the handle to build a payload from.</summary>
+    /// <param name="name">The file name the handler will see.</param>
+    /// <param name="bytes">The content the handler will read from <c>OpenReadStream</c>.</param>
+    /// <param name="contentType">MIME type; defaults to <c>application/octet-stream</c>.</param>
+    /// <param name="lastModified">Defaults to the Unix epoch, so a test is not time-dependent by accident.</param>
+    public TestFile Add(string name, byte[] bytes, string? contentType = null,
+        DateTimeOffset? lastModified = null)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        lock (_gate)
+        {
+            var file = new TestFile(
+                "test-file-" + _staged.Count.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                name,
+                bytes,
+                contentType ?? "application/octet-stream",
+                lastModified ?? DateTimeOffset.UnixEpoch);
+            _staged.Add(file);
+            return file;
+        }
+    }
+
+    /// <summary>Stages <paramref name="text" /> as UTF-8 — the common case for a CSV, JSON or text upload.</summary>
+    /// <param name="name">The file name the handler will see.</param>
+    /// <param name="text">The content, encoded as UTF-8.</param>
+    /// <param name="contentType">MIME type; defaults to <c>text/plain</c> for this overload.</param>
+    public TestFile Add(string name, string text, string? contentType = null)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return Add(name, Encoding.UTF8.GetBytes(text), contentType ?? "text/plain");
+    }
+
+    /// <summary>
+    ///     The payload for a file input's <c>files</c> event, carrying every staged file. Pass
+    ///     <paramref name="files" /> to send only some of them — e.g. when one test stages files for two
+    ///     different inputs.
+    /// </summary>
+    public string Payload(params TestFile[] files) =>
+        PayloadFor(files.Length > 0 ? files : Staged);
+
+    /// <summary>
+    ///     The <c>files</c>-event payload for <paramref name="files" />, without going through a backend
+    ///     instance — a <see cref="TestFile" /> carries its own metadata. This is what
+    ///     <c>page.On("#picker").FilesAsync(file)</c> uses.
+    /// </summary>
+    public static string PayloadFor(params TestFile[] files)
+    {
+        ArgumentNullException.ThrowIfNull(files);
+        return PayloadFor((IReadOnlyList<TestFile>)files);
+    }
+
+    private static string PayloadFor(IReadOnlyList<TestFile> files) =>
+        "{\"files\":" + MetadataArray(files) + "}";
+
+    /// <summary>
+    ///     The payload for a <c>submit</c> whose form contains a file input named <paramref name="fieldName" />
+    ///     — the shape <c>FormData.Files(fieldName)</c> reads. Merge extra text fields yourself if the form
+    ///     has them; this covers the file half.
+    /// </summary>
+    public string FormPayload(string fieldName, params TestFile[] files)
+    {
+        ArgumentNullException.ThrowIfNull(fieldName);
+        return "{\"form\":{\"__files\":{" + JsonSerializer.Serialize(fieldName) + ":"
+               + MetadataArray(files.Length > 0 ? files : Staged) + "}}}";
+    }
+
+    private static string MetadataArray(IReadOnlyList<TestFile> files)
+    {
+        var sb = new StringBuilder("[");
+        for (var i = 0; i < files.Count; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(',');
+            }
+
+            sb.Append(files[i].Metadata);
+        }
+
+        return sb.Append(']').ToString();
+    }
+}
+
+/// <summary>
+///     One file staged in a <see cref="TestFileBackend" />. It <em>is</em> the <see cref="RaskFile" /> the
+///     handler receives, so a test can compare identity as well as content.
+/// </summary>
+public sealed class TestFile : RaskFile
+{
+    internal TestFile(string reference, string name, byte[] bytes, string contentType,
+        DateTimeOffset lastModified)
+    {
+        Ref = reference;
+        Name = name;
+        Bytes = bytes;
+        ContentType = contentType;
+        LastModified = lastModified;
+    }
+
+    /// <summary>The handle the event payload refers to this file by.</summary>
+    public string Ref { get; }
+
+    /// <summary>The staged content.</summary>
+    public byte[] Bytes { get; }
+
+    /// <inheritdoc />
+    public override string Name { get; }
+
+    /// <inheritdoc />
+    public override long Size => Bytes.Length;
+
+    /// <inheritdoc />
+    public override string ContentType { get; }
+
+    /// <inheritdoc />
+    public override DateTimeOffset LastModified { get; }
+
+    /// <summary>This file's entry in an event payload — the same metadata a real client would send.</summary>
+    public string Metadata =>
+        "{\"ref\":" + JsonSerializer.Serialize(Ref)
+                    + ",\"name\":" + JsonSerializer.Serialize(Name)
+                    + ",\"size\":" + Size.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                    + ",\"type\":" + JsonSerializer.Serialize(ContentType)
+                    + ",\"lastModified\":"
+                    + LastModified.ToUnixTimeMilliseconds().ToString(System.Globalization.CultureInfo.InvariantCulture)
+                    + "}";
+
+    /// <inheritdoc />
+    public override Stream OpenReadStream(long maxAllowedSize = 512 * 1024,
+        CancellationToken cancellationToken = default)
+    {
+        // Enforced here as the real backends do, so a test catches a component that forgot to raise the
+        // limit for a large upload instead of only finding out on a real file.
+        if (Size > maxAllowedSize)
+        {
+            throw new IOException($"File '{Name}' is {Size} bytes, exceeds maxAllowedSize of {maxAllowedSize}.");
+        }
+
+        return new MemoryStream(Bytes, writable: false);
+    }
+}

--- a/src/Rask.Testing/TestServiceProvider.cs
+++ b/src/Rask.Testing/TestServiceProvider.cs
@@ -1,0 +1,80 @@
+namespace Rask.Testing;
+
+/// <summary>
+///     A minimal <see cref="IServiceProvider" /> for handing a component under test the one or two services
+///     it resolves from the container — a <see cref="TestFileBackend" />, a <see cref="TestDownloadSink" />,
+///     a <c>Navigator</c>.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>RaskTest.Render</c> takes an <see cref="IServiceProvider" />, and <c>Rask.Testing</c>
+///         deliberately depends on no DI container — so without this, every test that needs one service had
+///         to either pull in <c>Microsoft.Extensions.DependencyInjection</c> or hand-roll a provider. This is
+///         that provider, once.
+///     </para>
+///     <para>
+///         Registrations are by exact type, with no lifetime, scope or resolution rules: whatever you put in
+///         is what comes out, and an unregistered type comes back <c>null</c> the way
+///         <c>IServiceProvider</c> requires. If a test needs more than that, register a real container's
+///         provider instead — <c>RaskTest.Render</c> accepts any <see cref="IServiceProvider" />.
+///     </para>
+///     <code>
+///     var files = new TestFileBackend();
+///     var page = RaskTest.Render(new UploadPage(), TestServiceProvider.With&lt;IBrowserFileBackend&gt;(files));
+///
+///     // several services:
+///     var services = new TestServiceProvider()
+///         .Add&lt;IBrowserFileBackend&gt;(files)
+///         .Add&lt;IDownloadSink&gt;(downloads);
+///     </code>
+/// </remarks>
+public sealed class TestServiceProvider : IServiceProvider
+{
+    private readonly Dictionary<Type, object> _services = [];
+
+    /// <inheritdoc />
+    public object? GetService(Type serviceType)
+    {
+        ArgumentNullException.ThrowIfNull(serviceType);
+        return _services.GetValueOrDefault(serviceType);
+    }
+
+    /// <summary>A provider holding a single service, for the common one-dependency case.</summary>
+    /// <typeparam name="TService">The type the component resolves — usually the interface, not the double's class.</typeparam>
+    /// <param name="instance">The instance to hand back.</param>
+    public static TestServiceProvider With<TService>(TService instance)
+        where TService : class => new TestServiceProvider().Add(instance);
+
+    /// <summary>Registers <paramref name="instance" /> under <typeparamref name="TService" />, replacing any previous one.</summary>
+    /// <typeparam name="TService">The type the component resolves — usually the interface, not the double's class.</typeparam>
+    /// <param name="instance">The instance to hand back.</param>
+    /// <returns>This provider, for chaining.</returns>
+    public TestServiceProvider Add<TService>(TService instance)
+        where TService : class
+    {
+        ArgumentNullException.ThrowIfNull(instance);
+        _services[typeof(TService)] = instance;
+        return this;
+    }
+
+    /// <summary>
+    ///     Registers <paramref name="instance" /> under <paramref name="serviceType" />, for a type only known
+    ///     at runtime.
+    /// </summary>
+    /// <param name="serviceType">The type the component resolves.</param>
+    /// <param name="instance">The instance to hand back; must be assignable to <paramref name="serviceType" />.</param>
+    /// <returns>This provider, for chaining.</returns>
+    public TestServiceProvider Add(Type serviceType, object instance)
+    {
+        ArgumentNullException.ThrowIfNull(serviceType);
+        ArgumentNullException.ThrowIfNull(instance);
+        if (!serviceType.IsInstanceOfType(instance))
+        {
+            throw new ArgumentException(
+                $"{instance.GetType()} is not assignable to {serviceType}.", nameof(instance));
+        }
+
+        _services[serviceType] = instance;
+        return this;
+    }
+}

--- a/tests/Rask.Testing.Tests/TestFileBackendTests.cs
+++ b/tests/Rask.Testing.Tests/TestFileBackendTests.cs
@@ -1,0 +1,161 @@
+using System.Text;
+using Rask.Core.Forms;
+using Rask.Core.Live;
+
+namespace Rask.Testing.Tests;
+
+// An OnFiles handler could not be unit-tested before this: FileListReader resolves IBrowserFileBackend from
+// the container and hands the handler an EMPTY list when there is none, so a test that rendered a file input
+// and raised its event exercised the empty branch and passed on whatever the handler did with nothing. The
+// end-to-end facts below are the ones that matter — the rest guard the seams they lean on.
+public partial class TestFileBackendTests : global::Rask.Core.RaskMarkup
+{
+    [Fact]
+    public async Task AFilesEvent_ReachesTheHandler_WithRealBytes()
+    {
+        var files = new TestFileBackend();
+        var picked = files.Add("notes.txt", "hello world", "text/plain");
+
+        var page = RaskTest.Render(UploadProbe, TestServiceProvider.With<IBrowserFileBackend>(files));
+        await page.On("#picker").FilesAsync(picked);
+
+        var received = Assert.Single(page.Instance.Received);
+        Assert.Equal("notes.txt", received.Name);
+        Assert.Equal("text/plain", received.ContentType);
+        Assert.Equal(11, received.Size);
+        Assert.Equal("hello world", page.Instance.ReadBack);
+    }
+
+    // The failure this whole type exists to end: without a backend the handler still fires, with nothing in
+    // it. Pinning it means a future refactor that quietly re-breaks the resolution shows up here.
+    [Fact]
+    public async Task WithNoBackendRegistered_TheHandlerGetsAnEmptyList()
+    {
+        var files = new TestFileBackend();
+        var picked = files.Add("notes.txt", "hello world", "text/plain");
+
+        var page = RaskTest.Render(UploadProbe);
+        await page.On("#picker").FilesAsync(picked);
+
+        Assert.True(page.Instance.Fired, "the handler still runs");
+        Assert.Empty(page.Instance.Received);
+    }
+
+    [Fact]
+    public async Task EveryStagedFile_IsPickedWhenThePickerIsGivenTheBackend()
+    {
+        var files = new TestFileBackend();
+        files.Add("a.txt", "one");
+        files.Add("b.txt", "two");
+
+        var page = RaskTest.Render(UploadProbe, TestServiceProvider.With<IBrowserFileBackend>(files));
+        await page.On("#picker").FilesAsync(files);
+
+        Assert.Equal(["a.txt", "b.txt"], page.Instance.Received.Select(f => f.Name));
+    }
+
+    [Fact]
+    public async Task TheFrameworkReleasesTheFiles_AfterTheHandlerReturns()
+    {
+        // The browser hosts drop their client-side references here and the server frees its upload slot, so a
+        // component that holds a RaskFile past the handler is holding something already gone.
+        var files = new TestFileBackend();
+        var page = RaskTest.Render(UploadProbe, TestServiceProvider.With<IBrowserFileBackend>(files));
+
+        await page.On("#picker").FilesAsync(files.Add("notes.txt", "hi"));
+
+        Assert.Equal(["notes.txt"], files.Released);
+    }
+
+    [Fact]
+    public void Add_DefaultsAreDeterministic_SoATestIsNotTimeDependent()
+    {
+        var file = new TestFileBackend().Add("blob.bin", new byte[] { 1, 2, 3 });
+
+        Assert.Equal("application/octet-stream", file.ContentType);
+        Assert.Equal(DateTimeOffset.UnixEpoch, file.LastModified);
+        Assert.Equal(3, file.Size);
+    }
+
+    [Fact]
+    public void Add_TextOverload_EncodesUtf8_AndDefaultsToTextPlain()
+    {
+        var file = new TestFileBackend().Add("notes.txt", "héllo");
+
+        Assert.Equal("text/plain", file.ContentType);
+        Assert.Equal(Encoding.UTF8.GetBytes("héllo"), file.Bytes);
+    }
+
+    [Fact]
+    public void OpenReadStream_EnforcesMaxAllowedSize_LikeTheRealBackends()
+    {
+        // So a component that forgot to raise the limit for a large upload fails in a unit test rather than
+        // on a real file.
+        var file = new TestFileBackend().Add("big.bin", new byte[1024]);
+
+        Assert.Throws<IOException>(() => file.OpenReadStream(512));
+    }
+
+    [Fact]
+    public void Create_WithAnUnstagedRef_SaysSo()
+    {
+        var backend = new TestFileBackend();
+        var meta = System.Text.Json.JsonDocument.Parse("""{"ref":"nope","name":"x.txt","size":1}""").RootElement;
+
+        var ex = Assert.Throws<InvalidOperationException>(() => backend.Create(meta));
+
+        Assert.Contains("nope", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task FormPayload_DeliversFilesUnderTheirFieldName()
+    {
+        var files = new TestFileBackend();
+        var page = RaskTest.Render(UploadFormProbe, TestServiceProvider.With<IBrowserFileBackend>(files));
+
+        await page.On("#form").SubmitAsync(files.FormPayload("attachment", files.Add("cv.pdf", "x")));
+
+        Assert.Equal(["cv.pdf"], page.Instance.Received.Select(f => f.Name));
+    }
+}
+
+internal sealed partial class UploadProbe : Component
+{
+    public bool Fired { get; private set; }
+    public IReadOnlyList<RaskFile> Received { get; private set; } = [];
+    public string? ReadBack { get; private set; }
+
+    private void OnFiles(IReadOnlyList<RaskFile> files)
+    {
+        Fired = true;
+        Received = files;
+        if (files.Count == 0)
+        {
+            return;
+        }
+
+        // Read through the real RaskFile API, so the test proves the stream works and not just the metadata.
+        using var reader = new StreamReader(files[0].OpenReadStream());
+        ReadBack = reader.ReadToEnd();
+    }
+
+    protected override Component? Render() =>
+        Input.Value<string>(null).Id("picker").Type(InputType.File).OnFiles(OnFiles);
+}
+
+internal sealed partial class UploadFormProbe : Component
+{
+    private readonly Attachment _model = new();
+
+    public IReadOnlyList<RaskFile> Received { get; private set; } = [];
+
+    private void OnSubmit(FormData form) => Received = form.Files("attachment");
+
+    protected override Component? Render() =>
+        Form.Model(_model).Id("form").OnSubmit(OnSubmit)[
+            Input.Value<string>(null).Type(InputType.File).Name("attachment")
+        ];
+
+    // Form is Form<TModel>; the model only exists to open the chain.
+    internal sealed class Attachment;
+}


### PR DESCRIPTION
Closes #737.

## The problem

`Rask.Testing` shipped a `TestDownloadSink` but no file backend, and the gap was worse than a missing helper: **an `OnFiles` handler test could not fail.**

`FileListReader` resolves `IBrowserFileBackend` from the container and hands the handler an **empty list** when there is none. So a test that rendered a file input and raised its event ran the handler with nothing in it, and passed on whatever the handler did with nothing. That's the same silent-empty failure the native host shipped with in #736 — reproduced in every unit test in every app.

## The fix

```csharp
var files = new TestFileBackend();
var picked = files.Add("notes.txt", "hello world", "text/plain");

var page = RaskTest.Render(UploadPage, TestServiceProvider.With<IBrowserFileBackend>(files));
await page.On("#picker").FilesAsync(picked);
```

The handler receives **real** `RaskFile`s: `OpenReadStream()` returns the staged bytes, `Size` is their length, and `maxAllowedSize` is enforced exactly as the real backends enforce it — so a component that forgot to raise the limit for a large upload fails in a unit test rather than on a real file.

- **`FormPayload(field, …)`** shapes the payload `FormData.Files(field)` reads, for a file inside a submitted form.
- **`.Staged`** lists what was added; **`.Released`** records the framework's release call after the handler returns — the browser hosts drop their client-side references there and the server frees its upload slot, so a component holding a `RaskFile` past the handler is holding something already gone.
- An **unstaged ref throws with the reason** rather than quietly yielding an empty file, because a ref the test never staged is a mistake in the test, not a condition to model.

**`TestServiceProvider`** is what makes it a one-liner. `RaskTest.Render` takes an `IServiceProvider` and this package deliberately depends on no DI container, so every test needing one service had to pull in `Microsoft.Extensions.DependencyInjection` or hand-roll a provider.

**`RenderedComponent.FilesAsync`** on both interaction surfaces (`page.On(selector).FilesAsync(...)` and the first-handler shortcut) builds the metadata payload a real client would send.

## A shipped-API naming decision worth reviewing

I first called the provider the obvious thing — `TestServices` — and the build broke **145 call sites with `CS0104`**, because `Rask.Example.Shared.Tests` already has a `TestServices` of its own (a full container factory — a genuinely different thing, not duplication to fold).

That's not a naming quibble: any app with its own `TestServices` helper would hit the identical break on upgrade. So the shipped type is `TestServiceProvider`, and the reason is recorded in its doc comment rather than left to be rediscovered. Say the word if you'd rather have the shorter name and accept the churn.

## Testing

- Unit gate **325/325**, formatter clean, with the 9 new tests confirmed running inside the gate rather than only under a filter.
- Browser E2E **60/60**, CLI build gate **24/24** (pre-push).
- The test that matters most pins the *old* behaviour: `WithNoBackendRegistered_TheHandlerGetsAnEmptyList` asserts the handler still fires and receives nothing — so a future refactor that quietly re-breaks the resolution shows up as a failure instead of as a green test proving nothing.
- End-to-end coverage reads back through the real `RaskFile` API (`OpenReadStream`), not just the metadata, and the form path goes through a real `Form.Model(...)` submit.

## Also

Core's "no `IBrowserFileBackend`" diagnostic (added in #736) could only say *"register a backend"*, because none shipped. It now names `TestFileBackend`.

Docs: a **Components that take file uploads** section and a **Handing a component its services** section in `docs/testing.md`, plus both types in the package readme.

## Not done

No benchmark run — this adds a test-only package surface and touches no render path. The one Core change is a string literal in an existing diagnostic message.
