### PR TITLE
fix(generators): an internal component's chain entry crosses an InternalsVisibleTo boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,21 @@ them until tagged releases begin.
   (the factory excluded it on name *and* type; the indexer owns the word).
 
 ### Fixed
+- **An `internal` component's chain entry did not cross an `InternalsVisibleTo` boundary.** A friend
+  assembly could see the component and could see its entry, and was told about neither: the scan that
+  reads a referenced assembly's `RaskEntries{Assembly}` class took **public** members only, and an
+  internal component publishes its entry `internal static`. The friend assembly's only remaining
+  spelling was the fully-qualified entry host — `global::RaskEntriesRask_Example_Shared.PageHeader
+  .Title(…)` — because with the factory gone there is no second way to reach the component at all.
+
+  The scan now asks `IAssemblySymbol.GivesAccessTo(compilation.Assembly)`, which is the same question
+  the compiler asks of `InternalsVisibleTo`, and admits internal entries when the answer is yes. They
+  are injected as `private static` forwarders like every other one, so an internal type never leaks
+  past the host that receives it. `PageHeaderTests` now reads `PageHeader.Title("Greetings")`
+  unqualified, and a cross-assembly generator test pins both halves — the grant, and a negative
+  control with the grant naming somebody else, where the public entry still arrives and the internal
+  one does not.
+
 - **An unset `NativeStack` / `NativeScreen` `Orientation` meant vertical on iOS and horizontal on Android.**
   iOS creates both with an explicit vertical axis; Android created a bare `LinearLayout`, whose platform
   default is HORIZONTAL, and nothing set one. So the same tree laid out in a column on one platform and a row

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -3266,7 +3266,18 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         foreach (var assembly in compilation.SourceModule.ReferencedAssemblySymbols)
         {
             var hostType = assembly.GetTypeByMetadataName(EntryHostName(SanitizeIdentifier(assembly.Name)));
-            if (hostType is null || hostType.DeclaredAccessibility != Accessibility.Public)
+            if (hostType is null)
+            {
+                continue;
+            }
+
+            // An INTERNAL component publishes an `internal static` entry (EmitEntryHost), so taking public
+            // members only would tell a friend assembly about neither the component nor its entry — even
+            // though it can see both. With the factory gone there is no second spelling to fall back on,
+            // and the fully-qualified entry host is all that is left. `GivesAccessTo` is the same question
+            // the compiler asks of `InternalsVisibleTo`.
+            var friend = assembly.GivesAccessTo(compilation.Assembly);
+            if (!VisibleToEntryScan(hostType.DeclaredAccessibility, friend))
             {
                 continue;
             }
@@ -3275,7 +3286,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             var hostFqn = hostType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
             foreach (var member in hostType.GetMembers())
             {
-                if (!member.IsStatic || member.DeclaredAccessibility != Accessibility.Public)
+                if (!member.IsStatic || !VisibleToEntryScan(member.DeclaredAccessibility, friend))
                 {
                     continue;
                 }
@@ -3295,6 +3306,11 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
 
         return new ExternalEntrySet(SortedEntries(libraries), SortedEntries(framework));
     }
+
+    // Public entries are visible everywhere; internal ones only across an `InternalsVisibleTo` grant. The
+    // injected forwarder is `private static`, so an internal entry's type never leaks past the host.
+    private static bool VisibleToEntryScan(Accessibility accessibility, bool friend) =>
+        accessibility == Accessibility.Public || (friend && accessibility == Accessibility.Internal);
 
     // What a referenced assembly publishes, split by whether this compilation's hosts already inherit it.
     private readonly record struct ExternalEntrySet(

--- a/tests/Rask.Example.Shared.Tests/Demos/PageHeaderTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/PageHeaderTests.cs
@@ -10,7 +10,7 @@ public sealed partial class PageHeaderTests : global::Rask.Core.RaskMarkup
     public void Render_EmitsTitle_AsH2_AndLead_AsP()
     {
         var html = new LiveHost(
-            () => global::RaskEntriesRask_Example_Shared.PageHeader
+            () => PageHeader
                 .Title("Greetings").Lead("A welcoming subtitle."),
             TestServices.Default()).RenderAsLiveRoot();
         // PageHeader uses H1 with bootstrap class "h2" (visual sizing, not HTML tag).
@@ -22,7 +22,7 @@ public sealed partial class PageHeaderTests : global::Rask.Core.RaskMarkup
     public void Render_HtmlEncodesContent()
     {
         var html = new LiveHost(
-            () => global::RaskEntriesRask_Example_Shared.PageHeader.Title("<a>").Lead("&amp;"),
+            () => PageHeader.Title("<a>").Lead("&amp;"),
             TestServices.Default()).RenderAsLiveRoot();
         Assert.Contains("&lt;a&gt;", html);
     }

--- a/tests/Rask.Generators.Tests/BuilderGeneratorHarness.cs
+++ b/tests/Rask.Generators.Tests/BuilderGeneratorHarness.cs
@@ -11,13 +11,26 @@ namespace Rask.Generators.Tests;
 // emission, the entry emission and the diagnostics all read the same run.
 internal static class BuilderGeneratorHarness
 {
-    internal static BuilderRun Run(string source)
+    internal static BuilderRun Run(string source) => Run(source, null);
+
+    /// <summary>
+    ///     The same run with extra references — an emitted library compilation, for the cross-assembly
+    ///     entry scan. The assembly name stays <c>TestAssembly</c>, which is what a library's
+    ///     <c>InternalsVisibleTo</c> has to name for the friend path to be exercised.
+    /// </summary>
+    internal static BuilderRun Run(string source, IEnumerable<MetadataReference>? extraReferences)
     {
+        var references = GeneratorDriverFixture.BuildReferences();
+        if (extraReferences is not null)
+        {
+            references = references.AddRange(extraReferences);
+        }
+
         var syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
         var compilation = CSharpCompilation.Create(
             "TestAssembly",
             new[] { syntaxTree },
-            GeneratorDriverFixture.BuildReferences(),
+            references,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
                 nullableContextOptions: NullableContextOptions.Enable));
 

--- a/tests/Rask.Generators.Tests/CrossAssemblyInternalEntryTests.cs
+++ b/tests/Rask.Generators.Tests/CrossAssemblyInternalEntryTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.CodeAnalysis;
+
+namespace Rask.Generators.Tests;
+
+/// <summary>
+///     What a friend assembly is told about a referenced library's INTERNAL components. An internal
+///     component publishes an <c>internal static</c> entry on its assembly's <c>RaskEntries{Assembly}</c>
+///     class, so a scan that takes public members only hands a friend assembly nothing — even though it
+///     can see both the component and the entry. With the factory gone there is no second spelling left,
+///     and the test has to name the entry host in full to reach the component at all.
+/// </summary>
+public class CrossAssemblyInternalEntryTests
+{
+    private const string Library = """
+        namespace Lib
+        {
+            public sealed class OpenCard : global::Rask.Core.Component
+            {
+                protected override global::Rask.Core.Component? Render() => null;
+            }
+
+            internal sealed class SecretCard : global::Rask.Core.Component
+            {
+                protected override global::Rask.Core.Component? Render() => null;
+            }
+        }
+        """;
+
+    private const string Consumer = """
+        using Rask.Core;
+
+        namespace Demo
+        {
+            public partial class Page : Component
+            {
+            }
+        }
+        """;
+
+    private const string OpenEntry =
+        "private static global::Rask.Core.Build<global::Lib.OpenCard> OpenCard "
+        + "=> global::RaskEntriesLib.OpenCard;";
+
+    private const string SecretEntry =
+        "private static global::Rask.Core.Build<global::Lib.SecretCard> SecretCard "
+        + "=> global::RaskEntriesLib.SecretCard;";
+
+    [Fact]
+    public void A_referenced_librarys_internal_entry_is_injected_into_a_friend_assembly()
+    {
+        var entries = ConsumerEntries(friend: "TestAssembly");
+
+        Assert.Contains(SecretEntry, entries, StringComparison.Ordinal);
+        Assert.Contains(OpenEntry, entries, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     The negative control that gives the one above its meaning: same library, same internal
+    ///     component, an <c>InternalsVisibleTo</c> naming somebody else. The public entry still arrives,
+    ///     so the scan ran — the internal one is withheld because the grant does not reach here, not
+    ///     because nothing was scanned.
+    /// </summary>
+    [Fact]
+    public void Without_the_grant_the_internal_entry_is_withheld_and_the_public_one_is_not()
+    {
+        var entries = ConsumerEntries(friend: "SomebodyElse");
+
+        Assert.DoesNotContain(SecretEntry, entries, StringComparison.Ordinal);
+        Assert.Contains(OpenEntry, entries, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     …and the entry the friend assembly reaches is the library's own canonical one, emitted
+    ///     <c>internal static</c> because the component is internal. This pins the shape the scan reads,
+    ///     so a change on the emitting side cannot quietly make the fix above a no-op.
+    /// </summary>
+    [Fact]
+    public void The_library_publishes_the_internal_entry_as_an_internal_member()
+    {
+        var host = BuilderGeneratorHarness.Run(Library).Source("RaskBuilderEntryHost.g.cs");
+
+        Assert.Contains(
+            "internal static global::Rask.Core.Build<global::Lib.SecretCard> SecretCard",
+            host,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "public static global::Rask.Core.Build<global::Lib.OpenCard> OpenCard",
+            host,
+            StringComparison.Ordinal);
+    }
+
+    // Emits the library — generated entry host included — and runs the generator over a consumer that
+    // references it. Emitting is what makes this a real test of the scan: it reads metadata, and an
+    // internal member's accessibility is exactly the thing that survives the round trip.
+    private static string ConsumerEntries(string friend)
+    {
+        var library = BuilderGeneratorHarness.Compile(
+            $"""
+             [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("{friend}")]
+
+             """ + Library,
+            "Lib");
+
+        using var stream = new MemoryStream();
+        var emit = library.Emit(stream);
+        Assert.True(emit.Success, string.Join("\n", emit.Diagnostics));
+        stream.Position = 0;
+
+        return BuilderGeneratorHarness
+            .Run(Consumer, new[] { MetadataReference.CreateFromStream(stream) })
+            .Source("RaskBuilderConsumerEntries.g.cs");
+    }
+}


### PR DESCRIPTION
## Summary

An `internal` component's chain entry did not cross an `InternalsVisibleTo` boundary. A friend
assembly could see the component and could see its entry, and was told about neither.

`ScanExternalEntries` reads a referenced assembly's `RaskEntries{Assembly}` class and collected
**public** members only. An internal component publishes its entry `internal static`
(`ComponentFactoryGenerator.cs:1523`), so the friend assembly's only remaining spelling was the
fully-qualified entry host:

```csharp
global::RaskEntriesRask_Example_Shared.PageHeader.Title("Greetings").Lead("…")
```

Before #792 this was invisible — a friend assembly could still reach the component through the
factory. With the factory gone there is no second spelling, so the entry host is all that is left.

## What changed

The scan now asks `IAssemblySymbol.GivesAccessTo(compilation.Assembly)` — the same question the
compiler asks of `InternalsVisibleTo` — and admits internal entries when the answer is yes. They
are injected as `private static` forwarders like every other one, so an internal type never leaks
past the host that receives it.

## Testing

- `tests/Rask.Example.Shared.Tests/Demos/PageHeaderTests.cs` now reads `PageHeader.Title("Greetings")`
  unqualified. Reverting just the generator turns both call sites into `CS1929` — the guard was
  proven by failing it.
- New `tests/Rask.Generators.Tests/CrossAssemblyInternalEntryTests.cs` emits a real library
  compilation carrying the grant and runs the generator over a consumer that references it, so the
  scan reads actual metadata. Three cases: the internal entry is injected into a friend assembly;
  a **negative control** where the grant names somebody else, in which the public entry still
  arrives and the internal one does not; and the emitted shape on the library side, so a change
  there cannot quietly make the fix a no-op.
- Reverting the generator fails exactly one of the three — the friend case.
- `BuilderGeneratorHarness.Run` gained an overload taking extra references, which is what lets a
  builder-surface test reference an emitted assembly at all.

## Gates

- `dotnet format Rask.slnx` — no changes.
- `CI=true dotnet build Rask.slnx -c Release -warnaserror -p:EnforceCodeStyleInBuild=true` — 0 warnings, 0 errors.
- `scripts/run-unit-local.sh` — passed (pre-commit).
- `scripts/run-e2e-local.sh` + watch hot-reload gate — passed (pre-push).
- No benchmark: generator-only, nothing on the render hot path.

Closes #794
