### PR TITLE
perf(forms): drop the Accessor's redundant delegates and decompose the bound-control pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,34 @@ them until tagged releases begin.
   (the factory excluded it on name *and* type; the indexer owns the word).
 
 ### Fixed
+- **A bound form control allocated less, and the pin that guards it now says which layer moved.**
+  `ExpressionAccessor.Accessor` carried a `Func<object?> Getter` and an `Action<object?> Setter` that
+  closed over the same `Target` and `Property` the record already held. They were rebuilt on every
+  `Parse`, which is every render of every bound control (`Input` / `Select` / `Textarea` / `Bs*`), for
+  a display class and two delegates that told nobody anything. They are methods now; every call site
+  still reads `acc.Getter()`. The bound probe went **5195 → 5034 B/render**.
+
+  The bigger result is the measurement. #793 recorded 5163 B/render against 3555 B on 2026-08-08 and
+  could not say where the difference went, because one aggregate ceiling cannot. Decomposed:
+
+  | | B/render |
+  | --- | --- |
+  | bare `Div` | 1088 |
+  | `Div[Input.Value(…)]` — controlled | 1216 |
+  | `Div[Input.Bind(hoisted)]` — bound, expression built once | 2723 |
+  | `Div[Input.Bind(() => …)]` — bound | 5034 |
+
+  **2311 B — 46% of the total — is the C# compiler building an `Expression<Func<T>>` at the call site
+  on every render.** That is not Rask code and nothing here can make it cheaper; only the shape of the
+  public `Bind` API could. So this probe cannot go below roughly 3500 B however good the bind path
+  gets — which is already above the 3555 B the old comment recorded, so that number cannot have been
+  measuring this shape and is not a baseline to chase. Rask's own share is the remaining 1507 B.
+
+  Those three layers are now three **absolute** pins rather than one. A relative pin is what let the
+  original regression hide, so they decompose the cost without reintroducing that: a regression in the
+  shared element path trips the controlled pin, one in the bind path trips the hoisted pin, and either
+  trips the aggregate — whose ceiling drops from 5600 B to 5300 B.
+
 - **No `rask new` template can reach a user uncompiled any more.** `CliBuildE2E` packs this commit's
   packages to a local feed and runs a real `dotnet build -warnaserror` over what the CLI writes, and it
   covered the server, wasm and wasm-hosted templates. It could not cover the **native** one: building

--- a/src/Rask.Core/Forms/ExpressionAccessor.cs
+++ b/src/Rask.Core/Forms/ExpressionAccessor.cs
@@ -88,14 +88,7 @@ public static class ExpressionAccessor
                      ?? throw new InvalidOperationException(
                          $"Bind expression target evaluated to null: {expression}");
 
-        return new Accessor(
-            target,
-            prop,
-            () => prop.GetValue(target),
-            v => prop.SetValue(target, v))
-        {
-            Owner = FindRootConstant(me),
-        };
+        return new Accessor(target, prop) { Owner = FindRootConstant(me) };
     }
 
     // Evaluates the target sub-expression (everything left of the terminal property) with plain
@@ -241,12 +234,22 @@ public static class ExpressionAccessor
     // Caveat: if the target is a value type (e.g. binding `() => structLocal.Field`), Target is a boxed
     // copy, so Setter writes to that copy, not the original — value-type targets are read-only in practice.
     // Bind to properties of reference-type models (the normal case) for round-tripping writes.
-    public sealed record Accessor(
-        object Target,
-        PropertyInfo Property,
-        Func<object?> Getter,
-        Action<object?> Setter)
+    public sealed record Accessor(object Target, PropertyInfo Property)
     {
+        /// <summary>Reads the terminal property off <see cref="Target" />.</summary>
+        /// <remarks>
+        ///     A method rather than the <c>Func&lt;object?&gt;</c> this used to carry. The delegate held
+        ///     nothing the record did not already have — it closed over the same <c>Target</c> and
+        ///     <c>Property</c> — and building it cost a display class and two delegates on <b>every
+        ///     Parse</b>, which is every render of every bound control. Every call site reads
+        ///     <c>acc.Getter()</c> either way (#793).
+        /// </remarks>
+        public object? Getter() => Property.GetValue(Target);
+
+        /// <summary>Writes the terminal property on <see cref="Target" />.</summary>
+        /// <remarks>See <see cref="Getter" /> for why this is a method and not an <c>Action</c>.</remarks>
+        public void Setter(object? value) => Property.SetValue(Target, value);
+
         public Type PropertyType => Property.PropertyType;
         public string PropertyName => Property.Name;
         public FieldIdentifier Field => new(Target, Property.Name);

--- a/tests/Rask.Core.Tests/Performance/BuilderEntryAllocationPinTests.cs
+++ b/tests/Rask.Core.Tests/Performance/BuilderEntryAllocationPinTests.cs
@@ -36,6 +36,30 @@ internal sealed partial class AllocBoundEntryProbe : Component
     protected override Component? Render() => Div[Input.Bind(() => Model.Name).Id("name")];
 }
 
+// The same control in CONTROLLED mode. Pinned so the bound number above decomposes: whatever the bound
+// probe costs over this one is the binding, and a regression in the shared element path moves both.
+internal sealed partial class AllocControlledInputProbe : Component
+{
+    internal readonly BoundForm Model = new() { Name = "Ada", Age = 36 };
+
+    protected override Component? Render() => Div[Input.Value(Model.Name).Id("name")];
+}
+
+// The bound control with the bind expression HOISTED into a field, so it is built once instead of on
+// every render. This is the pin that actually guards Rask's own bind path: the difference between this
+// and AllocBoundEntryProbe is the C# compiler constructing an Expression<Func<T>> at the call site,
+// which is not code this repo can make cheaper.
+internal sealed partial class AllocHoistedBoundEntryProbe : Component
+{
+    internal readonly BoundForm Model = new() { Name = "Ada", Age = 36 };
+
+    private readonly System.Linq.Expressions.Expression<Func<string>> _bind;
+
+    public AllocHoistedBoundEntryProbe() => _bind = () => Model.Name;
+
+    protected override Component? Render() => Div[Input.Bind(_bind).Id("name")];
+}
+
 // The event surface: every one of Element's ~88 handler pairs is a
 // plain `Action?` / `Action<TArgs>?` property over the same dictionary slot, so setting one and resetting
 // one are both supposed to be free. Critically, an element handler must stay UNWRAPPED: an AutoCallback
@@ -224,17 +248,58 @@ public class BuilderEntryAllocationPinTests
         AssertCosts(cost, 1800);
     }
 
-    // The one number that has MOVED: 3555 B/render on 2026-08-08 (3e143905), 5163 B/render now. Nothing
-    // caught it, because the pin was relative and the factory arm grew alongside it — which is the whole
-    // argument for pinning absolutely. Pinned where it is rather than where it should be, so the gate is
-    // green and the regression is written down instead of blessed silently.
+    // The bound control, decomposed. One aggregate ceiling could say a number had moved but never which
+    // layer moved it, and #793 was opened on exactly that: 3555 B/render recorded 2026-08-08, 5163 B/render
+    // when it was next looked at, with nothing in between able to say where it went.
+    //
+    // Measured 2026-08-24, after removing the Accessor's redundant getter/setter delegates:
+    //
+    //     bare Div                                   1088
+    //     Div[Input.Of<string>().Id]                 1192
+    //     Div[Input.Value(...).Id]      controlled   1216
+    //     Div[Input.Bind(hoisted).Id]   bound        2723
+    //     Div[Input.Bind(() => ...).Id] bound        5034
+    //
+    // Two things fall straight out of that, and both are why 3555 is not a baseline to chase:
+    //
+    //   * 2311 B — 46% of the total — is the C# compiler building an Expression<Func<T>> at the CALL SITE
+    //     on every render. It is not Rask code and no change here can make it cheaper; the only lever is
+    //     the shape of the public Bind API. So this probe cannot go below ~3500 B however good the bind
+    //     path gets, which is already above the 3555 the comment recorded — the old number cannot have
+    //     been measuring this same shape.
+    //   * 1507 B is Rask's own bind path (bound-hoisted minus controlled): parsing the expression, the
+    //     auto-created EditContext, two registered handlers and the validator registration.
+    //
+    // All three ceilings are ABSOLUTE. A relative pin is what let the regression hide in the first place
+    // (the factory arm grew alongside the entry arm and the difference stayed inside its slack), so these
+    // decompose the cost without reintroducing that: a regression in the shared element path trips the
+    // controlled pin, one in the bind path trips the hoisted pin, and one in either trips the aggregate.
+    [Fact]
+    public void A_controlled_input_costs_what_it_costs()
+    {
+        var cost = Measure(static () => new AllocControlledInputProbe());
+
+        // 1216 B/render measured 2026-08-24; pinned at 1400 B.
+        AssertCosts(cost, 1400);
+    }
+
+    [Fact]
+    public void A_bound_input_costs_what_it_costs_apart_from_its_expression_tree()
+    {
+        var cost = Measure(static () => new AllocHoistedBoundEntryProbe());
+
+        // 2723 B/render measured 2026-08-24; pinned at 3000 B. This is the one to watch — it is the only
+        // one of the three that moves when Rask's bind path changes.
+        AssertCosts(cost, 3000);
+    }
+
     [Fact]
     public void A_bound_generic_entry_costs_what_it_costs()
     {
         var cost = Measure(static () => new AllocBoundEntryProbe());
 
-        // 5163 B/render measured 2026-08-24; pinned at 5600 B.
-        AssertCosts(cost, 5600);
+        // 5034 B/render measured 2026-08-24; pinned at 5300 B, down from the 5600 #793 recorded.
+        AssertCosts(cost, 5300);
     }
 
     private static void AssertCosts(long actual, long ceiling) =>


### PR DESCRIPTION
## Summary

Two things: a real (if modest) reduction, and — more usefully — a measurement that says what the
number is actually made of.

### The reduction

`ExpressionAccessor.Accessor` carried a `Func<object?> Getter` and an `Action<object?> Setter` that
closed over the same `Target` and `Property` the record already held. They were rebuilt on **every
`Parse`** — every render of every bound control (`Input` / `Select` / `Textarea` / `Bs*`) — costing a
display class and two delegates that told nobody anything the record could not answer itself.

They are methods now. Every one of the ~20 call sites still reads `acc.Getter()` / `acc.Setter(v)`
unchanged; only the single construction site moved. **5195 → 5034 B/render.**

### What the number is actually made of

The issue recorded 5163 B/render against 3555 B on 2026-08-08 and could not say where the difference
went, because one aggregate ceiling cannot say which layer moved. Measured 2026-08-24, after the
change above:

| | B/render |
| --- | --- |
| bare `Div` | 1088 |
| `Div[Input.Of<string>().Id]` | 1192 |
| `Div[Input.Value(…).Id]` — controlled | 1216 |
| `Div[Input.Bind(hoisted).Id]` — bound, expression built once | 2723 |
| `Div[Input.Bind(() => …).Id]` — bound | 5034 |

**2311 B — 46% of the total — is the C# compiler building an `Expression<Func<T>>` at the call site
on every render.** It is not Rask code, and nothing in this repo can make it cheaper; the only lever
is the shape of the public `Bind` API. Two consequences:

- This probe **cannot go below roughly 3500 B** however good the bind path gets. That is already
  *above* the 3555 B the file's comment recorded, so the old number cannot have been measuring this
  shape — it is not a baseline to chase.
- Rask's own share is the remaining **1507 B**: parsing the expression (216 B), the auto-created
  `EditContext` (408 B), two registered handlers (112 B each) and the validator registration.

### The issue's suspected cause is not it

The issue pointed at "a per-call delegate" among the entry's reset arguments, cached per instantiation
in a `<>O` holder "only if the compiler can". That is not where the cost is: `Parse` is **one call per
render** (verified with a counter) and accounts for 216 B of 5034.

### The pins

Three **absolute** pins now, where there was one:

| pin | measured | ceiling |
| --- | --- | --- |
| controlled input | 1216 | 1400 |
| bound, expression hoisted | 2723 | 3000 |
| bound (aggregate) | 5034 | 5300 (was 5600) |

A *relative* pin is what let the original regression hide — the factory arm grew alongside the entry
arm and the difference stayed inside its slack. These decompose the cost without reintroducing that:
a regression in the shared element path trips the controlled pin, one in the bind path trips the
hoisted pin, and either trips the aggregate. The hoisted one is the pin to watch — it is the only one
of the three that moves when Rask's bind path changes.

## Testing

- All 10 pins in `BuilderEntryAllocationPinTests` pass.
- **Benchmark:** `Rask_InputTypingBurst` is **4.88 KB before and after** — no change, and that is the
  expected result: that benchmark's inputs are `Input.Value(…)`, i.e. **controlled**, so
  `ExpressionAccessor` is not on its path at all. It is quoted as evidence of no regression elsewhere,
  not of the improvement; the improvement's evidence is the pin measurement above.
- Worth noting as a gap: **no benchmark covers a bound control**, which is the most expensive control
  shape the framework has. The new hoisted pin now guards it in the unit gate (which runs on every
  commit), where a benchmark would only be run by hand.

## Gates

- `dotnet format Rask.slnx` — clean.
- `CI=true dotnet build Rask.slnx -c Release -warnaserror -p:EnforceCodeStyleInBuild=true` — 0 warnings, 0 errors.
- `scripts/run-unit-local.sh` — passed (pre-commit).
- `scripts/run-e2e-local.sh` + watch hot-reload gate — passed (pre-push).

Closes #793
