### PR TITLE
docs(native): use [Route] in the native-devices Screen snippet and guard the docs against API rot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- **`docs/native-devices.md` no longer teaches a `Route` override the framework removed.** The second
+  `TodosScreen` snippet still declared `protected override string Route => "/todos";`, so a reader who
+  copied it got `CS0115: no suitable method found to override` — `Screen` has had no virtual `Route` since
+  routes moved back to `[Route]`. The file contradicted itself, too: the first `TodosScreen` a page earlier
+  already used the attribute. Both now read `[Route("/todos")]`, and the prose calling a `Screen` "a `Page`"
+  no longer names a base class that does not exist.
+
+  The docs had already been broken this way twice in code (`ChromeScreen`), so the fix ships with the guard
+  that closes the loop: `DocsRoutingSyntaxTests` scans every doc for the members a breaking change deleted
+  — the `Route` and `Parent` overrides and the `Page` base list — and names the file, line and replacement.
+  The existing doc gates check that links *resolve*; this checks that the API a snippet names still exists.
+  Verified by reverting the doc and watching the guard fail on `native-devices.md:121`. Closes #767.
 - **`Rask.Wasm` now declares `Microsoft.Extensions.ObjectPool`, which its bundled `Rask.Core` needs at
   runtime.** `Rask.Core.dll` is packed into `lib/` with `PrivateAssets="all"`, which is exactly what keeps
   Core out of the nuspec — and takes Core's own package dependencies with it. The package already

--- a/docs/native-devices.md
+++ b/docs/native-devices.md
@@ -112,8 +112,8 @@ backends behind the *same* interfaces (biometrics, native push via APNs/FCM) are
 
 ## Screens — a page that owns its chrome
 
-A **`Screen`** is a `Page` that also declares the native chrome around it. Instead of the app root inspecting
-the current path to decide what the header should say, each screen names its own bars:
+A **`Screen`** is a routed component that also declares the native chrome around it. Instead of the app root
+inspecting the current path to decide what the header should say, each screen names its own bars:
 
 ```csharp
 [Route("/todos")]
@@ -168,10 +168,9 @@ The slots accept two families, and the choice is the usual portability trade:
 Reach for the portable set by default. One declaration, three hosts:
 
 ```csharp
+[Route("/todos")]
 public sealed class TodosScreen : Screen
 {
-    protected override string Route => "/todos";
-
     protected override Component? HeaderBar =>
         AppBar.Title("Todos")
             .Trailing([BarButton.Icon(BarIcon.Add).Title("New").OnClick(Add)]);

--- a/tests/Rask.Example.Shared.Tests/Pages/DocsRoutingSyntaxTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/DocsRoutingSyntaxTests.cs
@@ -1,0 +1,82 @@
+using System.Text.RegularExpressions;
+
+namespace Rask.Example.Shared.Tests.Pages;
+
+/// <summary>
+/// Guards that no doc still teaches a routing member the framework has removed.
+///
+/// <para>Routes moved back to <c>[Route]</c> / <c>[ParentRoute]</c> and the <c>Page</c> base class went away,
+/// but a snippet is only prose to the compiler: <c>docs/native-devices.md</c> kept a
+/// <c>protected override string Route</c> on a <c>Screen</c> long after the member it overrode was gone, so a
+/// reader who copied it got <c>CS0115</c>. That is the worst kind of doc bug — the page reads as
+/// authoritative and the reader blames their own code.</para>
+///
+/// <para>The other doc gates check <em>structure</em> (links resolve, every doc is reachable); this checks
+/// that the API the docs name still exists. It is a deliberately small, literal list: the members a breaking
+/// change deleted, each with the syntax that replaced it. When the next rename lands, add its pair here and
+/// the docs cannot silently rot past it.</para>
+/// </summary>
+public sealed partial class DocsRoutingSyntaxTests
+{
+    /// <summary>Each removed member, matched literally, with the syntax that replaced it.</summary>
+    private static readonly (Regex Pattern, string Removed, string Replacement)[] RemovedMembers =
+    [
+        (RouteOverrideRegex(), "protected override string Route", "the [Route(\"...\")] attribute"),
+        (ParentOverrideRegex(), "protected override Type? Parent", "the [ParentRoute(typeof(...))] attribute"),
+        (PageBaseRegex(), "the Page base class", "a plain Component, or Screen for native chrome"),
+    ];
+
+    [Fact]
+    public void No_doc_teaches_a_routing_member_that_was_removed()
+    {
+        var docs = DocsDirectory();
+        var stale = new List<string>();
+
+        foreach (var file in Directory.GetFiles(docs, "*.md", SearchOption.AllDirectories).Order(StringComparer.Ordinal))
+        {
+            var source = Path.GetRelativePath(docs, file).Replace('\\', '/');
+            var lines = File.ReadAllLines(file);
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                foreach (var (pattern, removed, replacement) in RemovedMembers)
+                {
+                    if (pattern.IsMatch(lines[i]))
+                    {
+                        stale.Add($"{source}:{i + 1} uses {removed} — use {replacement}");
+                    }
+                }
+            }
+        }
+
+        Assert.True(
+            stale.Count == 0,
+            "These docs name a routing member the framework removed, so a reader who copies the snippet gets "
+            + $"a compile error:{Environment.NewLine}  "
+            + string.Join($"{Environment.NewLine}  ", stale));
+    }
+
+    [GeneratedRegex(@"\boverride\s+string\s+Route\b")]
+    private static partial Regex RouteOverrideRegex();
+
+    [GeneratedRegex(@"\boverride\s+Type\??\s+Parent\b")]
+    private static partial Regex ParentOverrideRegex();
+
+    // Only a base list — ": Page" after a type name. `Page` is also an ordinary property name on the data
+    // grid ("Set `Page` with `OnPageChange`"), and matching the bare word would fail on those.
+    [GeneratedRegex(@"class\s+\w+\s*:\s*Page\b")]
+    private static partial Regex PageBaseRegex();
+
+    private static string DocsDirectory()
+    {
+        for (var dir = AppContext.BaseDirectory; dir is not null; dir = Path.GetDirectoryName(dir))
+        {
+            if (File.Exists(Path.Combine(dir, "Rask.slnx")))
+            {
+                return Path.Combine(dir, "docs");
+            }
+        }
+
+        throw new InvalidOperationException("Could not locate the repo root (Rask.slnx) from the test base directory.");
+    }
+}


### PR DESCRIPTION
## Summary

`docs/native-devices.md` still taught the `Route` override the framework removed. The second `TodosScreen` snippet declared

```csharp
public sealed class TodosScreen : Screen
{
    protected override string Route => "/todos";
```

`Screen` has had no virtual `Route` since routes moved back to `[Route]`, so a reader who copied that snippet got `CS0115: no suitable method found to override` — the same break already fixed twice in code (`ChromeScreen`, #761/#762), still sitting in the docs. The file contradicted itself, too: the *first* `TodosScreen`, a page earlier, already used the attribute. Both snippets now read `[Route("/todos")]`.

The prose one line above was stale in the same way — it introduced a `Screen` as "a `Page`", a base class that no longer exists. It now says "a routed component".

## The guard

Fixing the line alone leaves the next rename free to rot the docs again, so this ships the gate that closes the loop. `DocsRoutingSyntaxTests` scans every doc for the members a breaking change deleted — the `Route` and `Parent` overrides and the `: Page` base list — and reports the file, line and replacement:

```
native-devices.md:121 uses protected override string Route — use the [Route("...")] attribute
```

It is a deliberately small, literal list, one entry per removed member. The existing doc gates check *structure* (links resolve, every doc is reachable); this checks that the API a snippet **names** still exists — a different failure, and the worse one, because the page reads as authoritative and the reader blames their own code.

The `: Page` pattern matches only a base list, not the bare word: `Page` is also an ordinary property on the data grid ("Set `Page` with `OnPageChange`"), and a bare-word match would fail on those docs.

## Testing

- `DocsRoutingSyntaxTests` — **proven by failing it**: reverted the doc, watched the guard report `native-devices.md:121` with the replacement spelled out, restored the fix, green again.
- `dotnet format --verify-no-changes` — clean.
- `dotnet build -warnaserror` — 0 warnings, 0 errors.
- Full local unit gate via the pre-commit hook — 43 test projects, all green.
- Browser E2E via the pre-push hook — 61 passed.

No benchmarks: docs plus one test, no framework or render-hotpath code.

## Changelog

`[Unreleased] → Fixed`, in the same commit.

Closes #767.
