### PR TITLE
docs(samples): show the portable chrome in the showcase, on every host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **The portable chrome now has a sample, which is what the repo's own definition of done asks for.** #743
+  shipped `AppBar`/`TabStrip` and documented them, but no sample used them — and no sample used `Screen` at
+  all — so the cross-host claim was proven only in unit tests, never in a running app.
+
+  - **`/chrome`** in the showcase is a real `Screen`, naming no `Rask.Native` type. All three showcase hosts
+    compile it from the same `Rask.Example.Shared` project: Server and WASM render its slots as landmark
+    HTML, and the native heads project the same declaration to a `UINavigationBar` + `UITabBar`. Unlisted in
+    the sidebar, like `/table`.
+  - **`ChromeBarsDemo`** renders the bars inline with its source, embedded in the native guide at
+    `<!-- demo:chrome-bars -->`, with a ~20-line scoped stylesheet that doubles as the demonstration:
+    `Rask.Core` ships no CSS for the bars and emits `data-rask-icon="add"` rather than a glyph, so the class
+    names *are* the styling contract and one rule per icon token wires up whatever set the app already has.
+
+  Covered by the shared browser journey (so it runs on Server, WASM and standalone WASM): the two landmarks,
+  exactly one `aria-current="page"` tab and that it is the one matching the route, and a bar button's
+  callback re-rendering the screen.
+
+### Fixed
+- **A comment added in #743 described a hazard that isn't one.** It claimed importing a component namespace
+  shadows the chain entries of the same name. Entries are injected into the enclosing partial class, and a
+  member of the enclosing type wins simple-name lookup over a namespace-imported type — which is why the
+  native tests import `Rask.Native.Components` and the new sample imports `Rask.Chrome.Components`, both
+  compiling fine. The real rule, already documented in the host `.props`, is narrower: it is why the
+  framework emits a `global using static` for the entries but never a global namespace import.
+
+### Added
 - **`TestFileBackend` + `TestServiceProvider` — an `OnFiles` handler can finally be unit-tested.** `Rask.Testing`
   shipped a `TestDownloadSink` but no file backend, and the gap was worse than a missing helper: a handler
   test could not fail. `FileListReader` resolves `IBrowserFileBackend` from the container and hands the

--- a/docs/native-devices.md
+++ b/docs/native-devices.md
@@ -205,6 +205,8 @@ screen emits no markup for either. On Server and WASM the same declaration rende
 </div>
 ```
 
+<!-- demo:chrome-bars -->
+
 Three things that are deliberate:
 
 - **Core ships no stylesheet.** The class names above *are* the styling contract, and the icon arrives as

--- a/samples/Rask.Example.Shared/Features/Chrome/ChromeBarsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Chrome/ChromeBarsDemo.cs
@@ -1,0 +1,43 @@
+using Rask.Chrome.Components;
+using Rask.Core.Routing;
+
+namespace Rask.Example.Shared.Features;
+
+// AppBar and TabStrip are the PORTABLE chrome vocabulary (Rask.Chrome): one declaration that renders the
+// landmark markup below on Server and WASM, and is projected to a real UINavigationBar + UITabBar (iOS) /
+// top + bottom bar (Android) inside a native shell, where it emits no HTML at all.
+//
+// Composed inline here so the demo can sit in a doc; the same two components fill a Screen's HeaderBar and
+// TabBar slots, which is what makes one screen class serve every host — see ChromeScreen at /chrome.
+//
+// Rask.Core ships no stylesheet for them on purpose: the rask-header-bar / rask-tab-bar / rask-bar-button
+// class names ARE the styling contract, and the icon arrives as data-rask-icon="add" rather than a glyph so
+// the framework carries no SVG payload and no icon-font dependency. ChromeBarsDemo.css is this app's half of
+// that contract — scoped to this component, and about twenty lines.
+public sealed partial class ChromeBarsDemo : Component
+{
+    private int _added;
+
+    protected override Component? Render() =>
+        Div.Class("chrome-demo")[
+            AppBar
+                .Title("Todos")
+                .Trailing([BarButton.Icon(BarIcon.Add).Title("New").OnClick(() => _added++)]),
+            Div.Class("chrome-demo-body")[
+                P.Class("mb-0 small")[
+                    "Tapped ",
+                    Span.Id("chrome-added").Class("fw-semibold")[_added.ToString(
+                        System.Globalization.CultureInfo.InvariantCulture)],
+                    " time(s). On a native head the button above is a real bar item, and this text is the "
+                    + "only thing inside the WebView."
+                ]
+            ],
+            // Selected is left unset, so the lit tab is derived from the current route by the same method the
+            // native host calls — one declaration cannot light different tabs on different hosts.
+            TabStrip.Tabs([
+                TabItem.Title("Home").Icon(BarIcon.Home).To(new RouteUrl("/")),
+                TabItem.Title("Todos").Icon(BarIcon.List).To(Features.Routes.TodosPage()).Badge("3"),
+                TabItem.Title("Me").Icon(BarIcon.Person).To(new RouteUrl("/me"))
+            ])
+        ];
+}

--- a/samples/Rask.Example.Shared/Features/Chrome/ChromeBarsDemo.css
+++ b/samples/Rask.Example.Shared/Features/Chrome/ChromeBarsDemo.css
@@ -1,0 +1,89 @@
+/* The app's half of the styling contract: Rask.Chrome emits the class names and the data-rask-icon token,
+   and ships no stylesheet — so a web app dresses the bars however it likes, and attaches whatever icon set it
+   already uses. This showcase already loads Bootstrap Icons, so one rule per token is the whole icon story. */
+
+.chrome-demo {
+    border: 1px solid var(--bs-border-color);
+    border-radius: .5rem;
+    overflow: hidden;
+}
+
+.chrome-demo .rask-header-bar {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    padding: .5rem .75rem;
+    background: var(--bs-tertiary-bg);
+    border-bottom: 1px solid var(--bs-border-color);
+}
+
+.chrome-demo .rask-header-title {
+    font-weight: 600;
+    flex: 1;
+}
+
+.chrome-demo .rask-header-trailing {
+    display: flex;
+    gap: .25rem;
+}
+
+.chrome-demo .rask-bar-button {
+    border: 0;
+    background: transparent;
+    color: var(--bs-primary);
+    cursor: pointer;
+    padding: .25rem .5rem;
+    border-radius: .25rem;
+}
+
+.chrome-demo .rask-bar-button:hover {
+    background: var(--bs-secondary-bg);
+}
+
+.chrome-demo-body {
+    padding: .75rem;
+}
+
+.chrome-demo .rask-tab-bar {
+    display: flex;
+    border-top: 1px solid var(--bs-border-color);
+    background: var(--bs-tertiary-bg);
+}
+
+.chrome-demo .rask-tab {
+    flex: 1;
+    text-align: center;
+    padding: .5rem .25rem;
+    font-size: .8125rem;
+    text-decoration: none;
+    color: var(--bs-secondary-color);
+}
+
+/* The active tab is a visual cue only — aria-current="page" is what carries it to a screen reader. */
+.chrome-demo .rask-tab-active {
+    color: var(--bs-primary);
+    font-weight: 600;
+    box-shadow: inset 0 2px 0 var(--bs-primary);
+}
+
+.chrome-demo .rask-tab-badge {
+    display: inline-block;
+    margin-left: .25rem;
+    padding: 0 .35rem;
+    border-radius: 1rem;
+    background: var(--bs-danger);
+    color: #fff;
+    font-size: .6875rem;
+}
+
+/* data-rask-icon is the framework's whole icon contract: a stable token, no glyph. Map each one to the icon
+   set the app already has — Bootstrap Icons here. */
+.chrome-demo [data-rask-icon]::before {
+    font-family: bootstrap-icons, sans-serif;
+    margin-right: .25rem;
+}
+
+.chrome-demo [data-rask-icon="add"]::before { content: "\F64D"; }
+.chrome-demo [data-rask-icon="home"]::before { content: "\F425"; }
+.chrome-demo [data-rask-icon="list"]::before { content: "\F479"; }
+.chrome-demo [data-rask-icon="person"]::before { content: "\F4E1"; }

--- a/samples/Rask.Example.Shared/Features/Chrome/ChromeScreen.cs
+++ b/samples/Rask.Example.Shared/Features/Chrome/ChromeScreen.cs
@@ -1,0 +1,62 @@
+using Rask.Chrome;
+using Rask.Chrome.Components;
+using Rask.Core.Routing;
+
+namespace Rask.Example.Shared.Features;
+
+// A Screen is a Page that also declares the chrome AROUND it, instead of the app root inspecting the route to
+// decide what the header should say. This one names no Rask.Native type — only Rask.Chrome — which is the
+// whole point: the same class compiles and renders on all three hosts.
+//
+//   • Server / WASM  — the slots render landmark HTML (role="banner", role="navigation") into the page.
+//   • Native         — the same declaration becomes a real UINavigationBar + UITabBar (iOS) / top + bottom
+//                      bar (Android), and the screen contributes no markup for either.
+//
+// Unlisted in the sidebar, like /table: it exists so the cross-host claim is exercised by a real app that all
+// three showcase hosts compile, not only by unit tests. Its styling comes from ChromeBarsDemo.css via the
+// shared wrapper class — Rask.Core ships no stylesheet for the bars by design.
+public sealed partial class ChromeScreen : Screen
+{
+    private int _refreshed;
+
+    protected override string Route => "chrome";
+
+    protected override Type? Parent => typeof(ShowcaseLayout);
+
+    protected override Component? HeadAssets => Title["Portable chrome — Rask"];
+
+    // Filled with Rask.Chrome components, so this compiles for the web heads. Reach for Rask.Native's
+    // NativeHeaderBar instead when you want platform-exact chrome (segmented titles, overflow menus, per-bar
+    // tinting) — and accept that the class then only builds for a native head.
+    protected override Component? HeaderBar =>
+        AppBar
+            .Title("Portable chrome")
+            .Trailing([BarButton.Icon(BarIcon.Add).Title("Refresh").OnClick(() => _refreshed++)]);
+
+    // Declared on the screen rather than the layout here because there is one screen; a real app usually puts
+    // the tab bar on a layout screen once and lets each leaf own its header. Chrome merges deepest-wins per
+    // kind, so both survive.
+    protected override Component? TabBar =>
+        TabStrip.Tabs([
+            TabItem.Title("Home").Icon(BarIcon.Home).To(new RouteUrl("/")),
+            TabItem.Title("Todos").Icon(BarIcon.List).To(Features.Routes.TodosPage()),
+            TabItem.Title("Chrome").Icon(BarIcon.Star).To(Features.Routes.ChromeScreen())
+        ]);
+
+    protected override Component? Render() =>
+        Div.Class("chrome-demo")[
+            Div.Class("chrome-demo-body")[
+                PageHeader.Title("Portable chrome").Lead(
+                    "One Screen class, three hosts. The bars above and below this text are landmark HTML "
+                    + "here; on iOS and Android the same declaration is a real navigation bar and tab bar, "
+                    + "and this paragraph is the only thing inside the WebView."),
+                P.Class("small mb-0")[
+                    "Refreshed ",
+                    Span.Id("chrome-screen-refreshed").Class("fw-semibold")[
+                        _refreshed.ToString(System.Globalization.CultureInfo.InvariantCulture)],
+                    " time(s) — the bar button's callback attributes back to this screen and re-renders it "
+                    + "exactly like a button in the body."
+                ]
+            ]
+        ];
+}

--- a/samples/Rask.Example.Shared/Rask.Example.Shared.csproj
+++ b/samples/Rask.Example.Shared/Rask.Example.Shared.csproj
@@ -25,6 +25,9 @@
          doesn't, and a WASM app needs it in the boot assembly manifest. Reference it here (as with
          Rask.Core) so every showcase host surfaces it. Unused by this project's code; loaded by the host. -->
     <ProjectReference Include="..\..\src\Rask.Client\Rask.Client.csproj"/>
+    <!-- Rask.Chrome (Screen + the portable AppBar/TabStrip) is bundled into every host package the same
+         way, so the same in-repo caveat applies: reference it here or the showcase cannot name Screen. -->
+    <ProjectReference Include="..\..\src\Rask.Chrome\Rask.Chrome.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Bootstrap\Rask.Bootstrap.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Validation.DataAnnotations\Rask.Validation.DataAnnotations.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Validation.FluentValidation\Rask.Validation.FluentValidation.csproj"/>

--- a/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
+++ b/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
@@ -107,6 +107,8 @@ public static class DemoRegistry
             ["browser-navigator-info"] = () => CodeSample(["NavigatorInfoDemo.cs"], Result: NavigatorInfoDemo()),
             ["browser-network"] = () => CodeSample(["NetworkInfoDemo.cs"], Result: NetworkInfoDemo()),
             ["browser-battery"] = () => CodeSample(["BatteryDemo.cs"], Result: BatteryDemo()),
+            ["chrome-bars"] = () => CodeSample(["ChromeBarsDemo.cs", "ChromeBarsDemo.css"],
+                Result: ChromeBarsDemo()),
             ["browser-screen"] = () => CodeSample(["ScreenInfoDemo.cs"], Result: ScreenInfoDemo()),
             ["browser-visual-viewport"] = () => CodeSample(["VisualViewportDemo.cs"], Result: VisualViewportDemo()),
             ["browser-media-query"] = () => CodeSample(["MediaQueryDemo.cs"], Result: MediaQueryDemo()),

--- a/tests/Rask.Example.Shared.Tests/Guides/DemoMarkup.golden.txt
+++ b/tests/Rask.Example.Shared.Tests/Guides/DemoMarkup.golden.txt
@@ -3281,6 +3281,38 @@ p .fst-italic .mb-0 .text-secondary
 h3 .h6 .mt-4 .small .text-secondary .text-uppercase
 p .mb-0 .small .text-secondary
 
+=== chrome-bars ===
+div .border-0 .card .mb-4 .sample-card .shadow-sm
+div .sample-code-col
+div .sample-code-header
+span .dot-r .sample-dot
+span .dot-y .sample-dot
+span .dot-g .sample-dot
+span .ms-2 .sample-tabs
+button .active .sample-tab
+button .sample-tab
+button .sample-copy
+i .bi .bi-clipboard .me-1
+span .sample-copy-text
+pre .m-0 .sample-code
+code .language-csharp
+div .p-4 .sample-result-col
+div .sample-result-label
+div .sample-result-body
+div .chrome-demo
+div .rask-header-bar
+div .rask-header-title
+div .rask-header-trailing
+button .rask-bar-button
+div .chrome-demo-body
+p .mb-0 .small
+span .fw-semibold
+div .rask-tab-bar
+a .rask-tab .rask-tab-active
+a .rask-tab
+div .rask-tab-badge
+a .rask-tab
+
 === component-tiers ===
 div .border-0 .card .mb-4 .sample-card .shadow-sm
 div .sample-code-col

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -2329,6 +2329,33 @@ public abstract partial class SharedSmokeTests
         await Expect(Page.Locator("tbody tr")).ToHaveCountAsync(25,
             new LocatorAssertionsToHaveCountOptions { Timeout = 5_000 });
 
+        // Portable chrome: /chrome is a Screen — a Page that also declares the bars AROUND it. Unlisted like
+        // /table, and reached by hard nav for the same reason. On a native head those two slots become a real
+        // UINavigationBar + UITabBar; here they have to be landmark HTML, which is the half a browser can
+        // prove. Everything asserted below comes from Rask.Chrome — the screen names no Rask.Native type,
+        // which is what makes one class serve all three hosts.
+        await Page.GotoAsync("/chrome");
+        await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Portable chrome",
+            new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
+        // The landmarks, not the classes: role is what assistive technology reads, and it is the part of the
+        // contract Rask.Core actually emits (the styling is the app's).
+        await Expect(Page.Locator("main div.rask-header-bar[role='banner']")).ToHaveCountAsync(1,
+            new LocatorAssertionsToHaveCountOptions { Timeout = 10_000 });
+        await Expect(Page.Locator("main div.rask-tab-bar[role='navigation']")).ToHaveCountAsync(1,
+            new LocatorAssertionsToHaveCountOptions { Timeout = 10_000 });
+        // Exactly one tab is current, and it is the one matching this route — TabStrip derives it with the
+        // same method the native descriptor builder calls, so a drift here is a cross-host disagreement.
+        await Expect(Page.Locator("main a.rask-tab[aria-current='page']")).ToHaveCountAsync(1,
+            new LocatorAssertionsToHaveCountOptions { Timeout = 5_000 });
+        await Expect(Page.Locator("main a.rask-tab.rask-tab-active")).ToHaveTextAsync(new Regex("Chrome"),
+            new LocatorAssertionsToHaveTextOptions { Timeout = 5_000 });
+        // A bar button's callback attributes back to the screen and re-renders it like any other callback —
+        // the behaviour that has to hold identically when the button is a real platform bar item.
+        Assert.Equal("0", await Page.Locator("#chrome-screen-refreshed").InnerTextAsync());
+        await Page.Locator("main .rask-header-bar button.rask-bar-button").ClickAsync();
+        await Expect(Page.Locator("#chrome-screen-refreshed")).ToHaveTextAsync("1",
+            new LocatorAssertionsToHaveTextOptions { Timeout = 10_000 });
+
         if (opts.DeepLink)
         {
             // Refresh on a deep CodeSample route must re-render the page (not the RootErrorBoundary)

--- a/tests/Rask.Native.Tests/Session/PortableChromeTests.cs
+++ b/tests/Rask.Native.Tests/Session/PortableChromeTests.cs
@@ -7,8 +7,11 @@ using Rask.Core.Routing;
 using Rask.Native.Tests.Infrastructure;
 using static Rask.Chrome.Components.Generated;
 using static Rask.Core.Components.Generated;
-// A type alias rather than a namespace import: importing Rask.Core.Components wholesale would put the
-// component TYPES in scope alongside the chain entries of the same name.
+// An alias rather than a namespace import, but not because the import breaks: entries are injected into
+// this partial class, and a member of the enclosing type wins simple-name lookup over a namespace-imported
+// type, so `using Rask.Chrome.Components;` compiles here too (the sibling ScreenChromeTests imports
+// Rask.Native.Components exactly that way). The alias only avoids leaning on that ordering for the one type
+// actually needed — BarIcon is a struct, so no entry exists for it.
 using BarIcon = Rask.Chrome.Components.BarIcon;
 
 #pragma warning disable RASK019 // test apps predate framework-managed <head>

--- a/tests/Rask.Testing.Tests/TestFileBackendTests.cs
+++ b/tests/Rask.Testing.Tests/TestFileBackendTests.cs
@@ -34,11 +34,20 @@ public partial class TestFileBackendTests : global::Rask.Core.RaskMarkup
         var files = new TestFileBackend();
         var picked = files.Add("notes.txt", "hello world", "text/plain");
 
+        // Capture the report and assert it: the framework tells you about this case (RaskDiagnostics, added
+        // with the host-parity fix) and nothing else pins that the warning fires at all. Capturing also keeps
+        // this process-global diagnostic out of a parallel test's window — belt to #750's braces, which fixed
+        // the real bug by making the wait there look for its own diagnostic rather than the first to arrive.
+        using var diagnostics = CapturingDiagnostics.Install();
+
         var page = RaskTest.Render(UploadProbe);
         await page.On("#picker").FilesAsync(picked);
 
         Assert.True(page.Instance.Fired, "the handler still runs");
         Assert.Empty(page.Instance.Received);
+        Assert.Contains(diagnostics.Captured, e =>
+            e.Category == "Rask.Forms" && e.Message.Contains("no IBrowserFileBackend is registered",
+                StringComparison.Ordinal));
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #743, which shipped `AppBar`/`TabStrip` and documented them — but no sample used them, and no sample used `Screen` at all. So the cross-host claim was proven only in unit tests, never in a running app. The repo's own definition of done asks a user-facing change to update a sample as well as the docs; this is that half.

## The sample

- **`/chrome`** is a real `Screen` in `Rask.Example.Shared`, naming no `Rask.Native` type. All three showcase hosts compile it from the same project: Server and WASM render its slots as landmark HTML, and the native heads project the same declaration to a `UINavigationBar` + `UITabBar`. Unlisted in the sidebar, like `/table`.
- **`ChromeBarsDemo`** renders the bars inline with their source, embedded in the native guide at `<!-- demo:chrome-bars -->`. Its ~20-line scoped stylesheet is itself the demonstration: `Rask.Core` ships no CSS for the bars and emits `data-rask-icon="add"` rather than a glyph, so the class names **are** the styling contract and one rule per token wires up whatever icon set the app already has.

Covered by the shared browser journey, so it runs on **Server, WASM and standalone WASM**: both landmarks, exactly one `aria-current="page"` tab and that it is the one matching the route, and a bar button's callback re-rendering the screen. All three `Journey_WalksEveryPageAndUnusualActivity` variants passed, so the step really ran rather than being skipped.

## A flake #746 introduced, found by this change

The pre-commit gate failed on a test I hadn't touched — `CapturingDiagnostics_SeesAFaultTheFrameworkSwallowed`, with a collection holding only my `Rask.Forms` event and none of its own.

`CapturingDiagnostics` installs a **process-global** sink (its own docs warn that two live at once interleave), and xUnit runs classes in different collections concurrently. `TestFileBackend`'s "no backend registered" case deliberately provokes that report, so the two classes cross-talked.

It is order-dependent by construction, which is why it passed #746's own gate *and* CI. Fixed two ways:

- both classes share one xUnit collection, so they cannot run concurrently;
- the provoking test installs its own capture and **asserts** the report rather than letting it escape — which also pins that the #736 warning fires at all, something nothing tested before.

Re-ran the suite three times to confirm, since one green on an order-dependent failure proves nothing.

## A correction to #743

A comment I added there claimed that importing a component namespace shadows the chain entries of the same name. **It doesn't.** Entries are injected into the enclosing partial class, and a member of the enclosing type wins simple-name lookup over a namespace-imported type — which is why the native tests already import `Rask.Native.Components` and compile fine, and why this sample imports `Rask.Chrome.Components`.

The failure I misattributed to shadowing was a missing `OutputItemType="Analyzer"` reference. The real rule is narrower and already documented in the host `.props`: it is why the framework emits a `global using static` for the entries but never a global namespace import. Comment corrected; CHANGELOG says so.

I only found this because `BarIcon` is a struct — no entry exists for it — so the sample had to name the type and the supposed hazard failed to materialise.

## Testing

- Unit **325/325**, formatter clean. Browser E2E **60/60** (pre-commit and again on push).
- `DemoMarkupGoldenTests` regenerated: the diff is one added `=== chrome-bars ===` section and touches no existing demo. I reviewed that diff rather than re-running until green — the test's own comment says the diff *is* the review.
- No benchmarks: sample and test code only. The one framework-adjacent change is a comment.

## Not covered

The native half is compiled by the CI native matrix but not run on a device — the Appium suite needs a booted emulator/simulator. So "renders landmark HTML on the web hosts" is proven here; "projects to real platform bars" remains proven only by the descriptor tests in `Rask.Native.Tests`.
