### PR TITLE
fix(samples): declare ChromeScreen's route with [Route], not a Route override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **`ChromeScreen` declares its route the way every other page now does.** It landed with a `Route`
+  override in the same window that removed the `Page` base class, so `main` briefly did not compile —
+  each change was green on its own branch and only their combination was broken.
+
 ### Changed
 - **BREAKING — routes are declared by `[Route]` again; the `Page` base class is gone.** A routable
   component is any `Component` carrying `[Route("/x")]`, with `[ParentRoute(typeof(Layout))]` for nesting

--- a/samples/Rask.Example.Shared/Features/Chrome/ChromeScreen.cs
+++ b/samples/Rask.Example.Shared/Features/Chrome/ChromeScreen.cs
@@ -4,8 +4,8 @@ using Rask.Core.Routing;
 
 namespace Rask.Example.Shared.Features;
 
-// A Screen is a Page that also declares the chrome AROUND it, instead of the app root inspecting the route to
-// decide what the header should say. This one names no Rask.Native type — only Rask.Chrome — which is the
+// A Screen is a routed component that also declares the chrome AROUND it, instead of the app root inspecting
+// the route to decide what the header should say. This one names no Rask.Native type — only Rask.Chrome — which is the
 // whole point: the same class compiles and renders on all three hosts.
 //
 //   • Server / WASM  — the slots render landmark HTML (role="banner", role="navigation") into the page.
@@ -15,13 +15,11 @@ namespace Rask.Example.Shared.Features;
 // Unlisted in the sidebar, like /table: it exists so the cross-host claim is exercised by a real app that all
 // three showcase hosts compile, not only by unit tests. Its styling comes from ChromeBarsDemo.css via the
 // shared wrapper class — Rask.Core ships no stylesheet for the bars by design.
+[Route("chrome")]
+[ParentRoute(typeof(ShowcaseLayout))]
 public sealed partial class ChromeScreen : Screen
 {
     private int _refreshed;
-
-    protected override string Route => "chrome";
-
-    protected override Type? Parent => typeof(ShowcaseLayout);
 
     protected override Component? HeadAssets => Title["Portable chrome — Rask"];
 


### PR DESCRIPTION
## Summary

`main` does not compile. `ChromeScreen` landed in #754 with a `Route` override during the same window
#756 removed the `Page` base class that override needs. Each PR was green on its own branch, and GitHub
merged them without a textual conflict because they touch different lines — the combination is what broke.

```diff
+[Route("chrome")]
+[ParentRoute(typeof(ShowcaseLayout))]
 public sealed partial class ChromeScreen : Screen
 {
     private int _refreshed;
-
-    protected override string Route => "chrome";
-
-    protected override Type? Parent => typeof(ShowcaseLayout);
```

A component carries no `Route` member now; the attribute is the only declaration.

## Testing

- `dotnet build Rask.slnx -warnaserror` — clean, on top of merged `main`.
- Full unit suite — green; the pre-commit gate re-ran it (325/325 in `Rask.Example.Shared.Tests`, the
  project that compiles this sample).
- `scripts/run-e2e-local.sh` — passed via the pre-push gate.
- Repo-wide scan for `: Page` and `override string Route` — empty.

## Changelog

`[Unreleased]` records it under Fixed, including why two green branches produced a red `main`.