### PR TITLE
test: serialise the four suites that share a DbContext across parallel classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,28 @@ them until tagged releases begin.
   (the factory excluded it on name *and* type; the indexer owns the word).
 
 ### Fixed
+- **Four more test suites shared one `DbContext` across classes xUnit ran in parallel.** The shape that
+  made `Rask.Outbox.Tests` fail the gate in #769 was still present in `Rask.Jobs.Tests`,
+  `Rask.Cache.Tests`, `Rask.Mail.Tests` and `Rask.Data.Tests`: EF Core's model cache is **per process,
+  keyed on the context type** — not per `ServiceProvider` — so classes that each build their own
+  provider over their own SQLite file still share one `IModelSource` and one `IModel`, and the first
+  test in each racing to first-touch it drives one piece of EF-internal state from two threads. The
+  DB-touching classes in each suite now sit in one `[CollectionDefinition]`, as the Outbox ones do. It
+  costs nothing measurable — each suite still runs in 1–3 s, because these tests are bounded by their
+  own waits rather than by CPU.
+
+  `Rask.Dashboard.Tests` was on the same list and needed no change: it already disables parallelisation
+  assembly-wide. `OutboxSerializerRegistryReplaceTests` was flagged as "same family" and is not — the
+  registry rebuilds under a lock and installs its lookup in a single volatile store, so a reader
+  observes either the whole old map or the whole new one. Concurrent use is its design.
+
+  A shared `DbCollectionGuard` (linked into all five suites, Outbox included) now fails if a test class
+  is neither in the collection nor named as one that never builds a context. It asks the question the
+  safe way round on purpose: these suites build their contexts in a **local**, which no reflection over
+  fields and signatures can see, so a guard that tried to detect "does this class use the context?"
+  would pass every class for the wrong reason. Defaulting to *collected* means a new test class cannot
+  join the suite silently, and every exception is a name somebody wrote down with a reason.
+
 - **An `internal` component's chain entry did not cross an `InternalsVisibleTo` boundary.** A friend
   assembly could see the component and could see its entry, and was told about neither: the scan that
   reads a referenced assembly's `RaskEntries{Assembly}` class took **public** members only, and an

--- a/tests/Rask.Cache.Tests/CacheDbCollection.cs
+++ b/tests/Rask.Cache.Tests/CacheDbCollection.cs
@@ -1,0 +1,18 @@
+namespace Rask.Cache.Tests;
+
+/// <summary>
+///     The classes that build a <see cref="CacheDbContext" />, run as one xUnit collection so they do
+///     not run in parallel with each other. See <c>Rask.Jobs.Tests.JobsDbCollection</c> for why the
+///     shape is a race — EF Core's model cache is per process and keyed on the context type, so a
+///     per-class <c>ServiceProvider</c> over a per-class SQLite file still shares one <c>IModel</c>.
+/// </summary>
+/// <remarks>
+///     <c>CacheOptionsTests</c> is deliberately not in the collection: it only calls
+///     <c>AddRaskCache&lt;CacheDbContext&gt;</c> to assert the option validation, and never builds a
+///     context — so it never touches the model and has nothing to race over.
+/// </remarks>
+[CollectionDefinition(Name)]
+public sealed class CacheDbCollection
+{
+    public const string Name = "cache-db";
+}

--- a/tests/Rask.Cache.Tests/CacheDbCollectionGuardTests.cs
+++ b/tests/Rask.Cache.Tests/CacheDbCollectionGuardTests.cs
@@ -1,0 +1,19 @@
+using Rask.Tests.Shared;
+
+namespace Rask.Cache.Tests;
+
+// In the collection it guards, so it costs the suite nothing and needs no exemption of its own.
+[Collection(CacheDbCollection.Name)]
+public sealed class CacheDbCollectionGuardTests
+{
+    [Fact]
+    public void Every_test_class_is_collected_or_named_as_one_that_never_builds_a_context() =>
+        DbCollectionGuard.AssertEveryTestClassIsCollected(
+            typeof(CacheDbCollectionGuardTests).Assembly,
+            CacheDbCollection.Name,
+            // Names CacheDbContext only as the type argument to AddRaskCache while asserting option
+            // validation; never builds a context, so it never touches the model.
+            "CacheOptionsTests",
+            // Drives an in-memory external store through the cache abstraction — no EF at all.
+            "ExternalStoreCacheTests");
+}

--- a/tests/Rask.Cache.Tests/CachePurgerTests.cs
+++ b/tests/Rask.Cache.Tests/CachePurgerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Caching.Distributed;
 
 namespace Rask.Cache.Tests;
 
+[Collection(CacheDbCollection.Name)]
 public sealed class CachePurgerTests
 {
     private static byte[] Bytes(string s) => Encoding.UTF8.GetBytes(s);

--- a/tests/Rask.Cache.Tests/Rask.Cache.Tests.csproj
+++ b/tests/Rask.Cache.Tests/Rask.Cache.Tests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared.DbCollection\DbCollectionGuard.cs" Link="DbCollectionGuard.cs"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Rask.Cache.Tests/RaskDistributedCacheTests.cs
+++ b/tests/Rask.Cache.Tests/RaskDistributedCacheTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Caching.Distributed;
 
 namespace Rask.Cache.Tests;
 
+[Collection(CacheDbCollection.Name)]
 public sealed class RaskDistributedCacheTests
 {
     private static byte[] Bytes(string s) => Encoding.UTF8.GetBytes(s);

--- a/tests/Rask.Cache.Tests/TypedCacheTests.cs
+++ b/tests/Rask.Cache.Tests/TypedCacheTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Caching.Distributed;
 
 namespace Rask.Cache.Tests;
 
+[Collection(CacheDbCollection.Name)]
 public sealed class TypedCacheTests
 {
     public sealed record Widget(int Id, string Name);

--- a/tests/Rask.Data.Tests/BulkInsertFastPathTests.cs
+++ b/tests/Rask.Data.Tests/BulkInsertFastPathTests.cs
@@ -8,6 +8,7 @@ namespace Rask.Data.Tests;
 // reproduce by hand what the change tracker did for free. These pin the parts that could silently diverge:
 // the values that reach the columns, the audit stamps AuditingInterceptor is no longer there to write, the
 // transaction boundary, and every case the writer must refuse rather than write wrong rows.
+[Collection(DataDbCollection.Name)]
 public sealed class BulkInsertFastPathTests : IDisposable
 {
     private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"rask-bulk-fast-{Guid.NewGuid():N}.db");

--- a/tests/Rask.Data.Tests/BulkInsertTests.cs
+++ b/tests/Rask.Data.Tests/BulkInsertTests.cs
@@ -8,6 +8,7 @@ namespace Rask.Data.Tests;
 // batches, so the questions worth pinning are: does everything land, do the interceptors still run over
 // entities that only exist in the tracker for one batch, where does the transaction boundary sit, and does
 // the domain-event guard hold — inside a transaction the interceptor would publish before the commit.
+[Collection(DataDbCollection.Name)]
 public sealed class BulkInsertTests : IDisposable
 {
     private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"rask-bulk-test-{Guid.NewGuid():N}.db");

--- a/tests/Rask.Data.Tests/DataDbCollection.cs
+++ b/tests/Rask.Data.Tests/DataDbCollection.cs
@@ -1,0 +1,18 @@
+namespace Rask.Data.Tests;
+
+/// <summary>
+///     The classes that build a <see cref="TestDbContext" />, run as one xUnit collection so they do
+///     not run in parallel with each other. See <c>Rask.Jobs.Tests.JobsDbCollection</c> for why the
+///     shape is a race — EF Core's model cache is per process and keyed on the context type, so a
+///     per-class <c>ServiceProvider</c> over a per-class SQLite file still shares one <c>IModel</c>.
+/// </summary>
+/// <remarks>
+///     The extra contexts <c>BulkInsertFastPathTests</c> declares for its own cases
+///     (<c>GeneratedKeyContext</c>, <c>GraphContext</c>, <c>CountingContext</c>) are used by that one
+///     class only, so they are covered by xUnit already running a class's tests serially.
+/// </remarks>
+[CollectionDefinition(Name)]
+public sealed class DataDbCollection
+{
+    public const string Name = "data-db";
+}

--- a/tests/Rask.Data.Tests/DataDbCollectionGuardTests.cs
+++ b/tests/Rask.Data.Tests/DataDbCollectionGuardTests.cs
@@ -1,0 +1,14 @@
+using Rask.Tests.Shared;
+
+namespace Rask.Data.Tests;
+
+// In the collection it guards, so it costs the suite nothing and needs no exemption of its own.
+[Collection(DataDbCollection.Name)]
+public sealed class DataDbCollectionGuardTests
+{
+    [Fact]
+    public void Every_test_class_is_collected_or_named_as_one_that_never_builds_a_context() =>
+        DbCollectionGuard.AssertEveryTestClassIsCollected(
+            typeof(DataDbCollectionGuardTests).Assembly,
+            DataDbCollection.Name);
+}

--- a/tests/Rask.Data.Tests/Rask.Data.Tests.csproj
+++ b/tests/Rask.Data.Tests/Rask.Data.Tests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared.DbCollection\DbCollectionGuard.cs" Link="DbCollectionGuard.cs"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Rask.Data.Tests/RaskDataTests.cs
+++ b/tests/Rask.Data.Tests/RaskDataTests.cs
@@ -6,6 +6,7 @@ namespace Rask.Data.Tests;
 
 // End-to-end against a real SQLite file: the interceptors + conventions drive auditing, transparent soft
 // delete, optimistic concurrency, and after-commit domain-event publication.
+[Collection(DataDbCollection.Name)]
 public sealed class RaskDataTests : IDisposable
 {
     private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"rask-data-test-{Guid.NewGuid():N}.db");

--- a/tests/Rask.Jobs.Tests/JobLeaseTests.cs
+++ b/tests/Rask.Jobs.Tests/JobLeaseTests.cs
@@ -13,6 +13,7 @@ namespace Rask.Jobs.Tests;
 /// these fail every time if the claim is wrong. The one genuine race lives in
 /// <see cref="JobProcessorConcurrencyTests"/>.
 /// </remarks>
+[Collection(JobsDbCollection.Name)]
 public sealed class JobLeaseTests
 {
     private static readonly DateTimeOffset Start = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);

--- a/tests/Rask.Jobs.Tests/JobMetricsTests.cs
+++ b/tests/Rask.Jobs.Tests/JobMetricsTests.cs
@@ -8,6 +8,7 @@ namespace Rask.Jobs.Tests;
 /// actually running work, not from a unit poking the meter) and that a listener is what makes the
 /// queue-depth gauges cost anything at all.
 /// </summary>
+[Collection(JobsDbCollection.Name)]
 public sealed class JobMetricsTests
 {
     [Fact]

--- a/tests/Rask.Jobs.Tests/JobProcessorConcurrencyTests.cs
+++ b/tests/Rask.Jobs.Tests/JobProcessorConcurrencyTests.cs
@@ -9,6 +9,7 @@ namespace Rask.Jobs.Tests;
 /// stripped <c>ProcessedAt</c> from every job in the batch that had already run — so they all ran again, every
 /// poll, forever.
 /// </summary>
+[Collection(JobsDbCollection.Name)]
 public sealed class JobProcessorConcurrencyTests
 {
     [Fact]

--- a/tests/Rask.Jobs.Tests/JobProcessorTests.cs
+++ b/tests/Rask.Jobs.Tests/JobProcessorTests.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Rask.Jobs.Tests;
 
+[Collection(JobsDbCollection.Name)]
 public sealed class JobProcessorTests
 {
     [Fact]

--- a/tests/Rask.Jobs.Tests/JobShutdownGraceTests.cs
+++ b/tests/Rask.Jobs.Tests/JobShutdownGraceTests.cs
@@ -8,6 +8,7 @@ namespace Rask.Jobs.Tests;
 ///     <c>SIGTERM</c> cancelled a handler mid-call — a job halfway through a <c>SaveChangesAsync</c> was
 ///     simply torn in two and re-run whole on the next boot.
 /// </summary>
+[Collection(JobsDbCollection.Name)]
 public sealed class JobShutdownGraceTests
 {
     [Fact]

--- a/tests/Rask.Jobs.Tests/JobsDbCollection.cs
+++ b/tests/Rask.Jobs.Tests/JobsDbCollection.cs
@@ -1,0 +1,33 @@
+namespace Rask.Jobs.Tests;
+
+/// <summary>
+///     The classes that build a <see cref="JobsDbContext" />, run as one xUnit collection so they do not
+///     run in parallel with each other.
+/// </summary>
+/// <remarks>
+///     <para>
+///         EF Core's model cache is <b>per process, keyed on the context type</b> — not per
+///         <c>ServiceProvider</c>. Each of these classes builds its own provider over its own SQLite
+///         file and they still share one <c>IModelSource</c> and one <c>IModel</c> instance, so the
+///         first test in each class racing to first-touch <c>JobsDbContext</c>'s model is two threads
+///         driving one piece of EF-internal state. That is the shape that made the Outbox suite fail
+///         the gate in #769 with "The model must be finalized and its runtime dependencies must be
+///         initialized before 'GetRelationalModel' can be used", on a diff that touched none of it.
+///     </para>
+///     <para>
+///         Unobserved here, and serialised anyway: the failure is not reproducible in isolation — a
+///         targeted 16-thread repro of the Outbox one stayed green about thirty times, idle and under
+///         load, and only appeared on the full-solution gate. Waiting for it to be observed means
+///         waiting for a red gate on an unrelated diff.
+///     </para>
+///     <para>
+///         It costs the suite nothing measurable: these are a handful of SQLite integration tests, and
+///         the ones with real budgets spend their time waiting rather than working. Tests <i>within</i>
+///         a class already ran serially, so nothing here changes their meaning.
+///     </para>
+/// </remarks>
+[CollectionDefinition(Name)]
+public sealed class JobsDbCollection
+{
+    public const string Name = "jobs-db";
+}

--- a/tests/Rask.Jobs.Tests/JobsDbCollectionGuardTests.cs
+++ b/tests/Rask.Jobs.Tests/JobsDbCollectionGuardTests.cs
@@ -1,0 +1,20 @@
+using Rask.Tests.Shared;
+
+namespace Rask.Jobs.Tests;
+
+// In the collection it guards, so it costs the suite nothing and needs no exemption of its own.
+[Collection(JobsDbCollection.Name)]
+public sealed class JobsDbCollectionGuardTests
+{
+    [Fact]
+    public void Every_test_class_is_collected_or_named_as_one_that_never_builds_a_context() =>
+        DbCollectionGuard.AssertEveryTestClassIsCollected(
+            typeof(JobsDbCollectionGuardTests).Assembly,
+            JobsDbCollection.Name,
+            // Pure unit tests: options validation and the process-global serializer registry, which
+            // takes a lock and installs its lookup in a single store, and is driven here through
+            // per-test group keys — so there is no context and nothing to serialise.
+            "JobOptionsTests",
+            "JobSerializerRegistryTests",
+            "JobSerializerRegistryReplaceTests");
+}

--- a/tests/Rask.Jobs.Tests/MissingLeaseColumnTests.cs
+++ b/tests/Rask.Jobs.Tests/MissingLeaseColumnTests.cs
@@ -7,6 +7,7 @@ namespace Rask.Jobs.Tests;
 /// would otherwise be silent: the exception is swallowed by the cycle's catch, so the app looks healthy
 /// while logging the same error every poll and never processing a job again.
 /// </summary>
+[Collection(JobsDbCollection.Name)]
 public sealed class MissingLeaseColumnTests
 {
     [Fact]

--- a/tests/Rask.Jobs.Tests/Rask.Jobs.Tests.csproj
+++ b/tests/Rask.Jobs.Tests/Rask.Jobs.Tests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared.DbCollection\DbCollectionGuard.cs" Link="DbCollectionGuard.cs"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Rask.Mail.Tests/MailDbCollection.cs
+++ b/tests/Rask.Mail.Tests/MailDbCollection.cs
@@ -1,0 +1,18 @@
+namespace Rask.Mail.Tests;
+
+/// <summary>
+///     The classes that build a <see cref="MailDbContext" />, run as one xUnit collection so they do
+///     not run in parallel with each other. See <c>Rask.Jobs.Tests.JobsDbCollection</c> for why the
+///     shape is a race — EF Core's model cache is per process and keyed on the context type, so a
+///     per-class <c>ServiceProvider</c> over a per-class SQLite file still shares one <c>IModel</c>.
+/// </summary>
+/// <remarks>
+///     <c>MailUnitTests</c> is deliberately not in the collection: it names <c>MailDbContext</c> only
+///     as the type argument to <c>AddRaskMail</c> while asserting option validation, and never builds
+///     a context.
+/// </remarks>
+[CollectionDefinition(Name)]
+public sealed class MailDbCollection
+{
+    public const string Name = "mail-db";
+}

--- a/tests/Rask.Mail.Tests/MailDbCollectionGuardTests.cs
+++ b/tests/Rask.Mail.Tests/MailDbCollectionGuardTests.cs
@@ -1,0 +1,19 @@
+using Rask.Tests.Shared;
+
+namespace Rask.Mail.Tests;
+
+// In the collection it guards, so it costs the suite nothing and needs no exemption of its own.
+[Collection(MailDbCollection.Name)]
+public sealed class MailDbCollectionGuardTests
+{
+    [Fact]
+    public void Every_test_class_is_collected_or_named_as_one_that_never_builds_a_context() =>
+        DbCollectionGuard.AssertEveryTestClassIsCollected(
+            typeof(MailDbCollectionGuardTests).Assembly,
+            MailDbCollection.Name,
+            // Names MailDbContext only as the type argument to AddRaskMail while asserting option
+            // validation; never builds a context.
+            "MailUnitTests",
+            // Reads the metrics counters the processor emits — no context of its own.
+            "MailMetricsTests");
+}

--- a/tests/Rask.Mail.Tests/MailProcessorTests.cs
+++ b/tests/Rask.Mail.Tests/MailProcessorTests.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Rask.Mail.Tests;
 
+[Collection(MailDbCollection.Name)]
 public sealed partial class MailProcessorTests : global::Rask.Core.RaskMarkup
 {
     private static Email SampleEmail() =>

--- a/tests/Rask.Mail.Tests/MailShutdownGraceTests.cs
+++ b/tests/Rask.Mail.Tests/MailShutdownGraceTests.cs
@@ -6,6 +6,7 @@ namespace Rask.Mail.Tests;
 ///     transaction, so a send cancelled mid-conversation may already have been accepted by the server while
 ///     the row still reads unsent — and the next boot sends it again.
 /// </summary>
+[Collection(MailDbCollection.Name)]
 public sealed class MailShutdownGraceTests
 {
     [Fact]

--- a/tests/Rask.Mail.Tests/Rask.Mail.Tests.csproj
+++ b/tests/Rask.Mail.Tests/Rask.Mail.Tests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared.DbCollection\DbCollectionGuard.cs" Link="DbCollectionGuard.cs"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Rask.Outbox.Tests/OutboxDbCollectionGuardTests.cs
+++ b/tests/Rask.Outbox.Tests/OutboxDbCollectionGuardTests.cs
@@ -1,0 +1,19 @@
+using Rask.Tests.Shared;
+
+namespace Rask.Outbox.Tests;
+
+// In the collection it guards, so it costs the suite nothing and needs no exemption of its own.
+[Collection(OutboxDbCollection.Name)]
+public sealed class OutboxDbCollectionGuardTests
+{
+    [Fact]
+    public void Every_test_class_is_collected_or_named_as_one_that_never_builds_a_context() =>
+        DbCollectionGuard.AssertEveryTestClassIsCollected(
+            typeof(OutboxDbCollectionGuardTests).Assembly,
+            OutboxDbCollection.Name,
+            // The process-global serializer registry, driven through per-test group keys. It rebuilds
+            // its lookup under a lock and installs it in a single volatile store, so a reader observes
+            // either the whole old map or the whole new one — concurrent use is the design, not a race.
+            "OutboxSerializerRegistryTests",
+            "OutboxSerializerRegistryReplaceTests");
+}

--- a/tests/Rask.Outbox.Tests/Rask.Outbox.Tests.csproj
+++ b/tests/Rask.Outbox.Tests/Rask.Outbox.Tests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared.DbCollection\DbCollectionGuard.cs" Link="DbCollectionGuard.cs"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Shared.DbCollection/DbCollectionGuard.cs
+++ b/tests/Shared.DbCollection/DbCollectionGuard.cs
@@ -1,0 +1,96 @@
+using System.Reflection;
+
+namespace Rask.Tests.Shared;
+
+/// <summary>
+///     Asserts that every test class in a suite backed by one shared <c>DbContext</c> is either in the
+///     xUnit collection that serialises them, or named as an exception.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The race this defends is not reproducible on demand. EF Core's model cache is per process and
+///         keyed on the context type — not per <c>ServiceProvider</c> — so two test classes racing to
+///         first-touch one context drive a single <c>IModel</c> from two threads, and that only ever
+///         surfaced on the full-solution gate (#769, #772). A guard that waits for the race to happen is
+///         a guard that never fires. This one fires when the <i>shape</i> comes back, which is when
+///         somebody adds a test class without knowing the rule.
+///     </para>
+///     <para>
+///         It asks the question the safe way round. "Does this class build a context?" cannot be
+///         answered from metadata — these suites build theirs in a local
+///         (<c>await using var harness = new CacheHarness()</c>), which no amount of reflection over
+///         fields and signatures can see, so a guard shaped that way would pass every class for the
+///         wrong reason. So the default is <b>collected</b>, and a class that genuinely does not touch
+///         the database is listed by name at the call site. Each name is a judgement somebody made, and
+///         listing it is how the judgement gets recorded.
+///     </para>
+/// </remarks>
+public static class DbCollectionGuard
+{
+    /// <summary>
+    ///     Fails when a test class in <paramref name="assembly" /> is neither in
+    ///     <paramref name="collectionName" /> nor named in <paramref name="exempt" />.
+    /// </summary>
+    /// <param name="assembly">The test assembly to scan.</param>
+    /// <param name="collectionName">The collection that serialises the DB-touching classes.</param>
+    /// <param name="exempt">
+    ///     Classes that never build a context — pure unit tests over options, serializers and the like.
+    /// </param>
+    public static void AssertEveryTestClassIsCollected(
+        Assembly assembly, string collectionName, params string[] exempt)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        ArgumentNullException.ThrowIfNull(collectionName);
+        ArgumentNullException.ThrowIfNull(exempt);
+
+        var stale = exempt.Where(name => assembly.GetTypes().All(t => t.Name != name)).ToList();
+        Assert.True(
+            stale.Count == 0,
+            $"The exempt list names classes that no longer exist: {string.Join(", ", stale)}. "
+            + "Drop them — a stale name silently exempts nothing and hides the next one.");
+
+        var uncollected = new List<string>();
+        foreach (var type in assembly.GetTypes())
+        {
+            if (!IsTestClass(type) || exempt.Contains(type.Name, StringComparer.Ordinal))
+            {
+                continue;
+            }
+
+            if (!string.Equals(CollectionOf(type), collectionName, StringComparison.Ordinal))
+            {
+                uncollected.Add(type.Name);
+            }
+        }
+
+        Assert.True(
+            uncollected.Count == 0,
+            $"These test classes are neither in the \"{collectionName}\" collection nor exempt: "
+            + string.Join(", ", uncollected.Order(StringComparer.Ordinal))
+            + ". EF Core's model cache is per process and keyed on the context type, so a class that "
+            + "builds one and runs in parallel with another that does drives a single IModel from two "
+            + $"threads. Add [Collection(\"{collectionName}\")] — or, if the class never builds a "
+            + "context, add its name to this guard's exempt list.");
+    }
+
+    // xUnit v2's CollectionAttribute takes the name as a constructor argument and exposes no property
+    // for it, so the attribute DATA is the only place to read it back from.
+    private static string? CollectionOf(Type type)
+    {
+        foreach (var data in type.GetCustomAttributesData())
+        {
+            if (data.AttributeType == typeof(CollectionAttribute)
+                && data.ConstructorArguments is [{ Value: string name }])
+            {
+                return name;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsTestClass(Type type) =>
+        type is { IsClass: true, IsAbstract: false }
+        && type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Any(static m => m.GetCustomAttributes<FactAttribute>(inherit: true).Any());
+}


### PR DESCRIPTION
## Summary

EF Core's model cache is **per process, keyed on the context type** — not per `ServiceProvider`. Test
classes that each build their own provider over their own SQLite file still share one `IModelSource`
and one `IModel`, so the first test in each racing to first-touch it drives one piece of EF-internal
state from two threads. That is the shape that made `Rask.Outbox.Tests` fail the gate in #769 with
`The model must be finalized and its runtime dependencies must be initialized before 'GetRelationalModel'
can be used`, on a diff that touched none of it.

Four suites still had it. Their DB-touching classes now sit in one `[CollectionDefinition]` each,
exactly as #769 did for Outbox:

| Suite | Context | Classes collected |
| --- | --- | --- |
| `Rask.Jobs.Tests` | `JobsDbContext` | 6 |
| `Rask.Cache.Tests` | `CacheDbContext` | 3 |
| `Rask.Mail.Tests` | `MailDbContext` | 2 |
| `Rask.Data.Tests` | `TestDbContext` | 3 |

## Two items on the issue's list that needed no change

Reporting these is part of the fix — a list that names safe things trains people to ignore it.

- **`Rask.Dashboard.Tests` was already safe.** It carries
  `[assembly: CollectionBehavior(DisableTestParallelization = true)]`, added for a different reason
  (a static `HarnessDbContext.Mapped`), which covers this too. No change.
- **`OutboxSerializerRegistryReplaceTests` is not the same family.** `OutboxSerializerRegistry`
  rebuilds its lookup under a lock and installs it in a **single volatile store**, so a reader
  observes either the complete old map or the complete new one, never a half-built one. Concurrent
  use is its design, not an accident. The tests also drive per-test group keys, so they cannot
  disturb each other's registrations. No change.

## The guard

A shared `DbCollectionGuard` (linked into all five suites, Outbox included) fails when a test class
is neither in the collection nor named as one that never builds a context.

It asks the question the safe way round on purpose. "Does this class build a context?" cannot be
answered from metadata — these suites build theirs in a **local**
(`await using var harness = new CacheHarness()`), which no reflection over fields and signatures can
see. A guard shaped that way would report zero findings and pass every class for the wrong reason.
Defaulting to *collected* means a new test class cannot join a suite silently, and every exception
is a name somebody wrote down with a reason next to it. A stale exempt name fails too, so the list
cannot rot into a blanket.

## Testing

- All five suites pass: Jobs 53, Cache 30, Mail 23, Data 33, Outbox 26.
- Timing unchanged — 1–3 s per suite. These tests are bounded by their own waits, not by CPU.
- The guard was **proven by failing it**: removing `[Collection]` from `BulkInsertTests` fails with
  `These test classes are neither in the "data-db" collection nor exempt: BulkInsertTests`.
- The exempt lists were derived from which classes actually construct a harness, and were right on
  the first run — no class needed adding after the fact.

## Gates

- `dotnet format Rask.slnx` — clean.
- `CI=true dotnet build Rask.slnx -c Release -warnaserror -p:EnforceCodeStyleInBuild=true` — 0 warnings, 0 errors.
- `scripts/run-unit-local.sh` — passed (pre-commit).
- `scripts/run-e2e-local.sh` + watch hot-reload gate — passed (pre-push).
- No benchmark: test-only change, no product code touched.

Closes #772
