### PR TITLE
fix(wasm): declare Microsoft.Extensions.ObjectPool, which the bundled Rask.Core needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- **`Rask.Wasm` now declares `Microsoft.Extensions.ObjectPool`, which its bundled `Rask.Core` needs at
+  runtime.** `Rask.Core.dll` is packed into `lib/` with `PrivateAssets="all"`, which is exactly what keeps
+  Core out of the nuspec — and takes Core's own package dependencies with it. The package already
+  re-declared `Microsoft.JSInterop` and `Microsoft.AspNetCore.Authorization` for that reason, but not
+  ObjectPool, which `RaskStringBuilderPool.Shared` uses on the render path. `Rask.Server` never noticed
+  because `Microsoft.AspNetCore.App` carries ObjectPool; the WASM track has no framework reference to hide
+  behind, so a consumer restoring the published package got a `FileNotFoundException` on the first render.
+
+  Confirmed against the shipped artifact, not only the source: restoring the published
+  `Rask.Wasm 0.20.1-alpha.0.77` into a fresh browser-WASM app resolves **no** ObjectPool on either target
+  framework, while the same restore of the fixed package delivers
+  `lib/net10.0/Microsoft.Extensions.ObjectPool.dll`.
+
+  `PackageDependencyTests` gained the guard that would have caught it and will catch the next one: for
+  every host that packs another project's DLL into its own `lib/` (via `TfmSpecificPackageFile` or
+  `BuildOutputInPackage`), each of that project's package references must be declared by the host,
+  reachable from what it does declare, or covered by a `FrameworkReference`. Reachability is read from the
+  host's real restore graph rather than a hand-kept list — `Microsoft.Extensions.Primitives` sits in the
+  same position and is fine only because `Logging -> Options -> Primitives` brings it in, so the guard has
+  to fail if that edge ever disappears. Closes #742.
 - **`ChromeScreen` declares its route the way every other page now does.** It landed with a `Route`
   override in the same window that removed the `Page` base class, so `main` briefly did not compile —
   each change was green on its own branch and only their combination was broken.

--- a/src/Rask.Wasm/Rask.Wasm.csproj
+++ b/src/Rask.Wasm/Rask.Wasm.csproj
@@ -68,6 +68,17 @@
       the dep was never declared for consumers to restore.
     -->
     <PackageReference Include="Microsoft.JSInterop"/>
+    <!--
+      Same reasoning again, and the one that was missed: Rask.Core pools its StringBuilders through
+      Microsoft.Extensions.ObjectPool (RaskStringBuilderPool.Shared, on the render path in Component,
+      Live/LivePayload and HeadAssetRegistry). Core is bundled into lib/ with PrivateAssets="all", so its
+      package dependencies never reach the nuspec, and nothing else this package declares brings ObjectPool
+      in transitively — Rask.Server is only immune because Microsoft.AspNetCore.App carries it, and the WASM
+      track has no framework reference. Without this line a consumer restoring the published package boots
+      and then dies with a FileNotFoundException on the first render. See #742; pinned by
+      PackageDependencyTests.
+    -->
+    <PackageReference Include="Microsoft.Extensions.ObjectPool"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Rask.Generators.Tests/PackageDependencyTests.cs
+++ b/tests/Rask.Generators.Tests/PackageDependencyTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Xml.Linq;
 
 namespace Rask.Generators.Tests;
@@ -226,6 +227,230 @@ public class PackageDependencyTests
             offenders.Count == 0,
             "A bundled DLL must ship its XML docs beside it, or the package's IntelliSense is blank: "
             + string.Join("; ", offenders));
+    }
+
+    // The mirror image of the first invariant, and the half that was missing.
+    //
+    // An unpackable project reaches consumers by having its DLL copied into a host package's lib/ folder.
+    // That copy carries the assembly and nothing else: NuGet never learns what the bundled project itself
+    // depended on, because PrivateAssets="all" is precisely what keeps it out of the nuspec. So every
+    // package the bundled assembly needs at runtime has to be re-declared at the HOST's boundary, or the
+    // consumer restores a package whose code calls into an assembly that was never downloaded.
+    //
+    // The regression: Rask.Wasm bundles Rask.Core.dll and re-declared Microsoft.JSInterop and
+    // Microsoft.AspNetCore.Authorization for exactly this reason, but not Microsoft.Extensions.ObjectPool
+    // — which RaskStringBuilderPool.Shared uses on the render path (Component.cs, Live/LivePayload.cs,
+    // HeadAssets/HeadAssetRegistry.cs). Nothing caught it: an in-repo build resolves everything through the
+    // ProjectReference, so ObjectPool is always present locally and only a restore of the PUBLISHED package
+    // is missing it. Rask.Server is immune because Microsoft.AspNetCore.App carries ObjectPool; the WASM
+    // track has no framework reference to hide behind. That is #742.
+    //
+    // "Declared" deliberately includes reachable-transitively, read from the host's own restore graph
+    // rather than assumed: Microsoft.Extensions.Primitives sits in the same position as ObjectPool and is
+    // fine only because Logging -> Options -> Primitives brings it in. Reading the real graph is what makes
+    // this fail if that edge ever disappears — a hand-maintained "covered transitively" list would not.
+    [Fact]
+    public void A_bundled_projects_package_dependencies_are_declared_at_the_host_boundary()
+    {
+        var projects = SourceProjects();
+        var offenders = new List<string>();
+
+        foreach (var (name, path) in projects.Where(p => IsPackable(p.Value)).OrderBy(p => p.Key, StringComparer.Ordinal))
+        {
+            var document = XDocument.Load(path);
+
+            var bundled = BundledProjects(document, projects);
+            if (bundled.Count == 0)
+            {
+                continue;
+            }
+
+            // A framework reference carries a whole shared framework, which is where Rask.Server gets
+            // ObjectPool, Primitives and JSInterop from. Naming the assemblies inside it would mean
+            // hard-coding a list that ships with the SDK, so the presence of the reference is the answer.
+            if (document.Descendants("FrameworkReference")
+                .Any(e => e.Attribute("Include")?.Value == "Microsoft.AspNetCore.App"))
+            {
+                continue;
+            }
+
+            var declared = PackageReferences(document);
+            var needed = bundled
+                .SelectMany(b => TransitivePackageReferences(b, projects))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Where(p => !declared.Contains(p))
+                .OrderBy(p => p, StringComparer.Ordinal)
+                .ToList();
+
+            if (needed.Count == 0)
+            {
+                continue;
+            }
+
+            var reachable = ReachablePackagesPerTarget(path, name);
+            foreach (var package in needed)
+            {
+                // Every target framework the host ships gets its own nuspec dependency group, so a package
+                // reachable in one and not another is still a hole in that one.
+                var uncovered = reachable
+                    .Where(target => !target.Value.Contains(package))
+                    .Select(target => target.Key)
+                    .ToList();
+
+                if (uncovered.Count > 0)
+                {
+                    offenders.Add(
+                        $"{name} bundles {string.Join("+", bundled)} which needs {package}, "
+                        + $"unreachable from what {name} declares under: {string.Join(", ", uncovered)}");
+                }
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "A bundled assembly's package dependencies do not flow to consumers — PrivateAssets=\"all\" is what "
+            + "keeps the bundled project out of the nuspec — so the host must declare them itself. These do not, "
+            + "and a consumer restoring the published package gets a FileNotFoundException at runtime:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    // The unpackable projects whose DLL this host packs into its own lib/ folder. Two mechanisms are in use
+    // and both count: TfmSpecificPackageFile with a lib/ PackagePath (Rask.Server, Rask.Wasm) and
+    // BuildOutputInPackage (Rask.Native). A PrivateAssets="all" ProjectReference on its own does NOT count —
+    // the batteries take one to compile against Rask.Core without bundling it, relying on the host package
+    // the consumer already has, so demanding they re-declare Core's dependencies would be noise.
+    private static IReadOnlyList<string> BundledProjects(XDocument document, Dictionary<string, string> projects) =>
+    [
+        .. document
+            .Descendants()
+            .Where(e => e.Name.LocalName is "BuildOutputInPackage"
+                || (e.Name.LocalName == "TfmSpecificPackageFile"
+                    && e.Attribute("PackagePath")?.Value.Replace('\\', '/')
+                        .StartsWith("lib", StringComparison.OrdinalIgnoreCase) == true))
+            .Select(e => e.Attribute("Include")?.Value.Replace('\\', '/'))
+            .Where(v => v is not null && v.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            .Select(v => BundledAssemblyName(v!))
+            .Where(projects.ContainsKey)
+            .Where(n => !IsPackable(projects[n]))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.Ordinal),
+    ];
+
+    // "$(OutputPath)Rask.Core.dll" -> "Rask.Core". The MSBuild property is not a directory, so it carries no
+    // separator and Path.GetFileNameWithoutExtension alone hands back "$(OutputPath)Rask.Core" — which matches
+    // no project, which silently empties the bundled set and makes this whole guard pass on everything. It did.
+    private static string BundledAssemblyName(string include)
+    {
+        var afterProperty = include.LastIndexOf(')') is var close and >= 0 ? include[(close + 1)..] : include;
+        return Path.GetFileNameWithoutExtension(afterProperty);
+    }
+
+    private static HashSet<string> PackageReferences(XDocument document) =>
+        new(
+            document.Descendants("PackageReference")
+                .Select(e => e.Attribute("Include")?.Value)
+                .Where(v => !string.IsNullOrEmpty(v))!,
+            StringComparer.OrdinalIgnoreCase);
+
+    // A bundled project can itself bundle another (Rask.Client and Rask.Html both take Rask.Core), and the
+    // host packs every one of their DLLs, so the whole chain's package references have to surface.
+    private static IEnumerable<string> TransitivePackageReferences(string name, Dictionary<string, string> projects)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var pending = new Stack<string>([name]);
+
+        while (pending.Count > 0)
+        {
+            var current = pending.Pop();
+            if (!seen.Add(current) || !projects.TryGetValue(current, out var path))
+            {
+                continue;
+            }
+
+            var document = XDocument.Load(path);
+            foreach (var package in PackageReferences(document))
+            {
+                yield return package;
+            }
+
+            foreach (var reference in document.Descendants("ProjectReference"))
+            {
+                // An analyzer/task reference contributes no runtime assembly, so it drags in no runtime dep.
+                if (string.Equals(reference.Attribute("ReferenceOutputAssembly")?.Value, "false", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (reference.Attribute("Include")?.Value.Replace('\\', '/') is { } include)
+                {
+                    pending.Push(Path.GetFileNameWithoutExtension(include));
+                }
+            }
+        }
+    }
+
+    // What the host's declared package references actually pull in, per target framework, read from the
+    // restore graph rather than guessed. Roots are the host's own PackageReferences — never the bundled
+    // ProjectReferences, which is the whole point: their dependencies are exactly what does not flow.
+    private static Dictionary<string, HashSet<string>> ReachablePackagesPerTarget(string csprojPath, string name)
+    {
+        var assetsPath = Path.Combine(Path.GetDirectoryName(csprojPath)!, "obj", "project.assets.json");
+
+        // Fail rather than skip. Every packable host is in Rask.slnx and the gate builds the whole solution,
+        // so a missing restore graph means this ran somewhere the gate never did — and a packaging guard that
+        // quietly passes when it cannot see anything is worse than no guard.
+        Assert.True(
+            File.Exists(assetsPath),
+            $"{name} has no restore graph at {assetsPath}, so its transitive packages cannot be resolved. "
+            + $"Restore it first: dotnet restore {Path.GetRelativePath(RepoRoot(), csprojPath)}");
+
+        using var stream = File.OpenRead(assetsPath);
+        using var assets = JsonDocument.Parse(stream);
+        var root = assets.RootElement;
+
+        var roots = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var framework in root.GetProperty("project").GetProperty("frameworks").EnumerateObject())
+        {
+            if (framework.Value.TryGetProperty("dependencies", out var dependencies))
+            {
+                foreach (var dependency in dependencies.EnumerateObject())
+                {
+                    roots.Add(dependency.Name);
+                }
+            }
+        }
+
+        var perTarget = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        foreach (var target in root.GetProperty("targets").EnumerateObject())
+        {
+            // "Microsoft.Extensions.Logging/10.0.11" -> its dependency names.
+            var graph = target.Value.EnumerateObject().ToDictionary(
+                entry => entry.Name.Split('/')[0],
+                entry => entry.Value.TryGetProperty("dependencies", out var d)
+                    ? d.EnumerateObject().Select(x => x.Name).ToArray()
+                    : [],
+                StringComparer.OrdinalIgnoreCase);
+
+            var reached = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var pending = new Stack<string>(roots);
+            while (pending.Count > 0)
+            {
+                var current = pending.Pop();
+                if (!reached.Add(current) || !graph.TryGetValue(current, out var next))
+                {
+                    continue;
+                }
+
+                foreach (var dependency in next)
+                {
+                    pending.Push(dependency);
+                }
+            }
+
+            perTarget[target.Name] = reached;
+        }
+
+        return perTarget;
     }
 
     // Mirrors how the repo declares it: an explicit <IsPackable>false</IsPackable>. Everything else in src/


### PR DESCRIPTION
Closes #742.

## The defect

`Rask.Core.dll` is packed into `Rask.Wasm`'s `lib/` with `PrivateAssets="all"` — which is exactly what
keeps Core out of the nuspec, and takes Core's own package dependencies with it. The package already
re-declares `Microsoft.JSInterop` and `Microsoft.AspNetCore.Authorization` for that reason, but not
`Microsoft.Extensions.ObjectPool`, which `RaskStringBuilderPool.Shared` uses on the render path
(`Component`, `Live/LivePayload`, `HeadAssets/HeadAssetRegistry`).

`Rask.Server` never noticed because `Microsoft.AspNetCore.App` carries ObjectPool. The WASM track has no
framework reference to hide behind.

## Verified against the shipped artifact

The issue noted this was concluded from the nuspec and dependency graph rather than a restore. It is now
a restore, of the real package from nuget.org:

| Restored into a fresh `net10.0-browser` / `browser-wasm` app | `Microsoft.Extensions.ObjectPool` |
| --- | --- |
| published `Rask.Wasm 0.20.1-alpha.0.77` | **missing** on both target frameworks |
| this branch, packed | resolves → `lib/net10.0/Microsoft.Extensions.ObjectPool.dll` |

The packed nuspec goes from five dependencies per group to six, in **both** the `net10.0` and
`net10.0-browser1.0` groups (the issue showed only the browser group; the same hole was in the other one).

To be precise about scope: this proves the assembly is not delivered before and is after. I did not run a
real WASM app to observe the `FileNotFoundException` itself.

## The guard

`PackageDependencyTests` gains the invariant that was missing — the mirror image of the one already
there. For every host that packs another project's DLL into its own `lib/` (`TfmSpecificPackageFile` with
a `lib/` PackagePath, or `BuildOutputInPackage`, both of which are in use), each of that project's package
references must be:

- declared by the host itself, **or**
- reachable from what the host does declare, **or**
- covered by a `FrameworkReference` (how `Rask.Server` is legitimately immune).

Reachability is read from the host's real `project.assets.json`, not a hand-kept "covered transitively"
list. That matters: `Microsoft.Extensions.Primitives` sits in exactly the same position as ObjectPool and
is fine *only* because `Logging → Options → Primitives` brings it in. Reading the graph means the guard
fails if that edge ever disappears; an allowlist would rot silently. A missing restore graph fails loudly
rather than skipping — a packaging guard that quietly passes when it can see nothing is worse than none.

Scoped to hosts that actually bundle: a `PrivateAssets="all"` ProjectReference alone does not count. The
batteries take one to compile against Core without packing it, relying on the host package the consumer
already has, so demanding they re-declare Core's dependencies would be noise. Run against this tree the
guard reports exactly one offender — `Rask.Wasm` — and clears `Rask.Server` and `Rask.Native`.

## The guard was written first, and watched fail

Worth recording, because its **first version passed on everything**, including the known-broken package.
`Include="$(OutputPath)Rask.Core.dll"` carries no directory separator, so
`Path.GetFileNameWithoutExtension` hands back `$(OutputPath)Rask.Core`, which matches no project and
silently emptied the bundled set. Added after the fix, it would have looked green and protected nothing.

## Testing

Format + unit gate green (all suites), browser E2E 61/61, CLI build gate 24/24. Red→green demonstrated on
the guard itself. No benchmarks: a package reference change touches no hot path.

## Note

Only ObjectPool is added, not `Microsoft.Extensions.Primitives`. Primitives is genuinely reachable today
and the guard now enforces that it stays so; declaring it "for parity" would be a change nothing
justifies.
