### PR TITLE
fix(tests): stop the unit gate failing on diffs that cannot have caused it (#769)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,59 @@ them until tagged releases begin.
   request was issued" and then slept a fixed 50 ms before asserting on "the response rendered", which is the
   race that failed a gate run on an unrelated branch; they now wait on the rendered result itself.
 
+- **A diagnostics capture could be silently unhooked by another test class disposing its own.**
+  `CapturingDiagnostics` (Rask.Testing) saved the previous sink on install and put it back on dispose, and
+  the sink is process-global. xUnit runs test classes in parallel, so two captures were routinely live at
+  once: whichever disposed first restored the sink from before *it* installed, leaving the other one
+  installed but wired to nothing. That capture then recorded no diagnostics at all and its test failed on
+  `Assert.Contains` against an empty collection — on a full-solution run, on a diff that touched none of
+  it, while passing on its own. Installs are now tracked as a set: every live capture receives every
+  diagnostic, and the outer sink is restored only when the last one is disposed, in any order. Reproduced
+  4 runs out of 6 of the loaded gate before the fix, in both directions (each of the two installing
+  classes stealing from the other), and pinned by a test that stages the out-of-order dispose directly.
+
+- **Three unit tests that waited a fixed duration for a thread-pool continuation.** A `Task.Delay` budget
+  is not a synchronisation primitive: on a machine busy enough — which the gate itself makes it, running
+  ~40 test hosts at once — the continuation had not run when the assertion read the result.
+  `AsyncLifecycleErrorBoundaryTests` drained its async-fault path with 50 ms of `Task.Delay` and now waits
+  for the outcome (the boundary's error, the reported fault, and a `TaskCompletionSource` the recording
+  render handle signals). Waiting for the result is *faster* when the pool is idle — the class went from
+  five fixed sleeps per test to 27 ms for all four — and patient when it is not, which is what lets the
+  budget be generous rather than tuned.
+
+  `WaitFor.True` moved from `Rask.Example.Shared.Tests` into `Rask.TestSupport` so every suite polls the
+  same way instead of each growing its own timing helper; the Example projects that shared it by linking
+  the source file now reference it.
+
+- **The Outbox test classes that share a `DbContext` type no longer run in parallel.** EF Core's model
+  cache is per *process* and keyed on the context type, not per `ServiceProvider`: two Outbox test classes
+  building their own provider over their own SQLite file still share one `IModelSource` and one `IModel`
+  instance (verified by reference identity). Their first touch of the model was therefore two threads
+  driving one piece of EF-internal state, and the gate caught it — `SaveChangesAsync` threw *"The model
+  must be finalized and its runtime dependencies must be initialized before 'GetRelationalModel' can be
+  used"* from a test whose diff was a `.svg` file. The five classes that build a context are now one xUnit
+  collection, which removes the concurrency the failure needs; the suite still runs in 3 s.
+
+- **A WASM-hosting test class was outside the collection that keeps hosts off each other.** Two pieces of
+  state a host owns are process-wide statics — `ScopedAssetBundle.BakedDirectory`, which `UseRask` points
+  at the bundle it just resolved, and `LiveOptions.PathBase`. One app serves one bundle, so a single value
+  is right in production; it is the tests that stand up a host per case. Three of the four classes that do
+  were already grouped in the `ScopedAssets` collection for exactly this reason and `UseRaskTests` was not,
+  so it overlapped them: a host starting there re-pointed the bundle directory out from under a request
+  another class was midway through, and the `AssetEndpointParityTests` case covering precompressed-sibling
+  negotiation 404'd on a file it had written itself. Resetting the statics on dispose — which the
+  harness already did — cannot help when the tests overlap rather than follow one another. The property now
+  says so where it is declared.
+
+- **The unit gate collects crash evidence.** When a test host dies below the managed layer the run says
+  only "Test host process crashed", with no exception, no stack, and not even the name of the test in
+  flight — and because the solution runs its assemblies concurrently, the console lines nearest the crash
+  belong to whichever *other* assembly was writing at the time. That is how #769's third report attributed
+  a crash to `Rask.Server.Tests`, which has fewer tests than the crashed host had already passed. The gate
+  now runs with `--blame-crash`, so the next occurrence names the test and leaves a dump under
+  `artifacts/test-blame/` instead of being merely observed. The crash itself did not reproduce here (6
+  full loaded gate runs, plus 5 dedicated `Rask.Server.Tests` runs under load, all green).
+
 - **The hero animation no longer hangs a character off the end of an untyped line.** `spacingAndGlyphs`
   stopped the last glyph of a line from spilling *well* past `textLength`, but not from reaching the very
   edge of its advance box — the `>` of `=>` does — and a cover rectangle that stopped exactly at

--- a/scripts/run-unit-local.sh
+++ b/scripts/run-unit-local.sh
@@ -54,8 +54,17 @@ echo "==> Formatting check (dotnet format --verify-no-changes: whitespace + styl
 dotnet format Rask.slnx --verify-no-changes --no-restore
 
 echo "==> Unit & integration tests (excludes the browser E2E)"
+# --blame-crash: when a test host dies below the managed layer, the run reports "Test host process
+# crashed" with no exception, no stack and not even the name of the test that was running — and since
+# the solution runs ~40 assemblies at once, the last lines of console output belong to whichever OTHER
+# assembly happened to be writing, which is how #769 spent an investigation on Rask.Server.Tests over a
+# crash in an assembly that reported more tests than Rask.Server.Tests has. Blame writes a per-host
+# sequence file naming the test in flight and collects a dump, so the next occurrence is diagnosable
+# instead of merely observed. It costs nothing on a green run.
 dotnet test Rask.slnx -c Release --no-build \
   --filter "FullyQualifiedName!~Rask.Examples.E2E" \
+  --blame-crash \
+  --results-directory "$root/artifacts/test-blame" \
   --logger "console;verbosity=normal"
 
 echo "==> Format + unit gate passed."

--- a/src/Rask.Core/ScopedAssets/ScopedAssetBundle.cs
+++ b/src/Rask.Core/ScopedAssets/ScopedAssetBundle.cs
@@ -31,6 +31,14 @@ public static class ScopedAssetBundle
     ///     <see langword="null" /> and the registry stays the only source, exactly as before).
     ///     Set by <c>Rask.Wasm.Hosting</c>'s <c>UseRask</c> once it has resolved the bundle.
     /// </summary>
+    /// <remarks>
+    ///     <b>Process-wide, and last writer wins.</b> An app serves one published bundle, so a single
+    ///     value is right there — a WASM host mounted alongside a server-rendered dashboard still has
+    ///     exactly one bundle to point at. It is <em>tests</em> that stand up a host per case: two of
+    ///     them overlapping re-point this at each other's temp directory mid-request, and the loser
+    ///     404s on a file it wrote itself. A suite that starts more than one host must therefore keep
+    ///     every such class in one xUnit collection, not merely reset this between them.
+    /// </remarks>
     public static string? BakedDirectory { get; set; }
 
     /// <summary>

--- a/src/Rask.Testing/CapturingDiagnostics.cs
+++ b/src/Rask.Testing/CapturingDiagnostics.cs
@@ -20,10 +20,17 @@ namespace Rask.Testing;
 ///         on the framework — and a public seam is an irreversible commitment where this is not.
 ///     </para>
 ///     <para>
-///         <b>The sink is process-global</b>, so this serializes on a lock and restores the previous sink
-///         on <see cref="Dispose" />. Two of these live at once in parallel tests would still interleave —
-///         if a test asserts on a <em>count</em>, filter to the events it provoked (<see cref="OfCategory" />)
-///         rather than asserting over everything captured.
+///         <b>The sink is process-global</b>, so installs are tracked as a set rather than as a single
+///         slot: every capture that is currently installed receives every event, and the sink that was
+///         there before is restored when the last one is disposed. That is what makes this safe under
+///         xUnit's default parallelism — with a save/restore slot, two test classes installing at once
+///         meant the first to dispose silently unhooked the second, which then captured nothing and
+///         failed on a full-solution run while passing standalone (#769).
+///     </para>
+///     <para>
+///         Concurrent captures therefore see each other's events. A test asserting on a <em>count</em>
+///         should filter to the events it provoked (<see cref="OfCategory" />) rather than assert over
+///         everything captured.
 ///     </para>
 ///     <code>
 ///     using var diagnostics = CapturingDiagnostics.Install();
@@ -35,24 +42,57 @@ public sealed class CapturingDiagnostics : IDisposable
 {
     private static readonly Lock InstallGate = new();
 
+    // Every capture currently installed. Guarded by InstallGate for mutation; readers take a snapshot
+    // under the same lock, because a diagnostic can be reported from any thread at any time.
+    private static readonly List<CapturingDiagnostics> Installed = [];
+
+    // The sink that was in place before the FIRST capture installed — restored when the last one goes.
+    private static Action<RaskDiagnosticEvent>? _outerSink;
+
     private readonly Lock _gate = new();
     private readonly List<CapturedDiagnostic> _captured = [];
-    private readonly Action<RaskDiagnosticEvent>? _previous;
     private bool _disposed;
 
     private CapturingDiagnostics()
     {
-        _previous = RaskDiagnostics.Sink;
-        RaskDiagnostics.ResetReportOnceForTests();
-        RaskDiagnostics.Sink = Capture;
     }
 
-    /// <summary>Installs a capturing sink. Dispose to restore the previous one.</summary>
+    /// <summary>
+    ///     Installs a capturing sink. Dispose to remove it; the sink that was in place before the first
+    ///     install is restored once the last capture is disposed, in whatever order they are disposed.
+    /// </summary>
     public static CapturingDiagnostics Install()
     {
+        var capture = new CapturingDiagnostics();
+
         lock (InstallGate)
         {
-            return new CapturingDiagnostics();
+            if (Installed.Count == 0)
+            {
+                _outerSink = RaskDiagnostics.Sink;
+                RaskDiagnostics.Sink = Fanout;
+            }
+
+            Installed.Add(capture);
+            RaskDiagnostics.ResetReportOnceForTests();
+        }
+
+        return capture;
+    }
+
+    // One sink, fanned out to every installed capture. Snapshotting under the lock keeps a Dispose that
+    // races a report from mutating the list mid-iteration; the captures' own Capture takes its own lock.
+    private static void Fanout(RaskDiagnosticEvent e)
+    {
+        CapturingDiagnostics[] targets;
+        lock (InstallGate)
+        {
+            targets = Installed.ToArray();
+        }
+
+        foreach (var target in targets)
+        {
+            target.Capture(e);
         }
     }
 
@@ -76,7 +116,10 @@ public sealed class CapturingDiagnostics : IDisposable
     public IReadOnlyList<CapturedDiagnostic> OfCategory(string category) =>
         Captured.Where(e => string.Equals(e.Category, category, StringComparison.Ordinal)).ToArray();
 
-    /// <summary>Restores the sink that was installed before this one.</summary>
+    /// <summary>
+    ///     Removes this capture. The sink that was in place before the first install is restored once the
+    ///     last capture is disposed — a capture still in use by another test is never unhooked.
+    /// </summary>
     public void Dispose()
     {
         lock (InstallGate)
@@ -87,7 +130,14 @@ public sealed class CapturingDiagnostics : IDisposable
             }
 
             _disposed = true;
-            RaskDiagnostics.Sink = _previous;
+            Installed.Remove(this);
+
+            if (Installed.Count == 0)
+            {
+                RaskDiagnostics.Sink = _outerSink;
+                _outerSink = null;
+            }
+
             RaskDiagnostics.ResetReportOnceForTests();
         }
     }

--- a/src/Rask.Testing/NUGET.md
+++ b/src/Rask.Testing/NUGET.md
@@ -108,7 +108,11 @@ test keeps passing. `.On(selector)` names the element instead. (It's a handle ra
 - **`CapturingDiagnostics.Install()`** — captures the framework diagnostics raised while it is installed,
   so you can assert that a swallowed fault happened (or that none did). Swallow-and-log is the framework's
   designed behaviour for navigate faults, JS dispatch faults and faulted async lifecycle hooks, and
-  without this there is no supported way to see them.
+  without this there is no supported way to see them. Safe under xUnit's default parallelism: several
+  captures can be installed at once, every one of them sees every diagnostic, and disposing one never
+  unhooks another — so they may be disposed in any order. Because concurrent captures share the events,
+  a test asserting on a *count* should filter to what it provoked (`OfCategory(...)`) rather than assert
+  over everything captured.
 - **`.TryInvokeAsync(handlerId, json?)`** — dispatch only if the id is still live; returns `false` rather
   than throwing, so you can assert a handler is gone.
 - **`.Instance`** — the component object you passed in, for asserting its state directly.

--- a/tests/Rask.Core.Tests/Lifecycle/AsyncLifecycleErrorBoundaryTests.cs
+++ b/tests/Rask.Core.Tests/Lifecycle/AsyncLifecycleErrorBoundaryTests.cs
@@ -1,4 +1,6 @@
+using System.Text;
 using Rask.Core.Live;
+using Rask.TestSupport;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 
@@ -22,10 +24,9 @@ public partial class AsyncLifecycleErrorBoundaryTests : global::Rask.Core.RaskMa
             _ = boundary.ToHtml();
             child.RaiseLifecycleBeforeRender(true);
             await child.Fault.Task;
-            await DrainContinuations();
+            await WaitFor.True(() => boundary.Error is not null, Budget, "the boundary to trip");
         }
 
-        Assert.NotNull(boundary.Error);
         Assert.Equal("mount-async", boundary.Error!.Message);
     }
 
@@ -42,10 +43,9 @@ public partial class AsyncLifecycleErrorBoundaryTests : global::Rask.Core.RaskMa
             _ = boundary.ToHtml();
             child.RaiseLifecycleBeforeRender(true);
             await child.Fault.Task;
-            await DrainContinuations();
+            await WaitFor.True(() => boundary.Error is not null, Budget, "the boundary to trip");
         }
 
-        Assert.NotNull(boundary.Error);
         Assert.Equal("props-async", boundary.Error!.Message);
     }
 
@@ -57,7 +57,9 @@ public partial class AsyncLifecycleErrorBoundaryTests : global::Rask.Core.RaskMa
         // No boundary — the existing log-and-swallow path should fire.
 
         var origErr = Console.Error;
-        var sw = new StringWriter();
+        // The logging happens on the threadpool continuation while this test reads the buffer, so the
+        // writer has to be safe for a concurrent write + snapshot — StringWriter is not.
+        var sw = new LockedWriter();
         Console.SetError(sw);
         try
         {
@@ -65,7 +67,8 @@ public partial class AsyncLifecycleErrorBoundaryTests : global::Rask.Core.RaskMa
             {
                 child.RaiseLifecycleBeforeRender(true);
                 await child.Fault.Task;
-                await DrainContinuations();
+                await WaitFor.True(() => sw.Text.Contains("mount-async", StringComparison.Ordinal),
+                    Budget, "the fault to reach Console.Error");
             }
         }
         finally
@@ -73,8 +76,7 @@ public partial class AsyncLifecycleErrorBoundaryTests : global::Rask.Core.RaskMa
             Console.SetError(origErr);
         }
 
-        Assert.Contains("mount-async", sw.ToString());
-        Assert.Contains("FaultingComponent", sw.ToString());
+        Assert.Contains("FaultingComponent", sw.Text);
     }
 
     [Fact]
@@ -94,24 +96,20 @@ public partial class AsyncLifecycleErrorBoundaryTests : global::Rask.Core.RaskMa
             _ = boundary.ToHtml();
             child.RaiseLifecycleBeforeRender(true);
             await child.Fault.Task;
-            await DrainContinuations();
+            await handle.Requested.Task.WaitAsync(Budget);
         }
 
         Assert.True(handle.RequestRenderCount >= 1,
             $"expected boundary trip to request render, got {handle.RequestRenderCount}");
     }
 
-    private static async Task DrainContinuations()
-    {
-        // The async-fault path uses TaskContinuationOptions.ExecuteSynchronously, but the
-        // initial Task.Yield inside FaultingComponent hops onto the threadpool so we need
-        // a small delay to let the continuation observe the fault.
-        for (var i = 0; i < 5; i++)
-        {
-            await Task.Yield();
-            await Task.Delay(10);
-        }
-    }
+    // The async-fault path uses TaskContinuationOptions.ExecuteSynchronously, but the initial
+    // Task.Yield inside FaultingComponent hops onto the threadpool, so the continuation lands
+    // whenever the pool gets to it. These waits used to be a fixed 50ms of Task.Delay, which is not a
+    // synchronisation primitive: on a loaded machine the pool had not run it yet when the assert read
+    // the result, and the gate failed on a diff that could not have caused it (#769). Waiting for the
+    // outcome is fast when the pool is idle and patient when it is not, so the budget can be generous.
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(30);
 
     private enum FaultPoint
     {
@@ -157,10 +155,42 @@ public partial class AsyncLifecycleErrorBoundaryTests : global::Rask.Core.RaskMa
     {
         public int RequestRenderCount;
 
+        // Signalled on the first render request, so the test awaits the event rather than a duration.
+        public TaskCompletionSource Requested { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public Task RequestRenderAsync()
         {
             Interlocked.Increment(ref RequestRenderCount);
+            Requested.TrySetResult();
             return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>A <see cref="TextWriter" /> whose buffer can be read while another thread writes to it.</summary>
+    private sealed class LockedWriter : TextWriter
+    {
+        private readonly StringBuilder _buffer = new();
+
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public string Text
+        {
+            get { lock (_buffer) { return _buffer.ToString(); } }
+        }
+
+        public override void Write(char value)
+        {
+            lock (_buffer) { _buffer.Append(value); }
+        }
+
+        public override void Write(string? value)
+        {
+            lock (_buffer) { _buffer.Append(value); }
+        }
+
+        public override void WriteLine(string? value)
+        {
+            lock (_buffer) { _buffer.AppendLine(value); }
         }
     }
 }

--- a/tests/Rask.Example.Server.Tests/Rask.Example.Server.Tests.csproj
+++ b/tests/Rask.Example.Server.Tests/Rask.Example.Server.Tests.csproj
@@ -28,12 +28,15 @@
 
   <ItemGroup>
     <Using Include="Xunit"/>
+    <Using Include="Rask.TestSupport"/>
   </ItemGroup>
 
   <!--
-    Share FakeHttp / FakeJsRuntime / LiveHost / TestServices / WaitFor with
+    Share FakeHttp / FakeJsRuntime / LiveHost / TestServices with
     Rask.Example.Shared.Tests via linked files. Avoids duplicating the same fakes
     across every Example test project and keeps them in lockstep when one changes.
+    WaitFor is no longer among them: it moved to Rask.TestSupport (referenced below),
+    because suites outside the Example family need it too (#769).
   -->
   <ItemGroup>
     <Compile Include="..\Rask.Example.Shared.Tests\Infrastructure\FakeHttp.cs"
@@ -44,8 +47,6 @@
              Link="Infrastructure\RecordingHandle.cs"/>
     <Compile Include="..\Rask.Example.Shared.Tests\Infrastructure\LifecycleLog.cs"
              Link="Infrastructure\LifecycleLog.cs"/>
-    <Compile Include="..\Rask.Example.Shared.Tests\Infrastructure\WaitFor.cs"
-             Link="Infrastructure\WaitFor.cs"/>
     <Compile Include="..\Rask.Example.Shared.Tests\Infrastructure\LiveHost.cs"
              Link="Infrastructure\LiveHost.cs"/>
     <Compile Include="..\Rask.Example.Shared.Tests\Infrastructure\TestServices.cs"
@@ -66,6 +67,7 @@
     <ProjectReference Include="..\..\src\Rask.Server\Rask.Server.csproj"/>
     <ProjectReference Include="..\..\samples\Rask.Example.Shared\Rask.Example.Shared.csproj"/>
     <ProjectReference Include="..\..\samples\Rask.Example.Server\Rask.Example.Server.csproj"/>
+    <ProjectReference Include="..\..\tests\Rask.TestSupport\Rask.TestSupport.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false"/>

--- a/tests/Rask.Example.Shared.Tests/Rask.Example.Shared.Tests.csproj
+++ b/tests/Rask.Example.Shared.Tests/Rask.Example.Shared.Tests.csproj
@@ -28,6 +28,8 @@
   <ItemGroup>
     <Using Include="Xunit"/>
     <Using Include="Rask.Testing"/>
+    <!-- WaitFor lives in the shared helper library now, so every suite polls the same way (#769). -->
+    <Using Include="Rask.TestSupport"/>
   </ItemGroup>
 
   <ItemGroup>
@@ -37,6 +39,7 @@
          app author would. -->
     <ProjectReference Include="..\..\src\Rask.Testing\Rask.Testing.csproj"/>
     <ProjectReference Include="..\..\samples\Rask.Example.Shared\Rask.Example.Shared.csproj"/>
+    <ProjectReference Include="..\..\tests\Rask.TestSupport\Rask.TestSupport.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false"/>

--- a/tests/Rask.Outbox.Tests/OutboxConcurrencyTests.cs
+++ b/tests/Rask.Outbox.Tests/OutboxConcurrencyTests.cs
@@ -12,6 +12,7 @@ namespace Rask.Outbox.Tests;
 /// stripped <c>ProcessedAt</c> from every message already published in that batch — so they were all published
 /// again on the next poll. Duplicate delivery is the exact failure the outbox exists to prevent.
 /// </summary>
+[Collection(OutboxDbCollection.Name)]
 public sealed class OutboxConcurrencyTests : IDisposable
 {
     private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"rask-outbox-conc-{Guid.NewGuid():N}.db");

--- a/tests/Rask.Outbox.Tests/OutboxDbCollection.cs
+++ b/tests/Rask.Outbox.Tests/OutboxDbCollection.cs
@@ -1,0 +1,30 @@
+namespace Rask.Outbox.Tests;
+
+/// <summary>
+///     The classes that build an <see cref="OutboxDbContext" />, run as one xUnit collection so they do
+///     not run in parallel with each other.
+/// </summary>
+/// <remarks>
+///     <para>
+///         EF Core's model cache is <b>per process, keyed on the context type</b> — not per
+///         <c>ServiceProvider</c>. Two of these classes each build their own provider over their own
+///         SQLite file, and they still share one <c>IModelSource</c> and one <c>IModel</c> instance
+///         (verified by reference identity). So the first test in each class racing to first-touch
+///         <c>OutboxDbContext</c>'s model is two threads driving one piece of EF-internal state, and the
+///         gate caught it doing so: <c>SaveChangesAsync</c> threw "The model must be finalized and its
+///         runtime dependencies must be initialized before 'GetRelationalModel' can be used" on a diff
+///         that touched none of this (#769).
+///     </para>
+///     <para>
+///         Serialising the classes removes the concurrency the failure needs, which no amount of
+///         retrying or widening a timeout would. It costs little: these are a handful of SQLite
+///         integration tests, and the ones with real budgets (the shutdown-grace pair) spend their time
+///         waiting rather than working, so the suite is bounded by those waits either way. Tests
+///         <i>within</i> a class already ran serially, so nothing here changes their meaning.
+///     </para>
+/// </remarks>
+[CollectionDefinition(Name)]
+public sealed class OutboxDbCollection
+{
+    public const string Name = "outbox-db";
+}

--- a/tests/Rask.Outbox.Tests/OutboxMetricsTests.cs
+++ b/tests/Rask.Outbox.Tests/OutboxMetricsTests.cs
@@ -10,6 +10,7 @@ namespace Rask.Outbox.Tests;
 /// The outbox pillar's metrics, driven through the real processor — instrumentation that isn't wired into
 /// the drain would pass any test that called the meter directly.
 /// </summary>
+[Collection(OutboxDbCollection.Name)]
 public sealed class OutboxMetricsTests : IDisposable
 {
     private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"rask-outbox-metrics-{Guid.NewGuid():N}.db");

--- a/tests/Rask.Outbox.Tests/OutboxRetentionTests.cs
+++ b/tests/Rask.Outbox.Tests/OutboxRetentionTests.cs
@@ -10,6 +10,7 @@ namespace Rask.Outbox.Tests;
 /// application — every domain event ever raised, payload included, on the same SQLite file the app serves
 /// from (and that Litestream replicates and snapshots copy).
 /// </summary>
+[Collection(OutboxDbCollection.Name)]
 public sealed class OutboxRetentionTests : IDisposable
 {
     private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"rask-outbox-ret-{Guid.NewGuid():N}.db");

--- a/tests/Rask.Outbox.Tests/OutboxShutdownGraceTests.cs
+++ b/tests/Rask.Outbox.Tests/OutboxShutdownGraceTests.cs
@@ -32,6 +32,7 @@ public sealed class GatedEventHandler(OutboxGate gate) : INotificationHandler<Ga
 ///     Before <c>ShutdownGracePeriod</c>, the host's stopping token went straight into the handler, so
 ///     <c>SIGTERM</c> cancelled a publish mid-call.
 /// </summary>
+[Collection(OutboxDbCollection.Name)]
 public sealed class OutboxShutdownGraceTests : IDisposable
 {
     private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"rask-outbox-grace-{Guid.NewGuid():N}.db");

--- a/tests/Rask.Outbox.Tests/OutboxTests.cs
+++ b/tests/Rask.Outbox.Tests/OutboxTests.cs
@@ -110,6 +110,7 @@ public sealed class OutboxDbContext(DbContextOptions<OutboxDbContext> options) :
     }
 }
 
+[Collection(OutboxDbCollection.Name)]
 public sealed class OutboxTests : IDisposable
 {
     private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"rask-outbox-test-{Guid.NewGuid():N}.db");

--- a/tests/Rask.TestSupport/WaitFor.cs
+++ b/tests/Rask.TestSupport/WaitFor.cs
@@ -1,6 +1,12 @@
-namespace Rask.Example.Shared.Tests.Infrastructure;
+namespace Rask.TestSupport;
 
-internal static class WaitFor
+/// <summary>
+/// The one polling wait shared by every suite. Lives here rather than in any single test project so a
+/// test that needs to wait for a thread-pool continuation reaches for this instead of a fixed
+/// <c>Task.Delay</c> budget — a duration is not a synchronisation primitive, and on a loaded machine the
+/// gate failed on diffs that could not have caused it (#769).
+/// </summary>
+public static class WaitFor
 {
     /// <summary>
     /// Polls <paramref name="condition"/> until it holds, and <b>throws</b> if it never does within

--- a/tests/Rask.Testing.Tests/TestingSurfaceTests.cs
+++ b/tests/Rask.Testing.Tests/TestingSurfaceTests.cs
@@ -182,6 +182,26 @@ public class TestingSurfaceTests
     }
 
     [Fact]
+    public async Task CapturingDiagnostics_DisposedOutOfOrder_DoesNotUnhookOneStillInUse()
+    {
+        // xUnit runs test classes in parallel, so two of these are routinely installed at once and are
+        // disposed in whatever order their tests finish. While the sink was a single slot saved and
+        // restored per install, the FIRST to dispose put back the sink from before it was installed —
+        // silently unhooking the other, which then captured nothing and failed on a full-solution run
+        // while passing standalone. That is #769's Rask.Testing.Tests flake, reproduced here without
+        // needing a second class or a loaded machine.
+        var first = CapturingDiagnostics.Install();
+        using var second = CapturingDiagnostics.Install();
+
+        first.Dispose();
+
+        _ = RaskTest.Render(new FaultsInMountAsync(), new ServiceCollection().BuildServiceProvider());
+        await WaitForCaptureAsync(second, IsTheSwallowedFault);
+
+        Assert.Contains(second.Captured, IsTheSwallowedFault);
+    }
+
+    [Fact]
     public async Task CapturingDiagnostics_RestoresThePreviousSinkOnDispose()
     {
         var before = CapturingDiagnostics.Install();
@@ -203,14 +223,32 @@ public class TestingSurfaceTests
     // CapturingDiagnostics installs a PROCESS-GLOBAL sink, so a sibling test class running in parallel can
     // drop its own diagnostic in first; a "wait until non-empty" loop then returns before the awaited one
     // has landed and the assertion fails on a full-solution run while passing standalone.
+    //
+    // Throws when it gives up, rather than returning and letting the caller's Assert.Contains report an
+    // empty collection: "the diagnostic never arrived" and "the sink was unhooked underneath us" look
+    // identical in that assertion, and telling them apart cost #769 a full investigation. The budget is
+    // generous because this only ever waits as long as the thread pool actually takes — the gate runs 40+
+    // test hosts at once, and a two-second ceiling is a duration, not a synchronisation primitive.
     private static async Task WaitForCaptureAsync(
         CapturingDiagnostics diagnostics, Func<CapturedDiagnostic, bool>? match = null)
     {
         match ??= _ => true;
 
-        for (var i = 0; i < 200 && !diagnostics.Captured.Any(match); i++)
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(30);
+        while (DateTimeOffset.UtcNow < deadline)
         {
-            await Task.Delay(10);
+            if (diagnostics.Captured.Any(match))
+            {
+                return;
+            }
+
+            await Task.Delay(15);
+        }
+
+        if (!diagnostics.Captured.Any(match))
+        {
+            throw new TimeoutException(
+                $"no matching diagnostic was captured within 30s (captured {diagnostics.Captured.Count})");
         }
     }
 }

--- a/tests/Rask.Wasm.Hosting.Tests/UseRaskTests.cs
+++ b/tests/Rask.Wasm.Hosting.Tests/UseRaskTests.cs
@@ -6,6 +6,14 @@ using Rask.Wasm.Hosting.Tests.Infrastructure;
 
 namespace Rask.Wasm.Hosting.Tests;
 
+// Every class that stands up a host belongs in this collection, because two of the things a host
+// owns are process-wide statics: ScopedAssetBundle.BakedDirectory (UseRask points it at the bundle it
+// just resolved) and LiveOptions.PathBase. The harness resets both on dispose, which handles one test
+// leaking into the NEXT one but cannot help when two tests OVERLAP — a host starting in one class
+// re-points the bundle directory out from under a request another class is midway through, and the
+// loser 404s on a file it wrote itself. This class was the one that had been left out, which is what
+// failed AssetEndpointParityTests on the loaded gate while investigating #769.
+[Collection("ScopedAssets")]
 public class UseRaskTests
 {
     [Fact]


### PR DESCRIPTION
Closes #769.

Four flakes, one shape: state shared across xUnit's default class-level parallelism, or a wait measured
in wall clock rather than in outcomes. All four only appear when the machine is busy — which the gate
itself makes it, running ~40 test hosts at once.

### `CapturingDiagnostics` could be unhooked by another class's dispose — a shipped-API bug

`Rask.Testing`'s capture saved the previous sink on install and restored it on dispose, and the sink is
process-global. Two classes installing at once meant whichever disposed **first** restored the sink from
before *it* installed, leaving the other one installed but wired to nothing — it then captured nothing at
all and failed `Assert.Contains` against an empty collection.

Installs are now tracked as a set: every live capture receives every diagnostic, and the outer sink comes
back only when the last one is disposed, in any order. Fixed in the framework rather than by serialising
our own suite, because a user with two test classes hits exactly this.

### Three tests waited a fixed duration for a thread-pool continuation

`AsyncLifecycleErrorBoundaryTests` drained its async-fault path with 50 ms of `Task.Delay` — in **all
four** tests, not only the one reported. They now wait for the outcome: the boundary's error, the reported
fault, and a `TaskCompletionSource` the recording render handle signals. Waiting is also *faster* — 27 ms
for the whole class against five sleeps per test.

`WaitFor` moved from `Rask.Example.Shared.Tests` into `Rask.TestSupport` so every suite polls one way; the
Example project that shared it by linking the source file now references it.

### EF Core's model cache is per process, not per `ServiceProvider`

Verified by reference identity: two Outbox test classes, each with its own provider over its own SQLite
file, share one `IModelSource` and one `IModel` (`sameModel=True sameModelSource=True`). Their first touch
of that model was two threads on one piece of EF-internal state, which is what threw *"The model must be
finalized and its runtime dependencies must be initialized before `GetRelationalModel` can be used"* from
a test whose diff was an `.svg`. The five classes that build a context are now one collection; the suite
still runs in 3 s.

A module-initializer warm-up does **not** work here — hand-built `DbContextOptions` land in a different
internal service provider (`bareSame=False`), so it primes the wrong cache.

### A WASM-hosting class stood outside the collection that keeps hosts apart

Found while verifying the above. `ScopedAssetBundle.BakedDirectory` and `LiveOptions.PathBase` are
process-wide statics a host writes on `UseRask`. Three of the four host-starting classes were already
grouped in `ScopedAssets` for that reason; `UseRaskTests` was not, so it re-pointed the bundle directory
out from under another class's in-flight request and that class 404'd on a file it had written itself.
Resetting on dispose — which the harness already did — cannot help when tests overlap rather than follow
one another. The property now says so where it is declared.

### The reported host crash: not reproduced, and the attribution looks wrong

`Rask.Server.Tests` has 325 tests; the crashed host had already passed 408. Because the solution runs its
assemblies concurrently, the console lines nearest a crash belong to whichever *other* assembly was
writing — which is how the drain-budget message came to sit next to it. Not reproduced in 6 loaded gate
runs plus 5 dedicated `Rask.Server.Tests` runs under load, all green.

The gate now runs with `--blame-crash`, so the next occurrence names the test in flight and leaves a dump
under `artifacts/test-blame/` instead of only being observed.

## Testing

Reproduction and verification were the same harness: `scripts/run-unit-local.sh` in a loop with 14 CPU
burners alongside, on a 14-core machine.

| | before | after |
| --- | --- | --- |
| loaded gate runs | **4 of 6 failed** (diagnostics sink, both directions) | 6 of 6 green |
| after the sink fix | 2 of 5 failed (WASM baked-bundle dir) | 6 of 6 green |

Targeted repros do not reach this family — a 16-thread hammer on the EF seam stayed green ~30 times, idle
and under load. The full-solution run is the vehicle.

Also: `dotnet format` clean, `-warnaserror` build clean, pre-commit and pre-push gates green. No framework
render-path code changed, so no benchmarks.

Follow-up filed for the same un-hit shape in five other suites: #772.
