### PR TITLE
fix(samples): give the native showcase the generator so it can use the builder chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- **`samples/Rask.Example.Native` could not use Rask's own markup syntax, because it never referenced the
+  generator.** Every other sample references `Rask.Generators` as an analyzer; the native showcase
+  referenced `Rask.Example.Shared` instead and assumed it would inherit one. A `ProjectReference` does not
+  flow analyzers, so the native sample compiled with **no Rask source generator at all**: no builder-chain
+  entries, and no `Generated.{Type}()` factory for any component the sample itself declared. The visible
+  symptom was that the showcase had to be written entirely in factory-call style
+  (`NativeHeaderBar(Title: "Rask", ...)`) while `CLAUDE.md` and every doc say markup is a chain — and
+  writing the documented form failed with `CS0119: 'Generated.NativeHeaderBar(...)' is a method`, because
+  the name fell through to the factory the *referenced* assembly publishes.
+
+  The sample now references the generator like its siblings and is written in the chain
+  (`NativeHeaderBar.Title("Rask").Background(Brand)`), which also means its markup host declares `partial`
+  as RASK036 requires. Nothing about the framework changed — this was one missing `OutputItemType="Analyzer"`
+  reference hiding the whole builder surface from the one sample that showcases the native host.
 - **`docs/native-devices.md` no longer teaches a `Route` override the framework removed.** The second
   `TodosScreen` snippet still declared `protected override string Route => "/todos";`, so a reader who
   copied it got `CS0115: no suitable method found to override` — `Screen` has had no virtual `Route` since

--- a/samples/Rask.Example.Native/NativeShowcaseApp.cs
+++ b/samples/Rask.Example.Native/NativeShowcaseApp.cs
@@ -1,9 +1,12 @@
 using Rask.Core;
 using Rask.Core.Routing;
 using Rask.Example.Shared;
+using Rask.Native.Components;
 using static Rask.Native.Components.Generated;
 using NativeColor = Rask.Native.Components.NativeColor;
 using NativeIcon = Rask.Native.Components.NativeIcon;
+using NativeFontWeight = Rask.Native.Components.NativeFontWeight;
+using NativeButtonStyle = Rask.Native.Components.NativeButtonStyle;
 using AppRoutes = Rask.Example.Shared.Features.Routes;
 
 namespace Rask.Example.Native;
@@ -17,7 +20,7 @@ namespace Rask.Example.Native;
 ///     <c>IsNative</c> gate in <c>ShowcaseLayout</c>. No <c>IsNative</c> guard is needed here — this type is only
 ///     ever mounted by the native heads.
 /// </summary>
-public sealed class NativeShowcaseApp(RouteState route) : App
+public sealed partial class NativeShowcaseApp(RouteState route) : App
 {
     // Brand palette — kept in one place and deliberately aligned with the web theme's accent so the native bars
     // and the WebView content read as one app. NativeColor mirrors NativeIcon: one authored value the platform
@@ -32,46 +35,90 @@ public sealed class NativeShowcaseApp(RouteState route) : App
     private int _filter;
     private bool _todosRead; // toggled from the overflow menu — hides the Todos badge
 
+    // SPIKE (#775): pure-native screen state. A plain string literal is used for the route below because a
+    // native-only surface is not a routed Page — the app root swaps surfaces on the path, which is the
+    // documented mixed-surface model, so there is no generated Routes.* entry to be type-safe against.
+    private const string NativeDemoPath = "/native-demo";
+    private string _note = string.Empty;
+    private bool _notify = true;
+    private int _taps;
+
     private bool OnTodos => route.Path.StartsWith("/todos", StringComparison.OrdinalIgnoreCase);
 
     // A guide detail page (/guides/{slug}) is a drill-down from the Guides index, so its header gets a native
     // back button that pops history back to the index (like hardware Back).
     private bool OnGuideDetail => route.Path.StartsWith("/guides/", StringComparison.OrdinalIgnoreCase);
 
+    private bool OnNativeDemo => route.Path.StartsWith(NativeDemoPath, StringComparison.OrdinalIgnoreCase);
+
+    // SPIKE (#775): the pure-native content — a real UIView / android.view.View tree, no WebView, no HTML.
+    // Every control below carries an AccessibilityId so Appium can assert on the NATIVE_APP context rather
+    // than a WEBVIEW one, which is the only way to prove the surface backend actually painted.
+    private Component NativeDemoScreen() =>
+        NativeScreen.Padding(20)[
+            NativeStack.Spacing(14)[
+                NativeLabel.FontSize(22).FontWeight(NativeFontWeight.Bold).AccessibilityId("spike-title")[
+                    "Pure-native screen"],
+                NativeLabel
+                    .Color(NativeColor.Adaptive(NativeColor.Hex("#4B5563"), NativeColor.Hex("#9CA3AF")))
+                    .Lines(0).AccessibilityId("spike-subtitle")[
+                    "No WebView is showing. This tree is UILabel / UITextField / UISwitch / UIButton."],
+                NativeDivider,
+                NativeTextField.Value(_note).Placeholder("Type a note").AccessibilityId("spike-note")
+                    .OnInput(v => _note = v),
+                NativeLabel.AccessibilityId("spike-echo")[
+                    _note.Length == 0 ? "note: (empty)" : $"note: {_note}"],
+                NativeSwitch.On(_notify).AccessibilityId("spike-switch").OnChanged(v => _notify = v),
+                NativeLabel.AccessibilityId("spike-switch-state")[$"notify: {(_notify ? "on" : "off")}"],
+                NativeButton.Style(NativeButtonStyle.Filled).Background(Brand).Color(OnBrand)
+                    .AccessibilityId("spike-tap").OnClick(() => _taps++)["Tap me"],
+                NativeLabel.AccessibilityId("spike-taps")[$"taps: {_taps}"],
+                NativeActivityIndicator,
+                NativeSpacer]];
+
     protected override Component? Render()
     {
         // An overflow menu of secondary actions (shown on every page's header). Selecting an entry re-renders,
-        // demonstrating a native pull-down menu (iOS UIMenu / Android PopupMenu) driving native state.
-        var overflow = NativeMenuButton(Items:
-        [
-            NativeMenuItem(Title: "Mark Todos read", Icon: NativeIcon.List, OnClick: () => _todosRead = true),
-            NativeMenuItem(Title: "Mark Todos unread", Icon: NativeIcon.Star, OnClick: () => _todosRead = false),
+        // demonstrating a native pull-down menu (iOS UIMenu / Android PopupMenu) driving native state. Typed as
+        // the concrete component, not `var`: the chain's receiver is Build<NativeMenuButton>, and the bar slots
+        // below take IReadOnlyList<NativeBarItem> — the implicit conversion needs a target to land on.
+        NativeMenuButton overflow = NativeMenuButton.Items([
+            NativeMenuItem.Title("Mark Todos read").Icon(NativeIcon.List).OnClick(() => _todosRead = true),
+            NativeMenuItem.Title("Mark Todos unread").Icon(NativeIcon.Star).OnClick(() => _todosRead = false),
         ]);
+
+        // Same reason: a `cond ? chain : null` needs a target type, and here that target is the slot's type.
+        NativeBarItem? back = OnGuideDetail ? NativeBackButton : null;
 
         return
         [
             // On Todos, the header shows the segmented filter in place of the title; elsewhere, the brand title
             // (with a back button when on a drill-down guide page). Both carry the overflow menu as a trailing item.
             OnTodos
-                ? NativeHeaderBar(
-                    Background: Brand, Tint: OnBrand, TitleColor: OnBrand,
-                    Segments: Filters, SelectedSegment: _filter, OnSegmentChanged: i => _filter = i,
-                    Trailing: [overflow])
-                : NativeHeaderBar(Title: "Rask", Background: Brand, Tint: OnBrand, TitleColor: OnBrand,
-                    Leading: OnGuideDetail ? NativeBackButton() : null,
-                    Trailing: [overflow]),
-            NativeWebView()[base.Render()],
-            NativeTabBar(
+                ? NativeHeaderBar
+                    .Background(Brand).Tint(OnBrand).TitleColor(OnBrand)
+                    .Segments(Filters).SelectedSegment(_filter).OnSegmentChanged(i => _filter = i)
+                    .Trailing([overflow])
+                : NativeHeaderBar
+                    .Title("Rask").Background(Brand).Tint(OnBrand).TitleColor(OnBrand)
+                    .Leading(back)
+                    .Trailing([overflow]),
+            // SPIKE (#775): one route paints natively, the rest paint as HTML. The host keeps BOTH content
+            // views alive and only toggles which is visible, so switching back does not reload the page.
+            OnNativeDemo ? NativeDemoScreen() : NativeWebView[base.Render()],
+            NativeTabBar
                 // Selected tab picks up the brand accent; the rest stay muted (adaptive so dark mode reads well).
-                Tint: Brand,
-                UnselectedTint: NativeColor.Adaptive(NativeColor.Hex("#6B7280"), NativeColor.Hex("#9CA3AF")),
-                Tabs:
-                [
+                .Tint(Brand)
+                .UnselectedTint(NativeColor.Adaptive(NativeColor.Hex("#6B7280"), NativeColor.Hex("#9CA3AF")))
+                .Tabs([
                     // Guides is the site root ("/") now that the Welcome landing page is gone.
-                    NativeTab(Title: "Guides", Icon: NativeIcon.Home, To: AppRoutes.GuidesIndexPage()),
+                    NativeTab.Title("Guides").Icon(NativeIcon.Home).To(AppRoutes.GuidesIndexPage()),
                     // The badge tracks the segmented filter on Todos, and the overflow menu can clear it.
-                    NativeTab(Title: "Todos", Icon: NativeIcon.Custom("checklist", "ic_todo"),
-                        To: AppRoutes.TodosPage(), Badge: _todosRead ? null : OnTodos ? Badges[_filter] : "2"),
+                    NativeTab.Title("Todos").Icon(NativeIcon.Custom("checklist", "ic_todo"))
+                        .To(AppRoutes.TodosPage())
+                        .Badge(_todosRead ? null : OnTodos ? Badges[_filter] : "2"),
+                    // SPIKE (#775): the pure-native tab.
+                    NativeTab.Title("Native").Icon(NativeIcon.Star).To(NativeDemoPath),
                 ])
             // Selected is omitted — the framework highlights the tab matching the current route.
         ];

--- a/samples/Rask.Example.Native/Platforms/iOS/AppDelegate.cs
+++ b/samples/Rask.Example.Native/Platforms/iOS/AppDelegate.cs
@@ -4,6 +4,7 @@ using Rask.Example.Native.Data;
 using Rask.Example.Shared;
 using Rask.Example.Shared.Features;
 using Rask.Native;
+using Rask.Native.Surface;
 using Rask.SQLite;
 using UIKit;
 
@@ -57,6 +58,11 @@ public class AppDelegate : UIApplicationDelegate
         // Native header/footer chrome: the same RaskWkWebView instance is the INativeChrome backend, so the
         // NativeShowcaseApp's NativeHeader/NativeFooter drive its UINavigationBar/UITabBar.
         host.Services.AddSingleton<INativeChrome>(webView);
+
+        // SPIKE (#775): the same RaskWkWebView is also the INativeSurface backend, so a route composing a
+        // NativeScreen paints a real UIView tree instead of HTML. With this line absent the native family is
+        // inert and every frame goes through the WebView, which is why nothing had exercised it before.
+        host.Services.AddSingleton<INativeSurface>(webView);
 
         // Serve the demo HttpClient's data/*.json fetches from the app's bundled assets (offline). This
         // AddSingleton overrides the plain-network HttpClient AddExampleServices registered.

--- a/samples/Rask.Example.Native/Rask.Example.Native.csproj
+++ b/samples/Rask.Example.Native/Rask.Example.Native.csproj
@@ -77,6 +77,13 @@
     <!-- On-device SQLite for the Todos screen (raw Microsoft.Data.Sqlite path — reflection-free/AOT-safe;
          brings the native e_sqlite3 for ios/android via SQLitePCLRaw). -->
     <ProjectReference Include="..\..\src\Rask.SQLite\Rask.SQLite.csproj"/>
+    <!-- The Rask factory/builder generator. A ProjectReference does NOT flow analyzers transitively, so
+         referencing Rask.Example.Shared (which has it) is not enough: without this the native sample gets no
+         Generated.{Type}() factories for its OWN components and no builder-chain entries at all, which is why
+         it had to be written in factory-call style while every other sample uses the chain. -->
+    <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"/>
   </ItemGroup>
 
   <!-- Each platform head compiles only for its own TFM. -->


### PR DESCRIPTION
## Summary

`samples/Rask.Example.Native` never referenced `Rask.Generators` as an analyzer. A `ProjectReference`
does not flow analyzers, so referencing `Rask.Example.Shared` (which has one) was not enough — the native
sample compiled with **no Rask source generator at all**: no builder-chain entries, and no
`Generated.{Type}()` factory for any component it declares.

The visible symptom: the one sample that showcases the native host could not use the framework's own
documented markup syntax. It was written entirely in factory-call style, and writing the chain failed with
`CS0119: 'Generated.NativeHeaderBar(...)' is a method` — the name fell through to the factory the
*referenced* assembly publishes. Exactly the signature of the `RaskBuilderSurface` trap, from a different
cause.

`NativeShowcaseApp` is now written in the chain and declares `partial` as RASK036 requires. Nothing about
the framework changed.

This PR also carries the spike that found it (#775, part of epic #774): a pure-native demo route — a
`NativeScreen` of real UIKit controls, a tab to reach it, and the `INativeSurface` registration the iOS
head was missing.

## Result

The iOS `INativeSurface` backend renders on a simulator — the first time it has been run anywhere.
`docs/native.md` currently says neither surface backend has been run on a simulator, emulator or device;
that is now out of date for iOS (Android remains unrun).

Real `UILabel` / `UITextField` / `UISwitch` / `UIButton` / `UIActivityIndicator` inside the native chrome,
no WebView showing, driven purely by the route, with the framework auto-highlighting the matching tab.

## Testing

- `dotnet build samples/Rask.Example.Native -f net10.0-ios -p:RaskNativeHeads=ios` — clean, 0 warnings.
- Ran on an iPhone 17 Pro simulator (iOS 26.5, Xcode 26.6); verified by screenshot, twice — content forced,
  then route-driven.
- Format + unit gate: 43 assemblies, **6,320 tests**, 0 failures.
- Browser E2E gate: **61 passed**.
- The Appium on-device suite is not part of either gate and was not run; the simulator run above was
  manual.

## Found on device

#785 — iOS silently ignores `NativeButton.Background(...)` and `.Color(...)`: a `UIButtonConfiguration`
paints over both, and `ApplyButtonStyle` replaces the configuration wholesale. Not fixed here.

## Method note

`dotnet build -t:Run` does **not** rebuild — it runs only the `Run` target against whatever is in `bin/`.
Two spike results were false negatives from a stale binary before the DLL timestamp gave it away.
`docs/native.md` and the sample csproj both tell people to use `-t:Run`.

## Changelog

`[Unreleased] → Fixed`, included.
