### PR TITLE
docs(native): correct when the Android half of #785 actually broke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,14 +178,20 @@ them until tagged releases begin.
   `BaseForegroundColor` are what you see; `UiKitViewOps` wrote `view.BackgroundColor` and
   `SetTitleColor`, which sit behind the configuration and are never seen. `ApplyButtonStyle` also
   assigned a **fresh** configuration on every `Style` write, so even a correct colour was discarded
-  whenever `Style` arrived last. On Android the same ordering bug in plainer form: `ApplyButtonStyle`
-  called `SetBackgroundColor` / `SetTextColor` unconditionally, wiping whatever came before it. The
-  props were order-dependent in a way nothing in the component surface hints at.
+  whenever `Style` arrived last.
+
+  Android's half of this was described wrongly here and is corrected: **the first render was fine.**
+  `NativeButton.WriteSurfaceProps` emits `Style` *before* `Color` and `Background`, so on a full node
+  build the colours are applied after the style and win. What was broken is the **incremental** path —
+  `NativeTreeDiffer.DiffProps` carries only the props that actually changed, so on a later frame where
+  `Style` changes and the colours do not, Android received `Style` alone and `ApplyButtonStyle` rewrote
+  both colours over values it was never sent. The fix below is right for that; only the account of when
+  it bites was wrong.
 
   Both backends now hold the three props together in a `NativeButtonAppearance` and repaint the whole
   of it on any write — the style first, then the explicit colours over it — so an explicit
-  `Background` / `Color` wins whatever order the patch delivers them in, which is the precedence
-  `NativeButton` already documented. Verified on an iPhone 17 Pro simulator: the pure-native showcase
+  `Background` / `Color` wins whether the patch carries all three or only one of them, which is the
+  precedence `NativeButton` already documented. Verified on an iPhone 17 Pro simulator: the pure-native showcase
   button went from system blue to the declared `#4C1D95` with white text.
 
   Two things found alongside it and fixed here. An **unstyled** `NativeButton` rendered Filled on iOS

--- a/src/Rask.Native/Platforms/Android/AndroidViewOps.cs
+++ b/src/Rask.Native/Platforms/Android/AndroidViewOps.cs
@@ -122,11 +122,13 @@ internal sealed class AndroidViewOps(Context context, Action<NativeSurfaceEvent>
                 linesText.SetMaxLines(lines <= 0 ? int.MaxValue : lines);
                 break;
 
-            // Ahead of the generic colour cases on purpose. ApplyButtonStyle writes the style's own fill
-            // and title colour unconditionally, so a Style arriving after a Background or Color used to
-            // throw them away — the props were order-dependent in a way nothing in the component surface
-            // hints at (#785). Routing all three through the retained appearance and repainting the whole
-            // of it removes the ordering from the answer. Every button Create() makes is a RaskButton.
+            // Ahead of the generic colour cases on purpose. A FULL node build was always fine here —
+            // WriteSurfaceProps emits Style before Color and Background, so the colours land after the
+            // style and win. The INCREMENTAL path was not: NativeTreeDiffer.DiffProps carries only the
+            // props that actually changed, so a frame that changes Style alone arrived as Style alone,
+            // and ApplyButtonStyle rewrote both colours over values it was never sent (#785). Holding
+            // all three on the view and repainting the whole appearance is what makes a partial patch
+            // land the same as a full one. Every button Create() makes is a RaskButton.
             case NativePropId.Color or NativePropId.Background or NativePropId.Style
                 when view is RaskButton appearanceButton:
                 if (appearanceButton.ButtonAppearance.Write(id, value, unset))
@@ -367,8 +369,8 @@ internal sealed class AndroidViewOps(Context context, Action<NativeSurfaceEvent>
     }
 
     // The WHOLE appearance, re-derived from scratch on every write to any of its three props: the style
-    // first, then the explicit colours over it, so an explicit Background or Color wins whichever order
-    // the patch delivered them in. NativeButton documents exactly that precedence.
+    // first, then the explicit colours over it, so an explicit Background or Color wins whether the
+    // patch carried all three or only one. NativeButton documents exactly that precedence.
     private void ApplyButtonAppearance(RaskButton button)
     {
         var appearance = button.ButtonAppearance;


### PR DESCRIPTION
## Summary

A correction to #798's account of the Android half of #785. **The fix that shipped is right; the
description of when it breaks was wrong**, and the #775 spike had already said so before #798 was
written — I did not read that comment.

## What #798 claimed

> On Android the same ordering bug in plainer form: `ApplyButtonStyle` called `SetBackgroundColor` /
> `SetTextColor` unconditionally, wiping whatever came before it. The props were order-dependent in a
> way nothing in the component surface hints at.

## What is actually true

`NativeButton.WriteSurfaceProps` emits the props in this order:

```csharp
props.Enum(NativePropId.Style, Style);
props.Color(NativePropId.Color, Color);
props.Color(NativePropId.Background, Background);
```

`Style` goes **first**. So on a full node build the colours are applied *after* the style and win —
**Android's first render was always correct**, which is what the #775 spike observed on an API 36
emulator.

The real hazard is the **incremental** path. `NativeTreeDiffer.DiffProps` returns "only the props that
actually changed", so a frame that changes `Style` and nothing else reaches the backend as `Style`
alone — and the old `ApplyButtonStyle` then rewrote *both* colours over values it was never sent. The
component still has its `Background` / `Color`; they simply are not in that patch.

Holding all three on the retained view and repainting the whole appearance — what #798 shipped — is
precisely the fix for that. No code changes here beyond comments.

## Unaffected

- **iOS.** There `UIButtonConfiguration` painted over `BackgroundColor` and `SetTitleColor` on every
  render regardless of order, so the colours never applied at all. That is what the simulator
  before/after in #798 showed, and it stands.
- **The unstyled-default fix.** A `null` `Style` emits no prop (`NativePropWriter.Number` skips
  nulls), and only iOS applied a default at creation — so one tree rendered Filled on iOS and a bare
  platform button on Android. That was correct as reported and is unchanged.

## Changed here

- The CHANGELOG entry, corrected in place with the real mechanism rather than quietly reworded.
- The comment in `AndroidViewOps.SetProp` and on `ApplyButtonAppearance`, which repeated the same
  wrong reasoning where the next reader of that switch would find it.

## Gates

- `dotnet format Rask.slnx` — clean.
- `CI=true dotnet build Rask.slnx -c Release -warnaserror -p:EnforceCodeStyleInBuild=true` — 0 warnings, 0 errors.
- `dotnet build src/Rask.Native -c Release -p:RaskNativeHeads=ios -warnaserror` — clean.
- `scripts/run-unit-local.sh` — passed (pre-commit).
- `scripts/run-e2e-local.sh` + watch hot-reload gate — passed (pre-push).
