### PR TITLE
docs(native): drop the stale contract count the changelog already dropped

### DIFF
--- a/docs/native.md
+++ b/docs/native.md
@@ -247,7 +247,7 @@ Two ordering rules the generated heads already follow — keep them if you edit 
 
 `Rask.Core` is the shared component surface, so anything a component can inject or call from it has to work
 on Server, WASM **and** native — otherwise a component written once breaks on one head only, at runtime,
-with nothing at compile time to warn you. `RaskHostContracts` names that set (47 contracts), and each host's
+with nothing at compile time to warn you. `RaskHostContracts` names that set, and each host's
 test project asserts its own bootstrap resolves every one of them.
 
 Three of them used to be missing here, and the failures were quiet: a file input handed the handler an


### PR DESCRIPTION
Follow-up to #736, which is already merged.

#736 removed the hard-coded **"47 contracts"** from its CHANGELOG entry, with the reason stated plainly:
that number went stale twice before the change it described had even merged. `docs/native.md` carried the
same number and kept it — so main now says 47 where `RaskHostContracts` holds **49** (9 host services + 40
browser APIs, after `IViewTransitions` and `IWebAnimations` joined in #739/#740).

Same treatment, same reason. The sentence reads fine without a number that only a test can keep honest,
and the completeness test in `Rask.Core.Tests` is what actually enforces the set.

```
- `RaskHostContracts` names that set (47 contracts), and each host's …
+ `RaskHostContracts` names that set, and each host's …
```

## Testing

`CI=true dotnet build Rask.slnx -warnaserror` → 0 warnings · full unit suite on this base → 43 projects,
6187 tests, 0 failures · pre-push browser E2E passed. Docs-only change; no behaviour touched.
