### PR TITLE
feat(native): let an app boot with no WebView at all — RunNativeAsync, the pure-native model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **A native app can boot with no WebView at all** — `NativeAppHost.RunNativeAsync<TApp>(INativeSurface)`,
+  the pure-native model (part of #777, the four-models epic). The component tree paints as real platform
+  views and nothing HTML is instantiated.
+
+  `NativeLiveSession` required an `INativeWebView` in its constructor, pushed every frame through it, and
+  implemented back navigation as `window.history.back()`, so a WebView-less app was unrepresentable. The
+  WebView is optional now. It turned out to be a small seam: `IsNativeFrame` already gated emission, so a
+  pure-native frame never reached the WebView send in the first place.
+
+  Three things a pure-native app needs, which it now has:
+
+  - **The first render happens without a handshake.** A WebView client posts `ready` once its document
+    loads; with no document, the host performs the first render itself before returning, so the caller
+    gets an app already on screen.
+  - **Back walks the session's own history.** With a WebView the page's history is the single source of
+    truth and the session keeps none — one history, not two that can disagree. With no WebView the
+    session keeps its own, seeded with the boot route. At the first entry back does nothing on purpose,
+    so Android's hardware Back falls through to the activity and closes the app rather than trapping the
+    user.
+  - **The two things that cannot work say so.** Rendering HTML with no WebView, and calling `IJSRuntime`,
+    both raise named errors naming the model and the way out.
+
+  Both errors are more careful than they look. The HTML frame is **dropped and recorded**, then turned
+  into a throw by `RunNativeAsync` once the render has unwound — throwing from inside `SendFrameAsync`
+  reaches the root error boundary, whose answer is to render an error page, which is more HTML, for ever.
+  A hung test host is how that was found. The `IJSRuntime` out-of-render path had the mirror-image
+  problem: it dispatched through `_webView?.`, so with no WebView it silently did nothing and left the
+  caller's `await` pending for ever — the worst way to report "there is no JS engine here".
+
+  Not yet done on this issue: the `rask new --template native` scaffold still produces the WebView-hybrid
+  shape, and the platform heads do not yet wire Android's hardware Back to `GoBackAsync`. Nine tests cover
+  the model on the existing `FakeNativeSurface` harness.
+
 - **`rask new --template native --host server|wasm-hosted` now scaffolds both halves as one solution.** The
   remote models used to emit only the shell, pointed at a placeholder `https://app.example.com/`, so the
   first command produced something that could not run and did not say what was missing. They now scaffold

--- a/src/Rask.Native/NativeAppHost.cs
+++ b/src/Rask.Native/NativeAppHost.cs
@@ -152,12 +152,76 @@ public sealed class NativeAppHost
     ///     The root <see cref="Component" />. It renders into <c>&lt;body&gt;</c>; Rask composes the
     ///     document around it (RASK021 flags a root that builds the shell itself).
     /// </typeparam>
-    public async Task<NativeApp> RunLocalAsync<
+    public Task<NativeApp> RunLocalAsync<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(
         INativeWebView webView, string initialPath = "/")
         where TApp : Component
     {
         ArgumentNullException.ThrowIfNull(webView);
+        return RunAsync<TApp>(webView, initialPath);
+    }
+
+    /// <summary>
+    ///     <b>Native + Pure-native</b> — boots the app with <b>no WebView at all</b>. The component tree
+    ///     paints as real platform views through <paramref name="surface" />, and nothing HTML is
+    ///     instantiated.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The counterpart to <see cref="RunLocalAsync{TApp}" />, which drives a WebView and can mix
+    ///         native screens into it. Use this when the app has no HTML at all: there is no WebView to
+    ///         create, so nothing pays for one, and the first frame is a view tree rather than a document.
+    ///     </para>
+    ///     <para>
+    ///         Two things behave differently and are not hidden. <c>IJSRuntime</c> has no engine to dispatch
+    ///         into and says so if called, and rendering HTML raises a named error from
+    ///         <c>NativeLiveSession.SendFrameAsync</c> rather than failing silently — see #777. Back
+    ///         navigation moves to the session's own history, so Android's hardware Back button works with
+    ///         no page history to pop.
+    ///     </para>
+    ///     <para>
+    ///         There is also no <c>ready</c> handshake: a WebView client posts that once its document has
+    ///         loaded, and with no document this host performs the first render itself before returning, so
+    ///         the caller gets an app that is already on screen.
+    ///     </para>
+    /// </remarks>
+    /// <typeparam name="TApp">The root component.</typeparam>
+    /// <param name="surface">The platform surface backend that paints the view tree.</param>
+    /// <param name="initialPath">The route to boot on.</param>
+    public async Task<NativeApp> RunNativeAsync<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(
+        INativeSurface surface, string initialPath = "/")
+        where TApp : Component
+    {
+        ArgumentNullException.ThrowIfNull(surface);
+
+        // Registered before the provider is built so the session resolves the same instance the caller
+        // owns, exactly as a platform head's UsePlatform registration would.
+        Services.AddSingleton(surface);
+
+        var app = await RunAsync<TApp>(webView: null, initialPath).ConfigureAwait(false);
+
+        // No client to post `ready`, so the first frame is this host's job.
+        await app.Session.InitialRenderAsync().ConfigureAwait(false);
+
+        // …and if that frame turned out to be HTML, say so HERE rather than from inside the render. The
+        // session drops such a frame and records it, because throwing mid-render reaches the root error
+        // boundary, whose answer is to render an error page — more HTML, dropped again, for ever. By this
+        // point the render has unwound, so the error is just an error.
+        if (app.Session.RenderedHtmlWithNoWebView)
+        {
+            await app.DisposeAsync().ConfigureAwait(false);
+            throw new InvalidOperationException(NativeLiveSession.HtmlWithoutWebViewMessage);
+        }
+
+        return app;
+    }
+
+    private async Task<NativeApp> RunAsync<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(
+        INativeWebView? webView, string initialPath)
+        where TApp : Component
+    {
 
         // Native-first wiring: the platform's native backends first, then the JS-backed fallbacks via TryAdd,
         // so a natively-backed interface wins and everything else resolves to the WebView's JS engine. The
@@ -196,7 +260,11 @@ public sealed class NativeAppHost
         // The WebView drives everything through this single message channel: the initial-render handshake
         // (ready), IJSRuntime results (jsResult), JS-initiated [JSInvokable] (dotNetInvoke), and component
         // events (everything else → the session). Mirrors how the WASM host multiplexes its JSExports.
-        webView.OnMessage = json => RouteMessageAsync(nativeApp, json);
+        // Absent in the pure-native model, where the surface's own event channel below is the only input.
+        if (webView is not null)
+        {
+            webView.OnMessage = json => RouteMessageAsync(nativeApp, json);
+        }
 
         // If a native-chrome backend is registered, route its bar interactions through the SAME dispatcher —
         // a button tap ({type:"nativeTap"}) and a tab tap ({type:"navigate"}) re-enter the router exactly like

--- a/src/Rask.Native/NativeJSRuntime.cs
+++ b/src/Rask.Native/NativeJSRuntime.cs
@@ -43,25 +43,58 @@ internal sealed class NativeJSRuntime : RaskJSRuntimeBase
         }
     }
 
+    internal const string NoJavaScriptEngineMessage =
+        "This app is running pure-native (NativeAppHost.RunNativeAsync), so there is no WebView and no "
+        + "JavaScript engine for IJSRuntime to call into. Use a native capability instead (IShare, "
+        + "IGeolocation, …), or boot with RunLocalAsync and host a NativeWebView on the route that needs JS.";
+
     /// <summary>Bind the session (for render-time queuing) and the WebView (for out-of-render dispatch).</summary>
-    public void AttachHost(ILiveJsHost host, INativeWebView webView)
+    /// <remarks>
+    ///     <paramref name="webView" /> is <see langword="null" /> in the pure-native model
+    ///     (<c>NativeAppHost.RunNativeAsync</c>), where there is no JS engine at all. The session still
+    ///     attaches so that a call gets the accurate error below rather than "not in a session scope",
+    ///     which would send somebody looking for a lifecycle-hook problem they do not have (#777).
+    /// </remarks>
+    public void AttachHost(ILiveJsHost host, INativeWebView? webView)
     {
         _host = host;
         _webView = webView;
     }
 
-    protected override ILiveJsHost CurrentHost =>
-        _host ?? throw new InvalidOperationException(
-            "IJSRuntime can only be used within a Rask session scope. " +
-            "Inject it through a Component ctor (DI) and call it from a lifecycle hook " +
-            "(OnMountAsync, OnRenderedAsync) or event handler.");
+    protected override ILiveJsHost CurrentHost
+    {
+        get
+        {
+            if (_host is null)
+            {
+                throw new InvalidOperationException(
+                    "IJSRuntime can only be used within a Rask session scope. " +
+                    "Inject it through a Component ctor (DI) and call it from a lifecycle hook " +
+                    "(OnMountAsync, OnRenderedAsync) or event handler.");
+            }
+
+            if (_webView is null)
+            {
+                throw new InvalidOperationException(NoJavaScriptEngineMessage);
+            }
+
+            return _host;
+        }
+    }
 
     // Outside a render, evaluate the invoke immediately in the WebView. window.__raskNative.beginInvokeJS
     // mirrors the WASM bridge's dispatchJsInvoke: it runs the identified function against argsJson and posts
     // a {type:'jsResult', ...} message back, which NativeAppHost feeds to DotNetDispatcher.EndInvokeJS. taskId
     // / targetInstanceId travel as strings (JS numbers can't hold the full range), matching the WASM host.
-    protected override void DispatchOutsideRender(PendingJsInvoke invoke) =>
-        _ = _webView?.EvaluateJavaScriptAsync(
+    protected override void DispatchOutsideRender(PendingJsInvoke invoke)
+    {
+        if (_webView is null)
+        {
+            // Dropping this would leave the caller's await pending for ever. Throwing reaches them.
+            throw new InvalidOperationException(NoJavaScriptEngineMessage);
+        }
+
+        _ = _webView.EvaluateJavaScriptAsync(
             "window.__raskNative.beginInvokeJS(" +
             invoke.TaskId.ToString() + "," +
             Quote(invoke.Identifier) + "," +
@@ -72,6 +105,7 @@ internal sealed class NativeJSRuntime : RaskJSRuntimeBase
             (invoke.ArgsJson is null ? "null" : Quote(invoke.ArgsJson)) + "," +
             (int)invoke.ResultType + "," +
             Quote(invoke.TargetInstanceId.ToString()) + ")");
+    }
 
     protected override void EndInvokeDotNet(DotNetInvocationInfo invocationInfo, in DotNetInvocationResult invocationResult)
     {

--- a/src/Rask.Native/NativeLiveSession.cs
+++ b/src/Rask.Native/NativeLiveSession.cs
@@ -34,7 +34,11 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
     // — stays sequential (each acquires a free lock). Lock order is always _lock (if any) then _renderLock;
     // RenderInScopeCoreAsync takes only _renderLock, so there's no inversion.
     private readonly SemaphoreSlim _renderLock = new(1, 1);
-    private readonly INativeWebView _webView;
+    // Optional since #777. A pure-native app (RunNativeAsync) boots with an INativeSurface and NO WebView
+    // at all, and never reaches the two places this is used: SendFrameAsync is gated behind IsNativeFrame,
+    // which is false only when the frame carries HTML, and GoBackAsync falls back to this session's own
+    // history. Both raise a named error rather than an NRE if an app does reach them without one.
+    private readonly INativeWebView? _webView;
     private readonly IUserProvider? _userProvider;
 
     // Set by BuildPayloadAsync when the frame it built carries queued IJSRuntime calls. The
@@ -64,25 +68,54 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
     // view it is not showing — see INativeSurface. That is what makes switching between a web route and a
     // native route free: neither side re-mounts, and coming back to a web page does not reload it.
     private readonly INativeSurface? _surface;
+
+    // Back history for the pure-native model. With a WebView, back is window.history.back() and the page's
+    // own history is the single source of truth; with no WebView there is no page and no history, so the
+    // session keeps its own. Entries are full urls (path + query), oldest first, current LAST — the same
+    // thing the WebView would have held. Only maintained when _webView is null, so the hybrid model keeps
+    // exactly one history rather than two that can disagree.
+    private readonly List<string> _nativeHistory = [];
     private readonly NativeTreeBuilder _treeBuilder = new();
     private NativeNode? _surfaceTree;
     private IReadOnlyDictionary<int, Func<string?, Task>> _surfaceHandlers =
         new Dictionary<int, Func<string?, Task>>();
 
-    public NativeLiveSession(Component view, IServiceProvider services, INativeWebView webView, LiveDiffMode diffMode)
+    public NativeLiveSession(Component view, IServiceProvider services, INativeWebView? webView, LiveDiffMode diffMode)
         : base(view, services, diffMode)
     {
         _webView = webView;
         _chrome = services.GetService<INativeChrome>();
         _surface = services.GetService<INativeSurface>();
 
-        // Bind this session to the runtime so its BeginInvokeJS queues onto JsInvokes.
+        if (webView is null && _surface is null)
+        {
+            throw new InvalidOperationException(
+                "A native session needs somewhere to paint: pass an INativeWebView (NativeAppHost."
+                + "RunLocalAsync, the WebView-hybrid model) or register an INativeSurface and use "
+                + "RunNativeAsync (the pure-native model). It was given neither.");
+        }
+
+        if (webView is null && services.GetService<RouteState>() is { } bootRoute)
+        {
+            // The boot route is history entry zero. Without it the first navigation would be the only
+            // entry, and back from the second screen would have nowhere to go.
+            _nativeHistory.Add(QueryString.Build(bootRoute.Path, bootRoute.Query));
+        }
+
+        // Bind this session to the runtime so its BeginInvokeJS queues onto JsInvokes. Attached even with
+        // no WebView, so a pure-native app that calls IJSRuntime is told THAT — see
+        // NativeJSRuntime.CurrentHost — rather than "not in a session scope", which would send somebody
+        // looking for a lifecycle-hook problem they do not have.
         services.GetService<NativeJSRuntime>()?.AttachHost(this, webView);
 
         // The base ctor already registered this session for hot-reload repaints; this only points the
         // "applied" indicator at the same WebView. No-op on a device build, where MetadataUpdater is
-        // unsupported and no delta can arrive anyway (#565).
-        HotReload.NativeHotReloadBridge.Attach(webView);
+        // unsupported and no delta can arrive anyway (#565), and skipped outright with no WebView to
+        // indicate on.
+        if (webView is not null)
+        {
+            HotReload.NativeHotReloadBridge.Attach(webView);
+        }
 
         if (services.GetService<IUserProvider>() is { } userProvider)
         {
@@ -572,7 +605,87 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
     ///     then sends a <c>navigate</c> to the now-current (previous) route, which re-enters the router — so back
     ///     reuses the existing history plumbing rather than a parallel server-side stack.
     /// </summary>
-    public ValueTask GoBackAsync() => _webView.EvaluateJavaScriptAsync("window.history.back()");
+    public ValueTask GoBackAsync() =>
+        _webView is { } webView
+            ? webView.EvaluateJavaScriptAsync("window.history.back()")
+            : GoBackNativeAsync();
+
+    /// <summary>
+    ///     Back with no WebView: pop this session's own history and re-enter the router at the entry
+    ///     underneath, which is what <c>popstate</c> would otherwise have done for us.
+    /// </summary>
+    /// <remarks>
+    ///     At the first entry there is nothing to go back to, and this does nothing — deliberately. On
+    ///     Android that lets the hardware Back button fall through to the activity and close the app, which
+    ///     is the platform behaviour a user expects at the root of a task; swallowing it would trap them.
+    /// </remarks>
+    private async ValueTask GoBackNativeAsync()
+    {
+        string previous;
+        lock (_nativeHistory)
+        {
+            if (_nativeHistory.Count < 2)
+            {
+                return;
+            }
+
+            _nativeHistory.RemoveAt(_nativeHistory.Count - 1);
+            previous = _nativeHistory[^1];
+        }
+
+        // Replace, not push: this IS the pop, so re-recording it would make back a no-op that alternates
+        // between two entries for ever.
+        var (path, query) = SplitUrl(previous);
+        await HandleNavigateAsync(path, query, replace: true).ConfigureAwait(false);
+    }
+
+    /// <summary>Whether this session owns its back history — true exactly when there is no WebView.</summary>
+    internal bool OwnsBackHistory => _webView is null;
+
+    /// <summary>This session's back history, current entry last. Empty unless it owns one.</summary>
+    internal IReadOnlyList<string> BackHistory
+    {
+        get
+        {
+            lock (_nativeHistory)
+            {
+                return _nativeHistory.ToArray();
+            }
+        }
+    }
+
+    private void RecordNativeHistory(string fullUrl, bool replace)
+    {
+        if (_webView is not null)
+        {
+            return;
+        }
+
+        lock (_nativeHistory)
+        {
+            if (replace && _nativeHistory.Count > 0)
+            {
+                _nativeHistory[^1] = fullUrl;
+                return;
+            }
+
+            // A navigate to where we already are is not a history entry — otherwise back would have to be
+            // pressed twice to move once.
+            if (_nativeHistory.Count > 0
+                && string.Equals(_nativeHistory[^1], fullUrl, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _nativeHistory.Add(fullUrl);
+        }
+    }
+
+    private static (string Path, string Query) SplitUrl(string url)
+    {
+        var mark = url.IndexOf('?', StringComparison.Ordinal);
+        return mark < 0 ? (url, string.Empty) : (url[..mark], url[mark..]);
+    }
 
     /// <summary>
     ///     Handle an interaction on a pure-native view — a button tap, a text field's edit, a switch toggle.
@@ -645,7 +758,7 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
     ///     Handle a bar-button tap (<c>{"type":"nativeTap","id":"…"}</c>): look up the button's <c>OnClick</c>,
     ///     invoke it (its factory wrapper re-renders the owner), then render + emit + push exactly like
     ///     <see cref="DispatchAsync" />. Returns the sent frame bytes (the test seam). A tab tap arrives as a
-    ///     <c>navigate</c> message and flows through <see cref="HandleNavigateAsync" /> instead.
+    ///     <c>navigate</c> message and flows through <see cref="HandleNavigateAsync(JsonElement)" /> instead.
     /// </summary>
     public async Task<byte[]> DispatchNativeTapAsync(byte[] json)
     {
@@ -733,7 +846,39 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
     // whose window.__raskNative.applyRender consumes it (applyDiff / morph). The memory is valid until the
     // returned ValueTask completes (the base awaits SendFrameAsync before swapping buffers), so a UI-thread
     // hop inside the platform implementation is safe.
-    protected override ValueTask SendFrameAsync(ReadOnlyMemory<byte> frame) => _webView.ApplyRenderAsync(frame);
+    protected override ValueTask SendFrameAsync(ReadOnlyMemory<byte> frame)
+    {
+        if (_webView is { } webView)
+        {
+            return webView.ApplyRenderAsync(frame);
+        }
+
+        // Pure-native, and the frame carries HTML — there is nothing to paint it into. This RECORDS and
+        // drops rather than throwing, deliberately: SendFrameAsync runs inside the render pipeline beneath
+        // the root error boundary, which answers an exception by rendering an error page. That page is
+        // more HTML, which lands here again, and the app spins for ever instead of reporting anything.
+        //
+        // So the frame is dropped, the fact is reported, and RunNativeAsync turns the first occurrence
+        // into a thrown, named error once the render has safely unwound — see RenderedHtmlWithNoWebView.
+        RenderedHtmlWithNoWebView = true;
+        RaskDiagnostics.Report(
+            RaskLogLevel.Error,
+            "Rask.Native",
+            HtmlWithoutWebViewMessage);
+        return default;
+    }
+
+    /// <summary>
+    ///     Whether a frame carrying HTML was dropped because this session has no WebView to paint it into.
+    /// </summary>
+    internal bool RenderedHtmlWithNoWebView { get; private set; }
+
+    /// <summary>What to tell somebody whose pure-native app rendered HTML.</summary>
+    internal const string HtmlWithoutWebViewMessage =
+        "This app is running pure-native (NativeAppHost.RunNativeAsync) and rendered HTML, which needs a "
+        + "WebView to display, so the frame was dropped. Either make the route's content a NativeScreen "
+        + "tree, or host a NativeWebView on it and boot with RunLocalAsync so there is a WebView to paint "
+        + "into.";
 
     protected override async Task RenderInScopeCoreAsync()
     {
@@ -916,14 +1061,14 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
         }
     }
 
-    private async Task<byte[]> HandleNavigateAsync(JsonElement root)
+    private Task<byte[]> HandleNavigateAsync(JsonElement root)
     {
         var navPath = root.TryGetProperty("path", out var p) && p.ValueKind == JsonValueKind.String
             ? p.GetString()
             : null;
         if (string.IsNullOrEmpty(navPath))
         {
-            return Array.Empty<byte>();
+            return Task.FromResult(Array.Empty<byte>());
         }
 
         var navQueryString = root.TryGetProperty("query", out var q) && q.ValueKind == JsonValueKind.String
@@ -931,6 +1076,13 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
             : string.Empty;
         var replace = root.TryGetProperty("replace", out var rEl) && rEl.ValueKind == JsonValueKind.True;
 
+        return HandleNavigateAsync(navPath, navQueryString, replace);
+    }
+
+    // The navigation itself, with the message already parsed. Split out so pure-native back navigation can
+    // re-enter the router directly (GoBackNativeAsync) instead of synthesising a JSON message to parse.
+    private async Task<byte[]> HandleNavigateAsync(string navPath, string navQueryString, bool replace)
+    {
         var fullUrl = string.IsNullOrEmpty(navQueryString)
             ? navPath
             : navQueryString.StartsWith("?", StringComparison.Ordinal)
@@ -944,6 +1096,7 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
             var routeState = Services.GetRequiredService<RouteState>();
             routeState.Path = navPath;
             routeState.Query = QueryString.Parse(navQueryString);
+            RecordNativeHistory(fullUrl, replace);
 
             await _renderLock.WaitAsync().ConfigureAwait(false);
             try

--- a/tests/Rask.Native.Tests/Session/PureNativeBootTests.cs
+++ b/tests/Rask.Native.Tests/Session/PureNativeBootTests.cs
@@ -1,0 +1,218 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using Rask.Core;
+using Rask.Core.Routing;
+using Rask.Native.Components;
+using Rask.Native.Surface;
+using Rask.Native.Tests.Infrastructure;
+
+namespace Rask.Native.Tests.Session;
+
+/// <summary>
+///     Booting with <b>no WebView at all</b> — the pure-native model (#777). The session used to require an
+///     <c>INativeWebView</c> in its constructor, push every frame through it, and implement back navigation
+///     as <c>window.history.back()</c>, so a WebView-less app was unrepresentable.
+/// </summary>
+[Collection("NativeSession")]
+public sealed class PureNativeBootTests : ResettingTestBase
+{
+    [Fact]
+    public async Task An_app_boots_and_paints_with_no_WebView_instantiated()
+    {
+        var (app, surface) = await NewPureNativeAsync();
+
+        // The first render happens without a `ready` handshake — there is no client to send one.
+        Assert.Equal("mount", Assert.Single(surface.Calls));
+        Assert.NotNull(surface.Tree);
+        Assert.False(surface.ShowingWebView);
+
+        await app.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task A_tap_re_renders_through_the_surface_alone()
+    {
+        var (app, surface) = await NewPureNativeAsync();
+        var tapId = FindTapId(surface.Tree!);
+        Assert.True(tapId >= 0, "the button should carry a tap handler id");
+
+        await surface.OnSurfaceEvent!(
+            new NativeSurfaceEvent(tapId, NativeSurfaceEventKind.Tap, null));
+
+        // A patch, not a re-mount: the tree is retained across the interaction exactly as on a device.
+        Assert.Equal(1, surface.MountCount);
+        Assert.Contains(surface.Calls, c => c.StartsWith("patch:", StringComparison.Ordinal));
+
+        await app.DisposeAsync();
+    }
+
+    /// <summary>
+    ///     Back with no page history to pop. The session keeps its own, so Android's hardware Back button
+    ///     has something to act on.
+    /// </summary>
+    [Fact]
+    public async Task Back_navigation_walks_the_sessions_own_history()
+    {
+        var (app, _) = await NewPureNativeAsync();
+        var routeState = app.Services.GetRequiredService<RouteState>();
+
+        Assert.True(app.Session.OwnsBackHistory);
+        Assert.Equal(["/"], app.Session.BackHistory);
+
+        await app.Session.DispatchAsync(Message("""{"type":"navigate","path":"/second"}"""));
+        Assert.Equal(["/", "/second"], app.Session.BackHistory);
+        Assert.Equal("/second", routeState.Path);
+
+        await app.Session.GoBackAsync();
+
+        Assert.Equal(["/"], app.Session.BackHistory);
+        Assert.Equal("/", routeState.Path);
+
+        await app.DisposeAsync();
+    }
+
+    /// <summary>
+    ///     At the first entry back does nothing, so on Android the hardware button falls through to the
+    ///     activity and closes the app — the platform behaviour at the root of a task. Swallowing it would
+    ///     trap the user.
+    /// </summary>
+    [Fact]
+    public async Task Back_at_the_first_entry_does_nothing()
+    {
+        var (app, _) = await NewPureNativeAsync();
+
+        await app.Session.GoBackAsync();
+
+        Assert.Equal(["/"], app.Session.BackHistory);
+        Assert.Equal("/", app.Services.GetRequiredService<RouteState>().Path);
+
+        await app.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Navigating_to_where_you_already_are_is_not_a_history_entry()
+    {
+        var (app, _) = await NewPureNativeAsync();
+
+        await app.Session.DispatchAsync(Message("""{"type":"navigate","path":"/second"}"""));
+        await app.Session.DispatchAsync(Message("""{"type":"navigate","path":"/second"}"""));
+
+        // Otherwise back would have to be pressed twice to move once.
+        Assert.Equal(["/", "/second"], app.Session.BackHistory);
+
+        await app.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task A_replace_navigation_overwrites_the_current_entry()
+    {
+        var (app, _) = await NewPureNativeAsync();
+
+        await app.Session.DispatchAsync(Message("""{"type":"navigate","path":"/second"}"""));
+        await app.Session.DispatchAsync(
+            Message("""{"type":"navigate","path":"/third","replace":true}"""));
+
+        Assert.Equal(["/", "/third"], app.Session.BackHistory);
+
+        await app.DisposeAsync();
+    }
+
+    /// <summary>
+    ///     The WebView-hybrid model keeps exactly one history — the page's — so the session must not start
+    ///     a second one that could disagree with it.
+    /// </summary>
+    [Fact]
+    public async Task A_session_with_a_WebView_keeps_no_history_of_its_own()
+    {
+        var (app, _, _) = await NativeSessionHarness.NewSessionAsync();
+
+        Assert.False(app.Session.OwnsBackHistory);
+        await app.Session.DispatchAsync(Message("""{"type":"navigate","path":"/second"}"""));
+        Assert.Empty(app.Session.BackHistory);
+
+        await app.DisposeAsync();
+    }
+
+    /// <summary>
+    ///     Rendering HTML with no WebView is a real mistake with a silent failure mode, so it names itself.
+    /// </summary>
+    [Fact]
+    public async Task Rendering_HTML_with_no_WebView_says_so()
+    {
+        var host = NativeAppHost.CreateDefault();
+        var surface = new FakeNativeSurface();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => host.RunNativeAsync<NativeStubApp>(surface));
+
+        Assert.Contains("pure-native", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("NativeScreen", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     And so does calling <c>IJSRuntime</c>, rather than reporting a session-scope problem the app
+    ///     does not have.
+    /// </summary>
+    [Fact]
+    public async Task Calling_IJSRuntime_with_no_WebView_says_so()
+    {
+        var (app, _) = await NewPureNativeAsync();
+        var js = app.Services.GetRequiredService<IJSRuntime>();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await js.InvokeVoidAsync("alert", "hi"));
+
+        Assert.Contains("pure-native", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("no JavaScript engine", ex.Message, StringComparison.Ordinal);
+
+        await app.DisposeAsync();
+    }
+
+    private static byte[] Message(string json) => System.Text.Encoding.UTF8.GetBytes(json);
+
+    private static async Task<(NativeApp App, FakeNativeSurface Surface)> NewPureNativeAsync()
+    {
+        var host = NativeAppHost.CreateDefault();
+        var surface = new FakeNativeSurface();
+        var app = await host.RunNativeAsync<PureNativeStubApp>(surface);
+        return (app, surface);
+    }
+
+    private static int FindTapId(FakeNativeSurface.MutableNode node)
+    {
+        if (node.Props.TryGetValue(NativePropId.TapId, out var tap))
+        {
+            return (int)tap.Number;
+        }
+
+        foreach (var child in node.Children)
+        {
+            var found = FindTapId(child);
+            if (found >= 0)
+            {
+                return found;
+            }
+        }
+
+        return -1;
+    }
+}
+
+// A tree that is pure-native all the way down: no HTML anywhere, so nothing ever asks for a WebView.
+internal sealed partial class PureNativeStubApp : Component
+{
+    private readonly RouteState _routeState;
+
+    private int _taps;
+
+    public PureNativeStubApp(RouteState routeState) => _routeState = routeState;
+
+    protected override Component? Render() =>
+        NativeScreen[
+            NativeStack[
+                NativeLabel[$"path={_routeState.Path}"],
+                NativeLabel[$"taps={_taps}"],
+                NativeButton.OnClick(() => _taps++)["bump"]
+            ]
+        ];
+}


### PR DESCRIPTION
## Summary

**Part of #777 — the framework half. The issue stays open** for the scaffold and the platform heads
(see "What is not done" below).

`NativeLiveSession` took an `INativeWebView` in its constructor (`:72`), pushed every frame through it
(`:736`) and implemented back navigation as `window.history.back()` (`:575`), so a WebView-less app was
unrepresentable — **G5** in the epic. It is optional now, and
`NativeAppHost.RunNativeAsync<TApp>(INativeSurface)` boots an app whose tree paints as real platform
views with nothing HTML instantiated.

The seam turned out to be small: `IsNativeFrame` already gated emission, so a pure-native frame never
reached the WebView send in the first place. What needed building is the three things a WebView was
quietly providing.

## What a WebView was providing

**The first render.** A WebView client posts `ready` once its document loads, and that is what triggers
the first frame. With no document, the host renders once itself before returning, so the caller gets an
app already on screen.

**Back navigation.** With a WebView the page's history stays the single source of truth and the session
keeps none — one history, not two that can disagree, and `A_session_with_a_WebView_keeps_no_history_of_its_own`
pins that. With no WebView the session keeps its own, seeded with the boot route, collapsing a navigate
to where you already are and overwriting on `replace`.

At the first entry back does **nothing**, on purpose. On Android that lets the hardware button fall
through to the activity and close the app, which is the platform behaviour a user expects at the root of
a task; swallowing it would trap them.

## The two errors, both subtler than they look

Rendering HTML with no WebView, and calling `IJSRuntime`, cannot work. Both now name the model and the
way out — and getting there took two corrections:

- **The HTML frame is dropped and recorded**, and `RunNativeAsync` turns that into a throw once the
  render has unwound. Throwing from inside `SendFrameAsync` instead reaches the **root error boundary**,
  whose answer is to render an error page — which is more HTML, dropped again, for ever. I found this as
  a hung test host, not by reasoning about it.
- **`IJSRuntime` had the mirror-image bug.** `DispatchOutsideRender` went through `_webView?.`, so with
  no WebView it silently did nothing and left the caller's `await` **pending for ever**. A hang is the
  worst possible way to report "there is no JS engine here". It throws now.

`NativeJSRuntime` also attaches even without a WebView, so a call gets that message rather than
"IJSRuntime can only be used within a Rask session scope", which would send somebody looking for a
lifecycle-hook problem they do not have.

## Testing

- **9 new tests** on the existing `FakeNativeSurface` harness: boot with no WebView, a tap that patches
  rather than re-mounts, the full back-history behaviour (walk, floor, dedupe, replace), the
  with-a-WebView control, and both error paths.
- `Rask.Native.Tests` — **194 passed**.
- The iOS head builds clean at `-warnaserror`.

## What is not done

Deliberately out of this PR, and why #777 is not closed:

- `rask new --template native` still scaffolds the WebView-hybrid shape. Flipping it changes what every
  native scaffold produces, which deserves its own review rather than riding along here.
- The platform heads do not yet route Android's hardware Back button to `GoBackAsync`.
- The issue's "done when" is an app running on a **simulator and an emulator**. I can drive an iOS
  simulator in this environment; there is no Android SDK installed, so the emulator half is not
  something I can verify — CI covers Android compilation only.

## Gates

- `dotnet format Rask.slnx` — clean.
- `CI=true dotnet build Rask.slnx -c Release -warnaserror -p:EnforceCodeStyleInBuild=true` — 0 warnings, 0 errors.
- `dotnet build src/Rask.Native -c Release -p:RaskNativeHeads=ios -warnaserror` — clean.
- `scripts/run-unit-local.sh` — passed (pre-commit).
- `scripts/run-e2e-local.sh` + watch hot-reload gate — passed (pre-push).
- No benchmark: this adds a boot path, and changes nothing on the render hot path for existing apps.

Part of #777
