### PR TITLE
fix(samples): declare ChromeScreen's route with the attributes, so main compiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ them until tagged releases begin.
   `[Route]` argument is an attribute argument and therefore constant by construction, so the failure it
   guarded cannot be written. The id is retired, not reused.
 
+### Fixed
+- **`main` did not compile: `ChromeScreen` still declared its route the old way.** #754 added the portable-chrome
+  showcase screen with `protected override string Route` / `Parent`, and #756 then removed those virtual members
+  in favour of `[Route]` / `[ParentRoute]`. Each was green against its own base, and the two merged without a
+  textual conflict — so the break only appeared once both were on `main` (`CS0115: no suitable method found to
+  override`). Converted to the attributes its sibling pages already use.
+
 ### Added
 - **The portable chrome now has a sample, which is what the repo's own definition of done asks for.** #743
   shipped `AppBar`/`TabStrip` and documented them, but no sample used them — and no sample used `Screen` at

--- a/samples/Rask.Example.Shared/Features/Chrome/ChromeScreen.cs
+++ b/samples/Rask.Example.Shared/Features/Chrome/ChromeScreen.cs
@@ -15,13 +15,11 @@ namespace Rask.Example.Shared.Features;
 // Unlisted in the sidebar, like /table: it exists so the cross-host claim is exercised by a real app that all
 // three showcase hosts compile, not only by unit tests. Its styling comes from ChromeBarsDemo.css via the
 // shared wrapper class — Rask.Core ships no stylesheet for the bars by design.
+[Route("chrome")]
+[ParentRoute(typeof(ShowcaseLayout))]
 public sealed partial class ChromeScreen : Screen
 {
     private int _refreshed;
-
-    protected override string Route => "chrome";
-
-    protected override Type? Parent => typeof(ShowcaseLayout);
 
     protected override Component? HeadAssets => Title["Portable chrome — Rask"];
 


### PR DESCRIPTION
`main` does not compile.

```
ChromeScreen.cs(22,31): error CS0115: 'ChromeScreen.Route': no suitable method found to override
ChromeScreen.cs(24,30): error CS0115: 'ChromeScreen.Parent': no suitable method found to override
```

## How it got there

Neither PR was wrong against the branch it was written on:

- **#754** added the portable-chrome showcase screen, declaring its route with the API its base had at the time — `protected override string Route` and `protected override Type? Parent`.
- **#756** then removed those virtual members, moving route declaration to `[Route]` / `[ParentRoute]`.

They touch different files, so they merged with no textual conflict, and each was green on its own base. The break exists only in the combination — which is the shape of failure a per-PR gate cannot see. `ChromeScreen.cs` already carried the old overrides at `b2ace11a` (#756's own merge commit), so `main` has been red since then; #758 landing on top neither caused nor touched it.

## The fix

The attribute form its siblings already use (`TablePage`, `GuidePage`, `NotFoundPage`):

```csharp
[Route("chrome")]
[ParentRoute(typeof(ShowcaseLayout))]
public sealed partial class ChromeScreen : Screen
```

`Screen` itself is untouched — it still derives from `Component` and still carries the `HeaderBar`/`Toolbar`/`TabBar` slots. Only the two route declarations move.

## Verification

`CI=true dotnet build Rask.slnx -c Release -warnaserror -m:1` fails at the parent commit with the two errors above and succeeds here — the failing build is the evidence, not a claim that it looks right. Local unit gate and browser E2E both green on push.
