### PR TITLE
perf(benchmarks): benchmark a bound control, and fix the model the bound pins were measured against

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,42 @@ them until tagged releases begin.
   (the factory excluded it on name *and* type; the indexer owns the word).
 
 ### Fixed
+- **The bound-control numbers were measured against the wrong model, and a bound control is now
+  benchmarked at all.** Adding the benchmark #802 asked for turned up the answer to #793.
+
+  Every probe in `BuilderEntryAllocationPinTests` bound `BoundForm`, a test fixture that derives
+  `RaskMarkup`. Constructing an `Expression<Func<T>>` resolves a member token on the terminal
+  property's **declaring type**, and that cost scales with how many members the type has — measured at
+  312 B for a one-property class, 1912 B for a 200-property one, and 2312 B for a `RaskMarkup`
+  subclass, which carries the whole chain surface as members. So the probes were paying ~1970 B/render
+  for a shape no guide recommends.
+
+  That is what #793 was looking at. It recorded 3555 B/render on 2026-08-08 against 5163 B when next
+  measured and concluded Rask's bind path had regressed 45%. It had not: the representative probe costs
+  **3041 B today, below the number it was compared against**, and the difference was the fixture. The
+  claim that ~46% of the cost was unavoidable compiler work went the same way — against a plain model
+  the expression tree is 320 B, about 10%. Rask's own share, 1505 B, was measured correctly and is
+  unchanged; it remains the part worth attacking.
+
+  | | B/render |
+  | --- | --- |
+  | `Div[Input.Value(…)]` — controlled | 1216 |
+  | `Div[Input.Bind(hoisted)]` — bound, expression built once | 2721 |
+  | `Div[Input.Bind(() => …)]` — bound | 3041 |
+  | …the same, against a model deriving `RaskMarkup` | 5011 |
+
+  The probes now bind a plain model, the aggregate ceiling drops from 5600 B to **3300 B**, and the
+  expensive shape gets a pin of its own instead of being averaged into the representative one — it is
+  not contrived, since `Component : RaskMarkup` means `Input.Bind(() => Draft)` against a component's
+  own property lands there.
+
+  `BoundControlRenderBenchmarks` closes the coverage gap that surfaced all this: nothing in
+  `benchmarks/` rendered a bound control. `ExpressionAccessorBenchmarks` covers `Parse` alone with a
+  hoisted expression, and `LiveDiffPayload_InputTypingBurstBenchmarks` reads like form coverage but its
+  inputs are `Input.Value(…)`, i.e. controlled. The new benchmark runs the three arms the pins now pin,
+  so the suite and the gate describe the same decomposition: controlled 6.77 KB, bound-hoisted 9.39 KB,
+  bound 10.38 KB per three-field form.
+
 - **The WASM-hosting tests raced each other over two process-wide statics.** `UseRask` sets
   `ScopedAssetBundle.BakedDirectory` and `LiveOptions.PathBase`, which are **per process**, not per
   server. Three classes in `Rask.Wasm.Hosting.Tests` stand hosts up and xUnit runs classes in
@@ -102,16 +138,16 @@ them until tagged releases begin.
   | `Div[Input.Bind(hoisted)]` — bound, expression built once | 2723 |
   | `Div[Input.Bind(() => …)]` — bound | 5034 |
 
-  **2311 B — 46% of the total — is the C# compiler building an `Expression<Func<T>>` at the call site
-  on every render.** That is not Rask code and nothing here can make it cheaper; only the shape of the
-  public `Bind` API could. So this probe cannot go below roughly 3500 B however good the bind path
-  gets — which is already above the 3555 B the old comment recorded, so that number cannot have been
-  measuring this shape and is not a baseline to chase. Rask's own share is the remaining 1507 B.
+  > **Corrected below (see "the bound-control numbers were measured against the wrong model").** This
+  > entry originally read that 2311 B — 46% of the total — was the C# compiler building an
+  > `Expression<Func<T>>`, and that the probe could therefore never go below ~3500 B. Both were
+  > artefacts of the probe binding a model that derives `RaskMarkup`. Against a representative model
+  > the tree is 320 B and the probe costs 3041 B. Rask's own share, 1505 B, was right.
 
-  Those three layers are now three **absolute** pins rather than one. A relative pin is what let the
+  Those layers are now **absolute** pins rather than one aggregate. A relative pin is what let the
   original regression hide, so they decompose the cost without reintroducing that: a regression in the
   shared element path trips the controlled pin, one in the bind path trips the hoisted pin, and either
-  trips the aggregate — whose ceiling drops from 5600 B to 5300 B.
+  trips the aggregate.
 
 - **No `rask new` template can reach a user uncompiled any more.** `CliBuildE2E` packs this commit's
   packages to a local feed and runs a real `dotnet build -warnaserror` over what the CLI writes, and it

--- a/benchmarks/Rask.Benchmarks/BoundControlRenderBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/BoundControlRenderBenchmarks.cs
@@ -1,0 +1,87 @@
+using System.Linq.Expressions;
+using BenchmarkDotNet.Attributes;
+using Rask.Core;
+
+namespace Rask.Benchmarks;
+
+// A BOUND form control, rendered end to end — the shape the suite had no view of (#802).
+//
+// ExpressionAccessorBenchmarks already covers ExpressionAccessor.Parse across the Bind shapes, and
+// LiveDiffPayload_InputTypingBurstBenchmarks reads like form coverage. Neither measures this: Parse is
+// one piece of the per-render cost, and the diff benchmark's inputs are Input.Value(...), i.e.
+// CONTROLLED, so the accessor, the auto-created EditContext, the two bound handlers and the validator
+// registration are all off its path.
+//
+// Three arms, mirroring the absolute pins in BuilderEntryAllocationPinTests so the benchmark suite and
+// the unit gate describe the same decomposition and can be read against each other:
+//
+//   Controlled     the same form with Input.Value — the floor, and the honest comparison
+//   BoundHoisted   the bind expression built ONCE in setup, so this moves only when Rask's bind path does
+//   Bound          the expression built at the CALL SITE, which is what a user actually writes
+//
+// Bound minus BoundHoisted is the C# compiler constructing an Expression<Func<T>> per render. It is not
+// Rask code and nothing here can make it cheaper — measured at 46% of a single bound control's cost in
+// #793 — so a regression hunt starts at BoundHoisted, not at Bound.
+[MemoryDiagnoser]
+public partial class BoundControlRenderBenchmarks : global::Rask.Core.RaskMarkup
+{
+    private readonly TypingModel _model = new();
+
+    private Expression<Func<string>> _boundA = null!;
+    private Expression<Func<string>> _boundB = null!;
+    private Expression<Func<string>> _boundC = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _boundA = () => _model.A;
+        _boundB = () => _model.B;
+        _boundC = () => _model.C;
+    }
+
+    [Benchmark(Baseline = true)]
+    public string Controlled() =>
+        Form.Model(_model)[
+            Label["Field A"],
+            Input.Value(_model.A).Type(InputType.Text).Name("a"),
+            Label["Field B"],
+            Input.Value(_model.B).Type(InputType.Text).Name("b"),
+            Label["Field C"],
+            Input.Value(_model.C).Type(InputType.Text).Name("c"),
+            Button.Type("submit")["Save"]
+        ].RenderAsLiveRoot();
+
+    [Benchmark]
+    public string BoundHoisted() =>
+        Form.Model(_model)[
+            Label["Field A"],
+            Input.Bind(_boundA).Type(InputType.Text),
+            Label["Field B"],
+            Input.Bind(_boundB).Type(InputType.Text),
+            Label["Field C"],
+            Input.Bind(_boundC).Type(InputType.Text),
+            Button.Type("submit")["Save"]
+        ].RenderAsLiveRoot();
+
+    [Benchmark]
+    public string Bound() =>
+        Form.Model(_model)[
+            Label["Field A"],
+            Input.Bind(() => _model.A).Type(InputType.Text),
+            Label["Field B"],
+            Input.Bind(() => _model.B).Type(InputType.Text),
+            Label["Field C"],
+            Input.Bind(() => _model.C).Type(InputType.Text),
+            Button.Type("submit")["Save"]
+        ].RenderAsLiveRoot();
+
+    // Settable properties: Bind needs a terminal property it can write back through.
+    private sealed class TypingModel
+    {
+        public string A { get; set; } = "abc";
+
+        public string B { get; set; } = "field B initial";
+
+        public string C { get; set; } = "field C initial";
+    }
+}

--- a/tests/Rask.Core.Tests/Performance/BuilderEntryAllocationPinTests.cs
+++ b/tests/Rask.Core.Tests/Performance/BuilderEntryAllocationPinTests.cs
@@ -25,13 +25,25 @@ internal sealed partial class AllocEntryProbe : Component
         ];
 }
 
+// A PLAIN model, which is what these probes bind. It matters more than it looks: constructing an
+// Expression<Func<T>> resolves a member token on the terminal property's DECLARING type, and that cost
+// scales with how many members that type has. Measured here — 1 property 312 B, 200 properties 1912 B,
+// a RaskMarkup subclass 2312 B. These probes used to bind `BoundForm`, which derives RaskMarkup, and
+// that alone accounted for ~2000 B of the number #793 was opened about.
+internal sealed class PlainBoundModel
+{
+    public string Name { get; set; } = "Ada";
+
+    public int Age { get; set; } = 36;
+}
+
 // The generic form control's entry is a static METHOD, so its reset arguments are method groups of a
 // GENERIC method. Those are cached per instantiation in a generic `<>O` holder — but only if the
 // compiler can; a per-call delegate here would be a silent per-render allocation on every bound input
 // in an app.
 internal sealed partial class AllocBoundEntryProbe : Component
 {
-    internal readonly BoundForm Model = new() { Name = "Ada", Age = 36 };
+    internal readonly PlainBoundModel Model = new();
 
     protected override Component? Render() => Div[Input.Bind(() => Model.Name).Id("name")];
 }
@@ -40,24 +52,37 @@ internal sealed partial class AllocBoundEntryProbe : Component
 // probe costs over this one is the binding, and a regression in the shared element path moves both.
 internal sealed partial class AllocControlledInputProbe : Component
 {
-    internal readonly BoundForm Model = new() { Name = "Ada", Age = 36 };
+    internal readonly PlainBoundModel Model = new();
 
     protected override Component? Render() => Div[Input.Value(Model.Name).Id("name")];
 }
 
 // The bound control with the bind expression HOISTED into a field, so it is built once instead of on
-// every render. This is the pin that actually guards Rask's own bind path: the difference between this
-// and AllocBoundEntryProbe is the C# compiler constructing an Expression<Func<T>> at the call site,
-// which is not code this repo can make cheaper.
+// every render. The difference between this and AllocBoundEntryProbe is the C# compiler constructing
+// the Expression<Func<T>> at the call site — not code this repo can make cheaper, but see
+// AllocBoundToMarkupHostProbe for how much the SHAPE of the model changes that price.
 internal sealed partial class AllocHoistedBoundEntryProbe : Component
 {
-    internal readonly BoundForm Model = new() { Name = "Ada", Age = 36 };
+    internal readonly PlainBoundModel Model = new();
 
     private readonly System.Linq.Expressions.Expression<Func<string>> _bind;
 
     public AllocHoistedBoundEntryProbe() => _bind = () => Model.Name;
 
     protected override Component? Render() => Div[Input.Bind(_bind).Id("name")];
+}
+
+// The SAME bind against a property declared on a type that derives RaskMarkup. This is not a contrived
+// shape: `Component : RaskMarkup`, so `Input.Bind(() => Draft)` — binding a component's own property,
+// which the guides do — lands here, and so does binding any model that happens to be a component. The
+// chain surface arrives as members on RaskMarkup, and resolving a member token on a type that large is
+// what costs. Pinned separately so the expensive shape is visible and guarded rather than averaged into
+// the representative one.
+internal sealed partial class AllocBoundToMarkupHostProbe : Component
+{
+    internal readonly BoundForm Model = new() { Name = "Ada", Age = 36 };
+
+    protected override Component? Render() => Div[Input.Bind(() => Model.Name).Id("name")];
 }
 
 // The event surface: every one of Element's ~88 handler pairs is a
@@ -248,32 +273,37 @@ public class BuilderEntryAllocationPinTests
         AssertCosts(cost, 1800);
     }
 
-    // The bound control, decomposed. One aggregate ceiling could say a number had moved but never which
-    // layer moved it, and #793 was opened on exactly that: 3555 B/render recorded 2026-08-08, 5163 B/render
-    // when it was next looked at, with nothing in between able to say where it went.
+    // The bound control, decomposed — and a correction to what #793 concluded.
     //
-    // Measured 2026-08-24, after removing the Accessor's redundant getter/setter delegates:
+    // Measured 2026-08-24:
     //
-    //     bare Div                                   1088
-    //     Div[Input.Of<string>().Id]                 1192
-    //     Div[Input.Value(...).Id]      controlled   1216
-    //     Div[Input.Bind(hoisted).Id]   bound        2723
-    //     Div[Input.Bind(() => ...).Id] bound        5034
+    //     Div[Input.Value(...).Id]            controlled          1216
+    //     Div[Input.Bind(hoisted).Id]         bound               2721
+    //     Div[Input.Bind(() => ...).Id]       bound               3041
+    //     …the same, model deriving RaskMarkup                    5011
     //
-    // Two things fall straight out of that, and both are why 3555 is not a baseline to chase:
+    // The first three bind a PLAIN model. The fourth binds `BoundForm`, which derives RaskMarkup — and
+    // that single difference is worth 1970 B/render. Constructing an Expression<Func<T>> resolves a
+    // member token on the terminal property's DECLARING type, and the cost scales with that type's
+    // member count: 312 B for a one-property class, 1912 B for a 200-property one, 2312 B for a
+    // RaskMarkup subclass, which carries the whole chain surface as members.
     //
-    //   * 2311 B — 46% of the total — is the C# compiler building an Expression<Func<T>> at the CALL SITE
-    //     on every render. It is not Rask code and no change here can make it cheaper; the only lever is
-    //     the shape of the public Bind API. So this probe cannot go below ~3500 B however good the bind
-    //     path gets, which is already above the 3555 the comment recorded — the old number cannot have
-    //     been measuring this same shape.
-    //   * 1507 B is Rask's own bind path (bound-hoisted minus controlled): parsing the expression, the
-    //     auto-created EditContext, two registered handlers and the validator registration.
+    // Every one of these probes used to bind BoundForm. That is what #793 was actually looking at: it
+    // recorded 3555 B/render on 2026-08-08 and 5163 B when next measured, and concluded Rask's bind
+    // path had regressed 45%. It had not. The representative probe costs 3041 B today — BELOW the
+    // number it was compared against — and the gap was the fixture, not the framework. The earlier
+    // claim that ~46% of the cost was unavoidable compiler work was wrong for the same reason: against
+    // a plain model the expression tree is 320 B, about 10%.
     //
-    // All three ceilings are ABSOLUTE. A relative pin is what let the regression hide in the first place
-    // (the factory arm grew alongside the entry arm and the difference stayed inside its slack), so these
-    // decompose the cost without reintroducing that: a regression in the shared element path trips the
-    // controlled pin, one in the bind path trips the hoisted pin, and one in either trips the aggregate.
+    // Rask's own share is the remaining 1505 B (bound-hoisted minus controlled): parsing the
+    // expression, the auto-created EditContext, two registered handlers and the validator registration.
+    // That figure did not move, and it is the one to attack.
+    //
+    // All four ceilings are ABSOLUTE. A relative pin is what let a real regression hide once already
+    // (the factory arm grew alongside the entry arm and the difference stayed inside its slack), so
+    // these decompose the cost without reintroducing that: the shared element path trips the controlled
+    // pin, the bind path trips the hoisted pin, and the model-shape penalty has a pin of its own rather
+    // than being averaged into the representative number.
     [Fact]
     public void A_controlled_input_costs_what_it_costs()
     {
@@ -288,8 +318,8 @@ public class BuilderEntryAllocationPinTests
     {
         var cost = Measure(static () => new AllocHoistedBoundEntryProbe());
 
-        // 2723 B/render measured 2026-08-24; pinned at 3000 B. This is the one to watch — it is the only
-        // one of the three that moves when Rask's bind path changes.
+        // 2721 B/render measured 2026-08-24; pinned at 3000 B. This is the one to watch — it is the
+        // only one of these that moves when Rask's bind path changes.
         AssertCosts(cost, 3000);
     }
 
@@ -298,7 +328,27 @@ public class BuilderEntryAllocationPinTests
     {
         var cost = Measure(static () => new AllocBoundEntryProbe());
 
-        // 5034 B/render measured 2026-08-24; pinned at 5300 B, down from the 5600 #793 recorded.
+        // 3041 B/render measured 2026-08-24; pinned at 3300 B, down from 5600 — the drop is the probe
+        // binding a representative model rather than a RaskMarkup subclass, not a change in the code.
+        AssertCosts(cost, 3300);
+    }
+
+    /// <summary>
+    ///     Binding a property declared on a <c>RaskMarkup</c> subclass, which
+    ///     <c>Input.Bind(() =&gt; Draft)</c> on a component's own property is.
+    /// </summary>
+    /// <remarks>
+    ///     Pinned as its own number because it is a real shape with a real price — 1970 B/render over
+    ///     the same bind against a plain model — and averaging it into the representative pin would
+    ///     hide both. If the chain surface on <c>RaskMarkup</c> ever shrinks, this is the pin that
+    ///     should move.
+    /// </remarks>
+    [Fact]
+    public void Binding_a_property_declared_on_a_markup_host_costs_what_it_costs()
+    {
+        var cost = Measure(static () => new AllocBoundToMarkupHostProbe());
+
+        // 5011 B/render measured 2026-08-24; pinned at 5300 B.
         AssertCosts(cost, 5300);
     }
 


### PR DESCRIPTION
## Summary

Adding the benchmark #802 asked for turned up the answer to #793 — and **reverses what #793
concluded**. Two things here: the missing benchmark, and the correction it forced.

## The correction

Every probe in `BuilderEntryAllocationPinTests` bound `BoundForm`, a test fixture that derives
`RaskMarkup`.

Constructing an `Expression<Func<T>>` resolves a member token on the terminal property's **declaring
type**, and the allocation scales with how many members that type has:

| declaring type of the bound property | B per tree |
| --- | --- |
| a class with 1 property | 312 |
| a class with 200 properties | 1912 |
| a class deriving `RaskMarkup` | 2312 |

`RaskMarkup` carries the entire chain surface as members, so the probes were paying ~1970 B/render for
a shape no guide recommends.

**That is what #793 was looking at.** It recorded 3555 B/render on 2026-08-08 against 5163 B when next
measured, and concluded Rask's bind path had regressed 45%. It had not — the representative probe
costs **3041 B today, below the number it was compared against**, and the difference was the fixture,
not the framework.

My own follow-on claim in #800 went the same way: I wrote that 2311 B (46%) was the C# compiler
building the expression tree and that the probe "cannot go below roughly 3500 B". Against a plain
model the tree is **320 B, about 10%**. The one figure that survives is Rask's own share — 1505 B,
measured correctly, and still the part worth attacking.

| | B/render |
| --- | --- |
| `Div[Input.Value(…)]` — controlled | 1216 |
| `Div[Input.Bind(hoisted)]` — bound, expression built once | 2721 |
| `Div[Input.Bind(() => …)]` — bound | 3041 |
| …the same, against a model deriving `RaskMarkup` | 5011 |

### What changed in the pins

- They bind a plain model now. The aggregate ceiling drops **5600 → 3300 B**.
- The expensive shape keeps a pin of its own rather than being averaged into the representative one.
  It is not contrived: `Component : RaskMarkup`, so `Input.Bind(() => Draft)` against a component's
  own property lands there. Filed separately as **#803** — pinning it is not fixing it.
- The `CHANGELOG` entry shipped with #793 is annotated with the correction rather than quietly edited,
  so anyone who read the original sees what replaced it.

## The benchmark

`BoundControlRenderBenchmarks` closes the gap that surfaced all this. I overstated the gap when I
filed #802 and corrected it there: `ExpressionAccessorBenchmarks` *does* cover `ExpressionAccessor.Parse`.
What nothing covered was a bound control **rendered end to end** — and `ExpressionAccessorBenchmarks`
hoists its expressions in `[GlobalSetup]`, so it deliberately excludes tree construction.
`LiveDiffPayload_InputTypingBurstBenchmarks` reads like form coverage but its inputs are
`Input.Value(…)`, i.e. controlled.

Three arms, mirroring the pins so the suite and the unit gate describe the same decomposition
(three-field form, `--job short`):

| Method | Mean | Allocated | Alloc Ratio |
| --- | ---: | ---: | ---: |
| Controlled | 863 ns | 6.77 KB | 1.00 |
| BoundHoisted | 1,733 ns | 9.39 KB | 1.39 |
| Bound | 2,092 ns | 10.38 KB | 1.53 |

The `Bound` − `BoundHoisted` delta is 0.99 KB over three inputs — ~330 B each, which is what
independently contradicted the 2311 B figure and started the investigation.

## Testing

- 11 pins pass, all absolute.
- The benchmark runs and produces the table above.
- The member-count result was isolated with a 200-property class that has **no inheritance**, so the
  effect is member count rather than anything specific to `RaskMarkup`'s hierarchy.
- I checked and **rejected** the obvious alternative explanation first: that the hoisted probe was
  cheap because a stable `Expression` instance left the input's props clean and the render cache served
  it. Forcing the input dirty every render moves the number by 175 B, not 2000.

## Gates

- `dotnet format Rask.slnx` — clean.
- `CI=true dotnet build Rask.slnx -c Release -warnaserror -p:EnforceCodeStyleInBuild=true` — 0 warnings, 0 errors.
- `scripts/run-unit-local.sh` — passed (pre-commit).
- `scripts/run-e2e-local.sh` + watch hot-reload gate — passed (pre-push).

Closes #802
