### PR TITLE
test(cli): compile the native template so no scaffolded project can reach a user broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,27 @@ them until tagged releases begin.
   (the factory excluded it on name *and* type; the indexer owns the word).
 
 ### Fixed
+- **No `rask new` template can reach a user uncompiled any more.** `CliBuildE2E` packs this commit's
+  packages to a local feed and runs a real `dotnet build -warnaserror` over what the CLI writes, and it
+  covered the server, wasm and wasm-hosted templates. It could not cover the **native** one: building
+  that needs the iOS and Android workloads the Ubuntu runner does not have. The templates are raw
+  strings, so no in-repo build compiles them either — which left the native template verified by
+  nothing at all.
+
+  That gap was not theoretical. Dropping the factory turned every factory call in a template into
+  `CS1955`; the packaged gate caught the one in the `--auth` LoginPage exactly as designed and could
+  not see the one in the native App shell, so `rask new --template native` would have shipped a project
+  that does not compile — the template a beginner is least able to debug.
+
+  `NativeTemplateCompileTests` now takes the cheaper half of the job and runs it **always**, with no
+  workloads, no packing and no network: a Roslyn compilation over the template's own component code
+  against this commit's assemblies, with the real generators running, over each platform selection.
+  Its global usings are read from the props `Rask.Native` ships rather than restated, so the gate keeps
+  tracking what a scaffolded project actually gets. Proven by reintroducing the shipped break: the gate
+  reports `App.cs(23,9): error CS1955: Non-invocable member 'RaskMarkup.Html' cannot be used like a
+  method` — the exact diagnostic that went unseen. A negative control pins that the harness really
+  binds the chain, so a gate that quietly compiled nothing could not pass for a gate that compiles
+  everything.
 - **`NativeButton.Background` and `Color` were ignored on iOS and thrown away by `Style` on Android.**
   A button declared `NativeButton.Style(Filled).Background(Brand).Color(OnBrand)` painted iOS system
   blue. No error, no warning — the props simply did nothing.

--- a/tests/Rask.Cli.Tests/NativeTemplateCompileTests.cs
+++ b/tests/Rask.Cli.Tests/NativeTemplateCompileTests.cs
@@ -1,0 +1,180 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Rask.Cli.Scaffolding;
+using Rask.Generators;
+
+namespace Rask.Cli.Tests;
+
+/// <summary>
+///     Compiles the C# that <c>rask new --template native</c> writes, against the in-repo Rask assemblies
+///     and the real generator.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <see cref="CliBuildE2E" /> packs this commit's packages and runs a real <c>dotnet build</c> over
+///         what the CLI writes, and it covers the server, wasm and wasm-hosted templates. It cannot cover
+///         the <b>native</b> one: building that needs the iOS and Android workloads, which the Ubuntu
+///         runner does not have. The templates are raw strings, so no in-repo build compiles them either —
+///         which left the native template verified by nothing at all.
+///     </para>
+///     <para>
+///         That gap was not theoretical. Dropping the factory (#792) turned every factory call in a
+///         template into <c>CS1955</c>. The packaged gate caught the one in the <c>--auth</c> LoginPage
+///         exactly as designed and could not see the one in the native App shell, so
+///         <c>rask new --template native</c> would have handed somebody a project that does not compile —
+///         and the native template is the one a beginner is least able to debug (#795).
+///     </para>
+///     <para>
+///         So this gate takes the cheaper half of the job and runs it <b>always</b>, with no workloads, no
+///         packing and no network: a Roslyn compilation over the template's own component code with
+///         <see cref="ComponentFactoryGenerator" /> and <see cref="RoutesGenerator" /> running, which is
+///         exactly the markup-surface class of break that actually happened. The platform heads under
+///         <c>Platforms/</c> are left to the workload-bearing build — they are UIKit and Android glue, not
+///         markup, and nothing in the chain's surface can break them.
+///     </para>
+/// </remarks>
+public sealed class NativeTemplateCompileTests
+{
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void The_native_templates_component_code_compiles(bool ios, bool android)
+    {
+        var diagnostics = CompileTemplateComponents(ios, android);
+
+        Assert.True(
+            diagnostics.Length == 0,
+            "rask new --template native emitted component code that does not compile:\n"
+            + string.Join("\n", diagnostics.Select(d => d.ToString())));
+    }
+
+    /// <summary>
+    ///     The negative control. A gate that compiles nothing reports no errors, which is indistinguishable
+    ///     from a gate that compiles everything — so this proves the harness actually binds the chain and
+    ///     would fail on the break it exists to catch.
+    /// </summary>
+    [Fact]
+    public void The_harness_reports_the_factory_call_the_shipped_break_was()
+    {
+        // `Html(...)` is the factory spelling #792 removed: the chain entry is a property, so calling it
+        // is CS1955 "Non-invocable member cannot be used like a method" — the exact diagnostic that
+        // reached the native template unseen.
+        var diagnostics = Compile([("App.cs", """
+            namespace Probe;
+
+            public sealed partial class Probe : global::Rask.Core.Component
+            {
+                protected override global::Rask.Core.Component? Render() => Html("en");
+            }
+            """)]);
+
+        Assert.Contains(diagnostics, d => d.Id == "CS1955");
+    }
+
+    private static ImmutableArray<Diagnostic> CompileTemplateComponents(bool ios, bool android)
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "rask-native-template-" + Guid.NewGuid().ToString("N"));
+        var result = ProjectGenerator.GenerateNative(directory, "NativeProbe", "native", "1.0.0", ios, android);
+
+        // The component code only. Platforms/ is UIKit and Android glue that needs the workloads, and the
+        // csproj / manifests are not C# at all.
+        var sources = result.Files
+            .Where(f => f.Path.EndsWith(".cs", StringComparison.Ordinal)
+                && f.Path.Contains(Path.DirectorySeparatorChar + "Features" + Path.DirectorySeparatorChar,
+                    StringComparison.Ordinal))
+            .Select(f => (Path.GetFileName(f.Path), f.Content))
+            .ToArray();
+
+        // If the template stops writing component code, this gate would pass by compiling nothing.
+        Assert.NotEmpty(sources);
+
+        return Compile(sources);
+    }
+
+    private static ImmutableArray<Diagnostic> Compile((string Name, string Source)[] sources)
+    {
+        var trees = sources
+            .Append((Name: "GlobalUsings.cs", Source: GlobalUsings()))
+            .Select(s => CSharpSyntaxTree.ParseText(
+                s.Source, new CSharpParseOptions(LanguageVersion.Latest), s.Name))
+            .ToArray();
+
+        var compilation = CSharpCompilation.Create(
+            "NativeProbe",
+            trees,
+            References(),
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+
+        CSharpGeneratorDriver
+            .Create(new ComponentFactoryGenerator(), new RoutesGenerator())
+            .WithUpdatedParseOptions(new CSharpParseOptions(LanguageVersion.Latest))
+            .RunGeneratorsAndUpdateCompilation(compilation, out var generated, out _);
+
+        return generated.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToImmutableArray();
+    }
+
+    /// <summary>
+    ///     The global usings a scaffolded native project actually gets, read from the props
+    ///     <c>Rask.Native</c> ships rather than restated here.
+    /// </summary>
+    /// <remarks>
+    ///     These are load-bearing, not cosmetic: without <c>Rask.Core</c> in scope the template's classes
+    ///     do not resolve <c>Component</c>, so they are not components, so the generator injects no chain
+    ///     entries and every <c>Div</c> / <c>H1</c> in the page becomes CS0103. A hard-coded copy would
+    ///     drift silently and start failing this gate for a reason that has nothing to do with the
+    ///     template, so the props file is the source of truth — the same file the package installs.
+    /// </remarks>
+    private static string GlobalUsings()
+    {
+        var props = XDocument.Load(
+            Path.Combine(CliBuildE2E.FindRepoRoot(), "src", "Rask.Native", "build", "Rask.Native.props"));
+
+        var usings = props.Descendants("Using")
+            .Select(e => (Namespace: (string?)e.Attribute("Include"), Alias: (string?)e.Attribute("Alias")))
+            .Where(u => u.Namespace is { Length: > 0 })
+            .Select(u => u.Alias is { Length: > 0 } alias
+                ? $"global using {alias} = {u.Namespace};"
+                : $"global using {u.Namespace};")
+            .ToList();
+
+        Assert.NotEmpty(usings);
+
+        // What <ImplicitUsings>enable</ImplicitUsings> adds on top, which the generated csproj sets.
+        usings.AddRange([
+            "global using System;",
+            "global using System.Collections.Generic;",
+            "global using System.IO;",
+            "global using System.Linq;",
+            "global using System.Net.Http;",
+            "global using System.Threading;",
+            "global using System.Threading.Tasks;",
+        ]);
+
+        return string.Join("\n", usings);
+    }
+
+    // The runtime's own reference set plus every Rask assembly a native project references. Loading them
+    // by name pins the gate to THIS commit's assemblies, which is the whole point — a template has to
+    // compile against the code it ships beside.
+    private static ImmutableArray<MetadataReference> References()
+    {
+        var refs = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty)
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .ToList();
+
+        foreach (var name in new[] { "Rask.Core", "Rask.Html", "Rask.Chrome", "Rask.Native" })
+        {
+            refs.Add(MetadataReference.CreateFromFile(Assembly.Load(name).Location));
+        }
+
+        return [.. refs];
+    }
+}

--- a/tests/Rask.Cli.Tests/Rask.Cli.Tests.csproj
+++ b/tests/Rask.Cli.Tests/Rask.Cli.Tests.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <!-- Spectre's own test doubles: `TestConsoleInput` scripts the key presses an interactive
          SelectionPrompt reads, which a StringReader of whole lines cannot express. -->
@@ -31,6 +32,19 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Rask.Cli\Rask.Cli.csproj"/>
+  </ItemGroup>
+
+  <!-- NativeTemplateCompileTests compiles what `rask new` writes for the native template, against THIS
+       commit's assemblies and the real generator. CliBuildE2E cannot: building the native template
+       needs the iOS/Android workloads the Ubuntu runner does not have, and the templates are raw
+       strings, so nothing else in the repo compiles them at all (#795). Referenced as plain libraries
+       (the generator is driven explicitly by the test, not run over this project's own sources). -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Html\Rask.Html.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Chrome\Rask.Chrome.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Native\Rask.Native.csproj"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

`CliBuildE2E` packs this commit's packages to a local feed and runs a real
`dotnet build -warnaserror` over what `rask new` writes. It covers the server, wasm and wasm-hosted
templates. It cannot cover the **native** one — building that needs the iOS/Android workloads the
Ubuntu runner does not have — and the templates are raw strings, so no in-repo build compiles them
either. The native template was verified by nothing at all.

That gap shipped. Dropping the factory (#792) turned every factory call in a template into `CS1955`.
The packaged gate caught the one in the `--auth` LoginPage exactly as designed, and could not see the
one in the native App shell:

```csharp
// src/Rask.Cli/Scaffolding/ProjectGenerator.Native.cs
protected override Component Shell(Component head, Component body) =>
    Html("en")[ ... ]        // CS1955: Non-invocable member 'RaskMarkup.Html' cannot be used like a method
```

`rask new --template native` would have handed somebody a project that does not compile — the
template a beginner is least able to debug. It was fixed in #792 only because somebody read it.

## What changed

`NativeTemplateCompileTests` takes the second option the issue suggests — compile the scaffolded text
against the in-repo assemblies — and runs it **always**: no workloads, no packing, no network, no
`RASK_CLI_BUILD_E2E` opt-in. A Roslyn compilation over the template's own component code against
**this commit's** `Rask.Core` / `Rask.Html` / `Rask.Chrome` / `Rask.Native`, with
`ComponentFactoryGenerator` and `RoutesGenerator` running, for each platform selection (iOS+Android,
iOS-only, Android-only).

The `Platforms/` heads are left to the workload-bearing build. They are UIKit and Android glue, not
markup, and nothing in the chain's surface can break them.

Two details that decide whether this gate is real:

- **The global usings are read from `src/Rask.Native/build/Rask.Native.props`**, not restated. They
  are load-bearing rather than cosmetic: without `Rask.Core` in scope the template's classes do not
  resolve `Component`, so they are not components, so the generator injects no chain entries and every
  `Div` / `H1` in the page becomes `CS0103`. A hand-copied list would drift and start failing this
  gate for reasons having nothing to do with the template.
- **The test asserts it found sources before compiling them.** If the template stops writing component
  code, the gate would otherwise pass by compiling nothing.

## Testing

- **Proven by failing it.** Reintroducing `Html("en")[` into the template makes all three platform
  cases fail with the exact diagnostic that shipped unseen:

  ```
  App.cs(23,9): error CS1955: Non-invocable member 'RaskMarkup.Html' cannot be used like a method.
  ```

  Restoring the template returns all four tests to green.
- A **negative control** (`The_harness_reports_the_factory_call_the_shipped_break_was`) compiles a
  probe carrying the factory spelling and requires `CS1955`, so a harness that quietly bound nothing
  cannot pass for one that binds the chain.
- Runs in under a second — it is a compilation, not a build.

## Gates

- `dotnet format Rask.slnx` — clean.
- `CI=true dotnet build Rask.slnx -c Release -warnaserror -p:EnforceCodeStyleInBuild=true` — 0 warnings, 0 errors.
- `scripts/run-unit-local.sh` — passed (pre-commit).
- `scripts/run-e2e-local.sh` + watch hot-reload gate — passed (pre-push).
- No benchmark: test-only change, no product code touched.

Closes #795
