### PR TITLE
fix(testing): wait for the diagnostic under test, not for the first one to arrive

### DIFF
--- a/tests/Rask.Testing.Tests/TestingSurfaceTests.cs
+++ b/tests/Rask.Testing.Tests/TestingSurfaceTests.cs
@@ -164,6 +164,9 @@ public class TestingSurfaceTests
         protected override Component? Render() => Div["x"];
     }
 
+    private static bool IsTheSwallowedFault(CapturedDiagnostic e) =>
+        e.Level == DiagnosticLevel.Error && e.Exception?.Message == "boom";
+
     [Fact]
     public async Task CapturingDiagnostics_SeesAFaultTheFrameworkSwallowed()
     {
@@ -173,10 +176,9 @@ public class TestingSurfaceTests
 
         // Swallow-and-log is the framework's designed behaviour here; without a capture there is no
         // supported way for an app author to assert that it happened, or that it didn't.
-        await WaitForCaptureAsync(diagnostics);
+        await WaitForCaptureAsync(diagnostics, IsTheSwallowedFault);
 
-        Assert.Contains(diagnostics.Captured, e =>
-            e.Level == DiagnosticLevel.Error && e.Exception?.Message == "boom");
+        Assert.Contains(diagnostics.Captured, IsTheSwallowedFault);
     }
 
     [Fact]
@@ -196,9 +198,17 @@ public class TestingSurfaceTests
     }
 
     // The hook faults on a thread-pool continuation, so the report lands after Render() returns.
-    private static async Task WaitForCaptureAsync(CapturingDiagnostics diagnostics)
+    //
+    // Waits for the diagnostic the caller is actually about, not merely for the list to become non-empty.
+    // CapturingDiagnostics installs a PROCESS-GLOBAL sink, so a sibling test class running in parallel can
+    // drop its own diagnostic in first; a "wait until non-empty" loop then returns before the awaited one
+    // has landed and the assertion fails on a full-solution run while passing standalone.
+    private static async Task WaitForCaptureAsync(
+        CapturingDiagnostics diagnostics, Func<CapturedDiagnostic, bool>? match = null)
     {
-        for (var i = 0; i < 200 && diagnostics.Captured.Count == 0; i++)
+        match ??= _ => true;
+
+        for (var i = 0; i < 200 && !diagnostics.Captured.Any(match); i++)
         {
             await Task.Delay(10);
         }


### PR DESCRIPTION
Closes #749. Found while verifying main after merging #736/#741/#747 — the full-solution unit run went red
on a test that passes standalone.

```
Assert.Contains() Failure: Filter not matched in collection
Collection: [CapturedDiagnostic { Level = Error, Category = Rask.Forms,
  Message = [Rask.Forms] 1 file(s) arrived from the client but no IBrowserFileBackend is registered … }]
```

The captured list holds someone else's diagnostic, not the `"boom"` the test is about.

## Cause

`CapturingDiagnostics.Install()` swaps a **process-global** sink, so every test in the assembly shares one
capture list. The helper stopped at the first diagnostic of any kind:

```csharp
for (var i = 0; i < 200 && diagnostics.Captured.Count == 0; i++)
```

`TestFileBackendTests.WithNoBackendRegistered_TheHandlerGetsAnEmptyList` — added in #746 — deliberately
runs with no backend and emits that `Rask.Forms` diagnostic. xUnit runs the two classes in parallel, so
when it lands first the loop exits immediately, before the swallowed fault (a thread-pool continuation) has
been reported.

**Load-dependent, and the wrong way round:** red on a full-solution run, green in three consecutive
standalone runs of the same assembly. Passing alone and failing together is the signature of shared state,
not of a broken assertion — the same shape as #732.

## Fix

The wait takes the predicate the caller is asserting on, so a foreign diagnostic doesn't satisfy it and the
loop keeps waiting regardless of what else is in flight. The assertion and the wait now use one shared
predicate, so they cannot drift apart.

## Noted, not fixed

`CapturingDiagnostics_RestoresThePreviousSinkOnDispose` asserts only `Assert.NotEmpty(after.Captured)`, so
it can still pass on a diagnostic emitted by a parallel test. Not failing, but weaker than it looks;
recorded in #749 rather than widened here.

## Testing

`CI=true dotnet build Rask.slnx -warnaserror` → 0 warnings. Full unit suite — the run that was red —
**43 projects, 6196 tests, 0 failures**. Pre-push browser E2E passed.
