### PR TITLE
test(wasm-hosting): serialise the classes that share the host's process-wide statics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,24 @@ them until tagged releases begin.
   (the factory excluded it on name *and* type; the indexer owns the word).
 
 ### Fixed
+- **The WASM-hosting tests raced each other over two process-wide statics.** `UseRask` sets
+  `ScopedAssetBundle.BakedDirectory` and `LiveOptions.PathBase`, which are **per process**, not per
+  server. Three classes in `Rask.Wasm.Hosting.Tests` stand hosts up and xUnit runs classes in
+  parallel, so a second host took the first one's state away from it — and disposal made it worse
+  rather than better, since it resets the statics, letting a host that merely *finished* break one
+  still serving. That is the
+  `RegistryMiss_BakedBundleFile_NegotiatesPrecompressedSibling — Expected: OK, Actual: NotFound`
+  the local gate reported on a diff that touched none of it (#789).
+
+  The assembly now disables test parallelisation, as `Rask.Dashboard.Tests` and `Rask.SQLite.Tests`
+  already do for their own process-wide state — assembly-wide rather than a per-class collection
+  precisely because a new class cannot forget to join it, which is how this arose. The suite still
+  runs in 2 s. `ProcessWideHostStateTests` demonstrates the overlap directly, standing two hosts up
+  and watching the second take the first's bundle directory and path base, so the reason for the
+  serialisation is verifiable instead of merely asserted.
+
+  The statics themselves are not a bug: a real deployment has one host per process, which is why
+  `UseRask` can set them at all. Only a test process holds two, so the fix belongs to the tests.
 - **A bound form control allocated less, and the pin that guards it now says which layer moved.**
   `ExpressionAccessor.Accessor` carried a `Func<object?> Getter` and an `Action<object?> Setter` that
   closed over the same `Target` and `Property` the record already held. They were rebuilt on every

--- a/tests/Rask.Wasm.Hosting.Tests/AssemblyInfo.cs
+++ b/tests/Rask.Wasm.Hosting.Tests/AssemblyInfo.cs
@@ -1,0 +1,16 @@
+// Two of the things UseRask configures are PROCESS-WIDE statics, not per-server state:
+// ScopedAssetBundle.BakedDirectory and LiveOptions.PathBase. Three classes here stand servers up
+// (AssetEndpointParityTests, PathBaseEndpointTests, UseRaskTests), xUnit runs classes in parallel, and
+// a second host therefore takes the first one's state away from it — disposal is worse still, since it
+// resets the statics and a host that merely finishes can break one that is still serving.
+//
+// That is what made the local gate fail with
+//   AssetEndpointParityTests.RegistryMiss_BakedBundleFile_NegotiatesPrecompressedSibling
+//   Assert.Equal() Failure: Expected: OK, Actual: NotFound
+// on a diff that touched none of it (#789). ProcessWideHostStateTests demonstrates the overlap
+// directly rather than leaving this comment to be believed.
+//
+// The statics are not the bug: a real deployment has one host per process, which is why UseRask can set
+// them at all. Only a test process holds two, so the fix belongs here. Matches the other suites that
+// share process-wide state (Rask.Dashboard.Tests, Rask.SQLite.Tests).
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Rask.Wasm.Hosting.Tests/ProcessWideHostStateTests.cs
+++ b/tests/Rask.Wasm.Hosting.Tests/ProcessWideHostStateTests.cs
@@ -1,0 +1,80 @@
+using System.Net;
+using Rask.Core.Live;
+using Rask.Core.ScopedAssets;
+using Rask.Wasm.Hosting.Tests.Infrastructure;
+
+namespace Rask.Wasm.Hosting.Tests;
+
+/// <summary>
+///     Why this assembly runs its test classes serially (see <c>AssemblyInfo.cs</c>): two of the things a
+///     host configures are <b>process-wide statics</b>, not per-server state, so two live servers in one
+///     process do not have independent ones.
+/// </summary>
+/// <remarks>
+///     <para>
+///         This is not an argument, it is a demonstration. The tests below stand two hosts up at once and
+///         show the second one taking the first one's state away from it — the first host's own baked
+///         asset then 404s, which is exactly the symptom the gate reported in #789:
+///         <c>AssetEndpointParityTests.RegistryMiss_BakedBundleFile_NegotiatesPrecompressedSibling —
+///         Assert.Equal() Failure: Expected: OK, Actual: NotFound</c>, on a diff that touched none of it.
+///     </para>
+///     <para>
+///         Three classes in this assembly build servers (<c>AssetEndpointParityTests</c>,
+///         <c>PathBaseEndpointTests</c>, <c>UseRaskTests</c>) and xUnit runs classes in parallel, so this
+///         overlap was reachable on any run. Disposal makes it worse rather than better: it resets the
+///         statics, so a host that merely finishes can pull the ground out from under one still serving.
+///     </para>
+///     <para>
+///         The statics are not themselves a bug. A real deployment has one host per process, which is why
+///         <c>UseRask</c> can set them at all. It is only a test process that holds two, so the fix
+///         belongs to the test assembly — serialising the classes — and not to the product.
+///     </para>
+/// </remarks>
+public sealed class ProcessWideHostStateTests
+{
+    [Fact]
+    public async Task A_second_host_takes_the_baked_bundle_directory_from_the_first()
+    {
+        using var firstBundle = new FakeBundleDirectory();
+        var scopedDir = Path.Combine(firstBundle.Path, "_rask", "a");
+        Directory.CreateDirectory(scopedDir);
+        const string hash = "0123456789ab";
+        File.WriteAllText(Path.Combine(scopedDir, $"{hash}.js"), "window.Rask=window.Rask||{};");
+
+        await using var first = await WasmHostingTestServer.CreateAsync(firstBundle.Path);
+
+        // The first host serves its own baked file, as its own tests assert.
+        Assert.Equal(HttpStatusCode.OK, (await first.Http.GetAsync($"/_rask/a/{hash}.js")).StatusCode);
+
+        // A second host — another test class, in parallel — points the one static somewhere else.
+        using var secondBundle = new FakeBundleDirectory();
+        await using (await WasmHostingTestServer.CreateAsync(secondBundle.Path))
+        {
+            Assert.Equal(
+                HttpStatusCode.NotFound,
+                (await first.Http.GetAsync($"/_rask/a/{hash}.js")).StatusCode);
+        }
+
+        // …and disposing the second one clears the static outright, so the first host stays broken.
+        Assert.Null(ScopedAssetBundle.BakedDirectory);
+        Assert.Equal(
+            HttpStatusCode.NotFound,
+            (await first.Http.GetAsync($"/_rask/a/{hash}.js")).StatusCode);
+    }
+
+    [Fact]
+    public async Task A_second_host_takes_the_path_base_from_the_first()
+    {
+        using var bundle = new FakeBundleDirectory();
+        await using var first = await WasmHostingTestServer.CreateAsync(bundle.Path, pathBase: "/app");
+
+        Assert.Equal("/app", LiveOptions.PathBase);
+
+        using var secondBundle = new FakeBundleDirectory();
+        await using (await WasmHostingTestServer.CreateAsync(secondBundle.Path))
+        {
+            // The second host configures no prefix, and the first host's is gone — one slot, not two.
+            Assert.NotEqual("/app", LiveOptions.PathBase);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

One of the three symptoms is root-caused, demonstrated and fixed. The other two did not reproduce, and
this says so rather than shipping a speculative change to the gate.

## Fixed: the `Rask.Wasm.Hosting.Tests` 404

`UseRask` sets two things that are **process-wide statics**, not per-server state:

- `ScopedAssetBundle.BakedDirectory` (`RaskWasmEndpointExtensions.cs:167`)
- `LiveOptions.PathBase`

Three classes in that assembly stand hosts up — `AssetEndpointParityTests`, `PathBaseEndpointTests`,
`UseRaskTests` — and xUnit runs classes in parallel. So a second host takes the first one's state away
from it, and **disposal makes it worse rather than better**: `WasmHostingTestServer.DisposeAsync`
resets both statics, letting a host that merely *finished* break one that is still serving.

That is exactly the reported failure:

```
Rask.Wasm.Hosting.Tests.AssetEndpointParityTests.RegistryMiss_BakedBundleFile_NegotiatesPrecompressedSibling
Assert.Equal() Failure: Expected: OK, Actual: NotFound
```

on a diff that touched none of it — and it passed alone immediately afterwards, which is the signature
of exactly this.

**`ProcessWideHostStateTests` demonstrates it directly** rather than leaving the comment to be
believed: it stands two hosts up, watches the second take the first's bundle directory (the first
host's own baked asset then 404s), and then watches disposal clear the static outright so the first
host stays broken. Same for `PathBase`.

The fix is `[assembly: CollectionBehavior(DisableTestParallelization = true)]`, which is what
`Rask.Dashboard.Tests` and `Rask.SQLite.Tests` already do for their own process-wide state. Chosen
assembly-wide rather than a per-class `[Collection]` deliberately: a new test class **cannot forget to
join it**, and forgetting is how this arose — every other suite that touches these statics
(`Rask.Core.Tests`, `Rask.Server.Tests`) already puts the classes in a `ScopedAssets` collection, and
this assembly was simply the one that never adopted the pattern. The suite still runs in 2 s.

The statics themselves are **not** a bug. A real deployment has one host per process, which is why
`UseRask` can set them at all. Only a test process holds two, so the fix belongs to the tests.

## Not reproduced: the other two symptoms

The issue asks to "reproduce by running the full gate in a loop and recording which assembly fails
each time". Done — **six full `scripts/run-unit-local.sh` runs, all six green**, 46 assemblies each:

| batch | tree | result |
| --- | --- | --- |
| 3 runs | with #772's DbContext collections | 3 × PASS |
| 3 runs | the above + this fix | 3 × PASS |

So the gate is not a coin flip on this machine, and neither the `Rask.Generators.Tests` test-host
crash nor the single unnamed `Rask.Server.Tests` failure appeared. Two things worth recording about
that:

- The runs were on an **idle** machine. The report's first failure had an iOS simulator running,
  though it also notes runs 3 and 4 did not — so load is a suspect, not an explanation.
- The runs were on a tree that already carries **#772**, which serialised the `Jobs` / `Cache` /
  `Mail` / `Data` suites over their shared `DbContext`. Those were the same latent shape as #769 and
  they postdate this issue's runs. That is a correlation, not a proof.

I have deliberately **not** capped test parallelism in `scripts/run-unit-local.sh`. The issue offers
it as a guess for the Roslyn host crash, and it would slow every developer's commit; making an
unverifiable change to the gate for a symptom I cannot reproduce is how a gate accumulates cargo. The
`--blame-crash` plumbing added in #769 already writes a per-host sequence file naming the test in
flight, so the next occurrence is diagnosable rather than merely observed.

If the crash recurs, the artifact to read is `artifacts/test-blame`.

## Testing

- `ProcessWideHostStateTests` — 2 new tests, both demonstrating the overlap.
- `Rask.Wasm.Hosting.Tests` — 66 passed (64 + the 2 new), 2 s, unchanged.
- Six full local gate runs, all green (above).

## Gates

- `dotnet format Rask.slnx` — clean.
- `CI=true dotnet build Rask.slnx -c Release -warnaserror -p:EnforceCodeStyleInBuild=true` — 0 warnings, 0 errors.
- `scripts/run-unit-local.sh` — passed (pre-commit).
- `scripts/run-e2e-local.sh` + watch hot-reload gate — passed (pre-push).
- No benchmark: test-only change, no product code touched.

Closes #789
