### PR TITLE
fix(native): make a NativeButton's Background and Color survive its Style on both platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,30 @@ them until tagged releases begin.
   (the factory excluded it on name *and* type; the indexer owns the word).
 
 ### Fixed
+- **`NativeButton.Background` and `Color` were ignored on iOS and thrown away by `Style` on Android.**
+  A button declared `NativeButton.Style(Filled).Background(Brand).Color(OnBrand)` painted iOS system
+  blue. No error, no warning — the props simply did nothing.
+
+  On iOS the button is driven by a `UIButtonConfiguration`, whose `BaseBackgroundColor` /
+  `BaseForegroundColor` are what you see; `UiKitViewOps` wrote `view.BackgroundColor` and
+  `SetTitleColor`, which sit behind the configuration and are never seen. `ApplyButtonStyle` also
+  assigned a **fresh** configuration on every `Style` write, so even a correct colour was discarded
+  whenever `Style` arrived last. On Android the same ordering bug in plainer form: `ApplyButtonStyle`
+  called `SetBackgroundColor` / `SetTextColor` unconditionally, wiping whatever came before it. The
+  props were order-dependent in a way nothing in the component surface hints at.
+
+  Both backends now hold the three props together in a `NativeButtonAppearance` and repaint the whole
+  of it on any write — the style first, then the explicit colours over it — so an explicit
+  `Background` / `Color` wins whatever order the patch delivers them in, which is the precedence
+  `NativeButton` already documented. Verified on an iPhone 17 Pro simulator: the pure-native showcase
+  button went from system blue to the declared `#4C1D95` with white text.
+
+  Two things found alongside it and fixed here. An **unstyled** `NativeButton` rendered Filled on iOS
+  and a bare platform button on Android — a `null` `Style` emits no prop at all, and only iOS applied
+  a default at creation, so the same tree looked different on the two platforms; Android now applies
+  the same default. And `NativeButton`'s own summary named `MaterialButton` as the Android widget,
+  where it is and always was `Button` (`docs/native.md` had it right).
+
 - **Four more test suites shared one `DbContext` across classes xUnit ran in parallel.** The shape that
   made `Rask.Outbox.Tests` fail the gate in #769 was still present in `Rask.Jobs.Tests`,
   `Rask.Cache.Tests`, `Rask.Mail.Tests` and `Rask.Data.Tests`: EF Core's model cache is **per process,

--- a/src/Rask.Native/Components/NativeButton.cs
+++ b/src/Rask.Native/Components/NativeButton.cs
@@ -3,7 +3,7 @@ using Rask.Native.Surface;
 namespace Rask.Native.Components;
 
 /// <summary>
-///     A tappable button, projected to a <c>UIButton</c> (iOS) or a <c>MaterialButton</c> (Android).
+///     A tappable button, projected to a <c>UIButton</c> (iOS) or a <c>Button</c> (Android).
 /// </summary>
 /// <remarks>Its label is its <b>children</b>, the same spelling as <c>Button["Save"]</c> on the web.</remarks>
 /// <example>

--- a/src/Rask.Native/Platforms/Android/AndroidViewOps.cs
+++ b/src/Rask.Native/Platforms/Android/AndroidViewOps.cs
@@ -122,6 +122,20 @@ internal sealed class AndroidViewOps(Context context, Action<NativeSurfaceEvent>
                 linesText.SetMaxLines(lines <= 0 ? int.MaxValue : lines);
                 break;
 
+            // Ahead of the generic colour cases on purpose. ApplyButtonStyle writes the style's own fill
+            // and title colour unconditionally, so a Style arriving after a Background or Color used to
+            // throw them away — the props were order-dependent in a way nothing in the component surface
+            // hints at (#785). Routing all three through the retained appearance and repainting the whole
+            // of it removes the ordering from the answer. Every button Create() makes is a RaskButton.
+            case NativePropId.Color or NativePropId.Background or NativePropId.Style
+                when view is RaskButton appearanceButton:
+                if (appearanceButton.ButtonAppearance.Write(id, value, unset))
+                {
+                    ApplyButtonAppearance(appearanceButton);
+                }
+
+                break;
+
             case NativePropId.Color:
                 ApplyForeground(view, unset ? null : ResolveColor(value.Text));
                 break;
@@ -136,10 +150,6 @@ internal sealed class AndroidViewOps(Context context, Action<NativeSurfaceEvent>
                     view.SetBackgroundColor(background);
                 }
 
-                break;
-
-            case NativePropId.Style when view is Button styleButton:
-                ApplyButtonStyle(styleButton, unset ? NativeButtonStyle.Filled : (NativeButtonStyle)(int)value.Number);
                 break;
 
             case NativePropId.Source when view is ImageView image:
@@ -267,6 +277,7 @@ internal sealed class AndroidViewOps(Context context, Action<NativeSurfaceEvent>
     private Button NewButton()
     {
         var button = new RaskButton(_context);
+        ApplyButtonAppearance(button);
         button.Click += (s, _) =>
         {
             if (s is RaskButton { TapId: >= 0 } b)
@@ -355,12 +366,17 @@ internal sealed class AndroidViewOps(Context context, Action<NativeSurfaceEvent>
         }
     }
 
-    private void ApplyButtonStyle(Button button, NativeButtonStyle style)
+    // The WHOLE appearance, re-derived from scratch on every write to any of its three props: the style
+    // first, then the explicit colours over it, so an explicit Background or Color wins whichever order
+    // the patch delivered them in. NativeButton documents exactly that precedence.
+    private void ApplyButtonAppearance(RaskButton button)
     {
-        switch (style)
+        var appearance = button.ButtonAppearance;
+        switch (appearance.Style)
         {
             case NativeButtonStyle.Plain:
                 button.SetBackgroundColor(Color.Transparent);
+                button.SetTextColor(Color.Argb(255, 33, 150, 243));
                 break;
             case NativeButtonStyle.Destructive:
                 button.SetBackgroundColor(Color.Argb(255, 211, 47, 47));
@@ -368,11 +384,22 @@ internal sealed class AndroidViewOps(Context context, Action<NativeSurfaceEvent>
                 break;
             case NativeButtonStyle.Tinted:
                 button.SetBackgroundColor(Color.Argb(40, 33, 150, 243));
+                button.SetTextColor(Color.Argb(255, 33, 150, 243));
                 break;
             default:
                 button.SetBackgroundColor(Color.Argb(255, 33, 150, 243));
                 button.SetTextColor(Color.White);
                 break;
+        }
+
+        if (ResolveColor(appearance.Background) is { } background)
+        {
+            button.SetBackgroundColor(background);
+        }
+
+        if (ResolveColor(appearance.Foreground) is { } foreground)
+        {
+            button.SetTextColor(foreground);
         }
     }
 
@@ -494,6 +521,10 @@ internal sealed class RaskScrollView : ScrollView
 internal sealed class RaskButton(Context context) : Button(context)
 {
     public int TapId { get; set; } = -1;
+
+    // Style, Background and Color decide one painted result together, so the button holds all three and
+    // repaints from the set — see NativeButtonAppearance.
+    public NativeButtonAppearance ButtonAppearance { get; } = new();
 }
 
 internal sealed class RaskEditText(Context context) : EditText(context)

--- a/src/Rask.Native/Platforms/iOS/UiKitViewOps.cs
+++ b/src/Rask.Native/Platforms/iOS/UiKitViewOps.cs
@@ -116,16 +116,26 @@ internal sealed class UiKitViewOps(Action<NativeSurfaceEvent> raise) : INativeVi
                 linesLabel.Lines = unset ? 0 : (nint)value.Number;
                 break;
 
+            // Ahead of the generic colour cases on purpose. A UIButton driven by a UIButtonConfiguration
+            // takes its fill from BaseBackgroundColor and its title colour from BaseForegroundColor;
+            // BackgroundColor and SetTitleColor sit BEHIND those and are never seen, so routing a button
+            // here is what makes Background and Color do anything at all (#785). Every button Create()
+            // makes is a RaskButton.
+            case NativePropId.Color or NativePropId.Background or NativePropId.Style
+                when view is RaskButton appearanceButton:
+                if (appearanceButton.ButtonAppearance.Write(id, value, unset))
+                {
+                    ApplyButtonAppearance(appearanceButton);
+                }
+
+                break;
+
             case NativePropId.Color:
                 ApplyForeground(view, unset ? null : RaskChromeContainerView.ResolveUIColor(value.Text));
                 break;
 
             case NativePropId.Background:
                 view.BackgroundColor = unset ? null : RaskChromeContainerView.ResolveUIColor(value.Text);
-                break;
-
-            case NativePropId.Style when view is UIButton styleButton:
-                ApplyButtonStyle(styleButton, unset ? NativeButtonStyle.Filled : (NativeButtonStyle)(int)value.Number);
                 break;
 
             case NativePropId.Source when view is UIImageView imageView:
@@ -243,7 +253,7 @@ internal sealed class UiKitViewOps(Action<NativeSurfaceEvent> raise) : INativeVi
     private UIButton NewButton()
     {
         var button = new RaskButton { TranslatesAutoresizingMaskIntoConstraints = false };
-        ApplyButtonStyle(button, NativeButtonStyle.Filled);
+        ApplyButtonAppearance(button);
         button.TouchUpInside += (s, _) =>
         {
             if (s is RaskButton { TapId: >= 0 } b)
@@ -418,18 +428,32 @@ internal sealed class UiKitViewOps(Action<NativeSurfaceEvent> raise) : INativeVi
         typed.Font = UIFont.SystemFontOfSize(typed.FontSize, weight);
     }
 
-    private static void ApplyButtonStyle(UIButton button, NativeButtonStyle style)
+    // The WHOLE appearance, re-derived from scratch on every write to any of its three props. Assigning a
+    // fresh UIButtonConfiguration is what a style change needs and is also what used to discard the
+    // colours: applying the explicit ones AFTER the style is what makes them win no matter which order
+    // the patch delivered them in.
+    private static void ApplyButtonAppearance(RaskButton button)
     {
-        var configuration = style switch
+        var appearance = button.ButtonAppearance;
+        var configuration = appearance.Style switch
         {
             NativeButtonStyle.Tinted => UIButtonConfiguration.TintedButtonConfiguration,
             NativeButtonStyle.Plain => UIButtonConfiguration.PlainButtonConfiguration,
-            NativeButtonStyle.Destructive => UIButtonConfiguration.FilledButtonConfiguration,
             _ => UIButtonConfiguration.FilledButtonConfiguration,
         };
-        if (style == NativeButtonStyle.Destructive)
+        if (appearance.Style == NativeButtonStyle.Destructive)
         {
             configuration.BaseBackgroundColor = UIColor.SystemRed;
+        }
+
+        if (RaskChromeContainerView.ResolveUIColor(appearance.Background) is { } background)
+        {
+            configuration.BaseBackgroundColor = background;
+        }
+
+        if (RaskChromeContainerView.ResolveUIColor(appearance.Foreground) is { } foreground)
+        {
+            configuration.BaseForegroundColor = foreground;
         }
 
         button.Configuration = configuration;
@@ -469,6 +493,10 @@ internal sealed class UiKitViewOps(Action<NativeSurfaceEvent> raise) : INativeVi
 internal sealed class RaskButton : UIButton
 {
     public int TapId { get; set; } = -1;
+
+    // Style, Background and Color decide one painted result together, so the button holds all three and
+    // repaints from the set — see NativeButtonAppearance.
+    public NativeButtonAppearance ButtonAppearance { get; } = new();
 }
 
 // Remembers the two halves of its font, which UIFont does not let you read back cleanly.

--- a/src/Rask.Native/Surface/NativeButtonAppearance.cs
+++ b/src/Rask.Native/Surface/NativeButtonAppearance.cs
@@ -1,0 +1,71 @@
+using Rask.Native.Components;
+
+namespace Rask.Native.Surface;
+
+/// <summary>
+///     The three props that together decide a button's fill and title colour — <c>Style</c>,
+///     <c>Background</c> and <c>Color</c> — kept as one piece of state so the painted result does not
+///     depend on the order they arrive in.
+/// </summary>
+/// <remarks>
+///     <para>
+///         A backend that paints each prop as it arrives gets the wrong answer the moment <c>Style</c>
+///         lands last: a style carries its own fill and title colour, so applying it discards the
+///         explicit colours applied before it. Both backends did exactly that (#785) — iOS by assigning
+///         a fresh <c>UIButtonConfiguration</c>, Android by calling <c>SetBackgroundColor</c> /
+///         <c>SetTextColor</c> unconditionally — which made two identical component trees paint
+///         differently for no reason the component surface hints at.
+///     </para>
+///     <para>
+///         <c>NativeButton</c> already documents the rule: an explicit <c>Background</c> / <c>Color</c>
+///         wins, and <see langword="null" /> lets <c>Style</c> decide. Holding all three and re-deriving
+///         the pair on every write is what makes that rule true whatever order the patch applies them
+///         in, and keeping it here means it is stated once rather than twice in platform code no test
+///         on a build machine can reach.
+///     </para>
+///     <para>
+///         A class rather than a struct on purpose: the backends hold this on the retained view and
+///         mutate it in place, and a mutable struct behind a property would take the write on a copy
+///         and silently lose it — the same class of bug one level down.
+///     </para>
+/// </remarks>
+public sealed class NativeButtonAppearance
+{
+    /// <summary>The visual treatment. <see cref="NativeButtonStyle.Filled" /> until a patch says otherwise.</summary>
+    public NativeButtonStyle Style { get; private set; } = NativeButtonStyle.Filled;
+
+    /// <summary>The explicit fill colour, or <see langword="null" /> to let <see cref="Style" /> decide.</summary>
+    public string? Background { get; private set; }
+
+    /// <summary>The explicit title colour, or <see langword="null" /> to let <see cref="Style" /> decide.</summary>
+    public string? Foreground { get; private set; }
+
+    /// <summary>Records one prop write, if it is one of the three that decide the appearance.</summary>
+    /// <param name="id">The prop being written.</param>
+    /// <param name="value">Its value; ignored when <paramref name="unset" /> is <see langword="true" />.</param>
+    /// <param name="unset">Whether the prop is being cleared rather than set.</param>
+    /// <returns>
+    ///     <see langword="true" /> when the appearance changed and the caller must repaint the whole of
+    ///     it — never just the prop that arrived.
+    /// </returns>
+    public bool Write(NativePropId id, NativePropValue value, bool unset)
+    {
+        switch (id)
+        {
+            case NativePropId.Style:
+                Style = unset ? NativeButtonStyle.Filled : (NativeButtonStyle)(int)value.Number;
+                return true;
+
+            case NativePropId.Background:
+                Background = unset ? null : value.Text;
+                return true;
+
+            case NativePropId.Color:
+                Foreground = unset ? null : value.Text;
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}

--- a/tests/Rask.Native.Tests/Surface/NativeButtonAppearanceTests.cs
+++ b/tests/Rask.Native.Tests/Surface/NativeButtonAppearanceTests.cs
@@ -1,0 +1,119 @@
+using Rask.Native.Components;
+using Rask.Native.Surface;
+
+namespace Rask.Native.Tests.Surface;
+
+/// <summary>
+///     The rule a button's three appearance props obey, pinned where a build machine can reach it.
+/// </summary>
+/// <remarks>
+///     <para>
+///         #785: <c>Background</c> and <c>Color</c> were silently ignored on iOS and were discarded on
+///         Android whenever <c>Style</c> was applied after them. The unit suite could not see it —
+///         <c>FakeNativeSurface</c> asserts the emitted patch, and the patch was always right; the loss
+///         happened inside the platform backend, which only a device or simulator exercises.
+///     </para>
+///     <para>
+///         So the property worth pinning is not "what colour did UIKit paint" but "does the answer
+///         depend on the order the props arrive in" — which is the actual defect, is platform-free, and
+///         is what both backends now derive their paint from.
+///     </para>
+/// </remarks>
+public sealed class NativeButtonAppearanceTests
+{
+    private const string Brand = "#7C3AED";
+    private const string OnBrand = "#FFFFFF";
+
+    public static TheoryData<NativePropId[]> EveryOrder()
+    {
+        var data = new TheoryData<NativePropId[]>();
+        NativePropId[] props = [NativePropId.Style, NativePropId.Background, NativePropId.Color];
+        foreach (var a in props)
+        {
+            foreach (var b in props)
+            {
+                foreach (var c in props)
+                {
+                    if (a != b && b != c && a != c)
+                    {
+                        data.Add([a, b, c]);
+                    }
+                }
+            }
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(EveryOrder))]
+    public void The_same_three_writes_land_the_same_way_in_any_order(NativePropId[] order)
+    {
+        var appearance = new NativeButtonAppearance();
+
+        foreach (var id in order)
+        {
+            var value = id switch
+            {
+                NativePropId.Style => NativePropValue.FromNumber((int)NativeButtonStyle.Filled),
+                NativePropId.Background => NativePropValue.FromText(Brand),
+                _ => NativePropValue.FromText(OnBrand),
+            };
+
+            Assert.True(appearance.Write(id, value, unset: false), $"{id} must be an appearance prop");
+        }
+
+        Assert.Equal(NativeButtonStyle.Filled, appearance.Style);
+        Assert.Equal(Brand, appearance.Background);
+        Assert.Equal(OnBrand, appearance.Foreground);
+    }
+
+    [Fact]
+    public void A_style_written_last_does_not_discard_the_colours_written_before_it()
+    {
+        // The exact sequence from the report: an explicit brand pair, then the style. Applying each
+        // prop as it arrived is what made this paint system blue.
+        var appearance = new NativeButtonAppearance();
+        appearance.Write(NativePropId.Background, NativePropValue.FromText(Brand), unset: false);
+        appearance.Write(NativePropId.Color, NativePropValue.FromText(OnBrand), unset: false);
+        appearance.Write(
+            NativePropId.Style, NativePropValue.FromNumber((int)NativeButtonStyle.Destructive), unset: false);
+
+        Assert.Equal(NativeButtonStyle.Destructive, appearance.Style);
+        Assert.Equal(Brand, appearance.Background);
+        Assert.Equal(OnBrand, appearance.Foreground);
+    }
+
+    [Fact]
+    public void Clearing_a_colour_hands_the_decision_back_to_the_style()
+    {
+        var appearance = new NativeButtonAppearance();
+        appearance.Write(NativePropId.Background, NativePropValue.FromText(Brand), unset: false);
+        appearance.Write(NativePropId.Background, NativePropValue.Unset, unset: true);
+
+        Assert.Null(appearance.Background);
+        Assert.Equal(NativeButtonStyle.Filled, appearance.Style);
+    }
+
+    [Fact]
+    public void Clearing_the_style_returns_it_to_filled_and_leaves_the_colours_alone()
+    {
+        var appearance = new NativeButtonAppearance();
+        appearance.Write(
+            NativePropId.Style, NativePropValue.FromNumber((int)NativeButtonStyle.Plain), unset: false);
+        appearance.Write(NativePropId.Background, NativePropValue.FromText(Brand), unset: false);
+        appearance.Write(NativePropId.Style, NativePropValue.Unset, unset: true);
+
+        Assert.Equal(NativeButtonStyle.Filled, appearance.Style);
+        Assert.Equal(Brand, appearance.Background);
+    }
+
+    [Fact]
+    public void A_prop_that_does_not_decide_the_appearance_is_declined_so_the_caller_does_not_repaint()
+    {
+        var appearance = new NativeButtonAppearance();
+
+        Assert.False(appearance.Write(NativePropId.Text, NativePropValue.FromText("Tap me"), unset: false));
+        Assert.False(appearance.Write(NativePropId.Padding, NativePropValue.FromNumber(8), unset: false));
+    }
+}


### PR DESCRIPTION
## Summary

`NativeButton.Background(...)` and `.Color(...)` were **silently ignored on iOS** and **thrown away by
`Style` on Android**. The showcase's own button —

```csharp
NativeButton.Style(NativeButtonStyle.Filled).Background(Brand).Color(OnBrand)
    .OnClick(() => _taps++)["Tap me"]
```

— painted iOS system blue. No error, no warning.

**iOS.** The button is driven by a `UIButtonConfiguration`, whose `BaseBackgroundColor` /
`BaseForegroundColor` are what you actually see. `UiKitViewOps` wrote `view.BackgroundColor`
(`:123`) and `SetTitleColor` (`:381`), which sit *behind* the configuration and are never seen.
`ApplyButtonStyle` (`:421`) also assigned a **fresh** configuration on every `Style` write, so even a
correct colour was discarded when `Style` landed last. `Destructive` was the only style that visibly
honoured a colour, because it was the only one reaching the configuration.

**Android.** The same ordering bug in plainer form: `ApplyButtonStyle` called `SetBackgroundColor` /
`SetTextColor` unconditionally, wiping whatever was applied before it.

Either way the props were **order-dependent** in a way nothing in the component surface hints at.

## What changed

Both backends now hold the three appearance props together in a platform-free
`NativeButtonAppearance` and repaint the **whole** of it on any write — the style first, then the
explicit colours over it. An explicit `Background` / `Color` therefore wins whatever order the patch
delivers them in, which is the precedence `NativeButton` already documented ("Leave `null` to let
`Style` decide"). The rule now lives in one place instead of twice inside platform code that no
build machine runs.

## Two more of the same family, found while in there

- **An unstyled `NativeButton` looked different on the two platforms.** A `null` `Style` emits *no
  prop* (`NativePropWriter.Number` skips nulls), and only iOS applied a default at creation — so iOS
  rendered Filled and Android rendered a bare platform button, from one identical tree. Android now
  applies the same default, which is what the component documents.
- **`NativeButton`'s summary named `MaterialButton`** as the Android widget. It is `Button`, and
  always was — `docs/native.md` already had it right.

## Testing

- **Verified on an iPhone 17 Pro simulator** with the pure-native showcase screen. Before: system
  blue. After: the declared `#4C1D95` with white text. Same tree, same sample, only the iOS backend
  differing — the "before" shot was taken by reverting `UiKitViewOps.cs` to `HEAD` and rebuilding.
- **10 unit tests** (`NativeButtonAppearanceTests`) pin the property the bug actually violated: that
  the painted result does not depend on the order the three props arrive in. All six permutations,
  plus the exact reported sequence, clearing a colour back to the style's, and declining a prop that
  is not part of the appearance so the caller does not repaint.

  This is deliberately not a test of "what colour did UIKit paint" — `FakeNativeSurface` asserts the
  emitted patch and the patch was always correct; the loss happened inside the platform backend,
  which only a device or simulator exercises. Order-independence is the defect, is platform-free, and
  is what both backends now derive their paint from.
- The iOS head builds clean at `-warnaserror`. **Android could not be compiled locally** — the
  workload is installed but the Android SDK is not (`XA5300`), which matches this repo's CI-only
  practice for the Android head. The `native (…, net10.0-android)` CI jobs cover it.

## Gates

- `dotnet format Rask.slnx` — clean.
- `CI=true dotnet build Rask.slnx -c Release -warnaserror -p:EnforceCodeStyleInBuild=true` — 0 warnings, 0 errors.
- `dotnet build src/Rask.Native -c Release -p:RaskNativeHeads=ios -warnaserror` — 0 warnings, 0 errors.
- `scripts/run-unit-local.sh` — passed (pre-commit).
- `scripts/run-e2e-local.sh` + watch hot-reload gate — passed (pre-push).
- No benchmark: platform backend code, off the render hot path.

Closes #785
