### PR TITLE
test(native): boot a published WASM client in the Android WebView, closing Phase 0 (#775)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **The last Phase 0 evidence gap is closed: a published WASM client boots inside the Android WebView too**
+  (#775, the four-models epic). `samples/WasmInWebViewSpike` grows an Android head, so both platforms now
+  answer the question the `wasm` model (#780) rests on. It boots and renders from the app's own bundled
+  assets over `https://appassets.rask/`, fully offline: 74 assets served, **zero misses**, and `.wasm`
+  served as `application/wasm` with no streaming-compilation fallback. Cold start is ~390 ms to the
+  activity and ~1.2 s more to first render applied.
+
+  Three things Android answered differently from iOS, all of which belong to #780's design:
+
+  - **Package size is 7.5 MB, not 12 MB.** The bundle is 20 MB published and 12 MB once the `.br`/`.gz`
+    siblings are dropped (neither head negotiates content encoding, so they are pure weight) — but an APK
+    deflates its assets, where an IPA stores them. 12 MB is the iOS number; Android pays 7.5 MB.
+  - **The origin-root claim reproduces identically.** `NativeOriginAssets.Resolve` takes `/`,
+    `/index.html` and `/index.native.html` for the native boot shell before consulting the bundle, so the
+    WASM shell cannot live at the root — and serving it elsewhere is not cosmetic: the router seeds the
+    document's path, so `/app.html` rendered *Not found*. Serving the bundle's own `index.html` at `/`
+    fixes it (`initial path=/`), which is the shape of the fix #780 owes.
+  - **The service worker is never even requested**, on either platform. On iOS the custom scheme forbids
+    it; on Android the origin is a secure context and it still did not register. Either way the bundle is
+    already offline, so what the service worker was doing for the app is the open question, not whether it
+    can run.
+
+  **A defect the spike found: the app renders completely unstyled on the bundled-asset origin.** Every
+  `<link rel="stylesheet">` the head morph manages — the keyed ones, `data-rask-key` — is fetched, served
+  200 with `text/css`, and then never becomes a CSSOM stylesheet; only the two unkeyed links do
+  (`document.styleSheets` is 2 of 7). The bytes are provably intact: a `fetch()` of the same URL from the
+  page returns the correct 15721 bytes of CSS. It is not the asset path and not the spike's plumbing — the
+  spike configures the WebView exactly as the shipping `RaskAndroidWebView` does — and it is not a general
+  WASM fault, since the same published bundle is fully styled in desktop Chromium over HTTP. Filed as
+  **#807**; it blocks #780 rather than Phase 0.
+
 - **A native app can boot with no WebView at all** — `NativeAppHost.RunNativeAsync<TApp>(INativeSurface)`,
   the pure-native model (part of #777, the four-models epic). The component tree paints as real platform
   views and nothing HTML is instantiated.

--- a/docs/native.md
+++ b/docs/native.md
@@ -61,13 +61,14 @@ and turns WebView events back into handler/navigate dispatches — structurally 
 
 ## Pure-native screens (no WebView)
 
-> **Status — both backends ship; neither has been run on a device.** The component family, the render →
-> view-tree → diff → patch pipeline, the surface/event contract and the mixed-surface switching all ship,
-> covered by unit tests against a test-double backend. The **iOS** (`RaskWkWebView`, UIKit) and **Android**
-> (`RaskAndroidWebView`, framework widgets) `INativeSurface` backends both ship and both compile against
-> their real platform SDKs — but neither has yet been run on a simulator, emulator or device, so treat the
-> on-screen result as unverified. Register no `INativeSurface` and your app keeps rendering through the
-> WebView exactly as before.
+> **Status — both backends ship, and both have now been run on a device.** The component family, the
+> render → view-tree → diff → patch pipeline, the surface/event contract and the mixed-surface switching
+> all ship, covered by unit tests against a test-double backend. The **iOS** (`RaskWkWebView`, UIKit) and
+> **Android** (`RaskAndroidWebView`, framework widgets) `INativeSurface` backends were both exercised on
+> real platforms by the #775 spike: iOS on an iPhone 17 Pro simulator and Android on an API 36 emulator,
+> each painting a real platform view tree inside the native chrome with no WebView showing, with route →
+> surface selection and tab tracking both working. Register no `INativeSurface` and your app keeps
+> rendering through the WebView exactly as before.
 
 `NativeScreen` is the pure-native counterpart of `NativeWebView`, and sits in the same slot — a sibling of
 the native bars. Everything inside it is a real platform view: no WebView, no HTML, no JavaScript.

--- a/samples/WasmInWebViewSpike/Platforms/Android/AndroidManifest.xml
+++ b/samples/WasmInWebViewSpike/Platforms/Android/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+	<!-- The spike serves everything from the app's own bundled assets over https://appassets.rask/, so it
+	     needs no network permission to boot. INTERNET is declared only so a failure to reach the network is
+	     a real 404 from the interceptor rather than a permission denial that would look like one. -->
+	<uses-permission android:name="android.permission.INTERNET"/>
+	<application android:label="Rask WASM Spike" android:allowBackup="false" android:supportsRtl="true"/>
+</manifest>

--- a/samples/WasmInWebViewSpike/Platforms/Android/MainActivity.cs
+++ b/samples/WasmInWebViewSpike/Platforms/Android/MainActivity.cs
@@ -1,0 +1,135 @@
+using Android.App;
+using Android.OS;
+using Android.Webkit;
+using Rask.Native;
+
+namespace Rask.Example.Native.WasmSpike;
+
+// SPIKE (#775, epic #774) — the Android half of "does a published Rask WASM client boot inside a platform
+// WebView, served from the app's own bundled-asset origin?" The iOS half passed; this answers the same
+// question against Chromium and the `https://appassets.rask/` origin.
+//
+// Mirrors Platforms/iOS/AppDelegate.cs: the WebView is wired here rather than via RaskAndroidWebView so the
+// spike can log every request and every console line, but resolution still goes through the SHIPPING
+// NativeOriginAssets.Resolve + AndroidBundledAssets.Read. What is under test is the real asset path; only
+// the plumbing around it is local.
+[Activity(Label = "Rask WASM Spike", MainLauncher = true, Exported = true,
+    Theme = "@android:style/Theme.Material.Light.NoActionBar")]
+public class MainActivity : Activity
+{
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+
+        WebView.SetWebContentsDebuggingEnabled(true);
+
+        var web = new WebView(this);
+        var settings = web.Settings;
+        settings.JavaScriptEnabled = true;
+        // The Mono runtime caches its boot config in localStorage, and the app's own state may use it too;
+        // it is off by default in a bare WebView and its absence surfaces as an opaque boot failure.
+        settings.DomStorageEnabled = true;
+
+        web.SetWebViewClient(new LoggingWebViewClient(RaskAndroidWebView.DefaultOrigin, AndroidBundledAssets.Read));
+        web.SetWebChromeClient(new ConsoleSink());
+
+        SetContentView(web);
+        web.LoadUrl(RaskAndroidWebView.DefaultOrigin);
+    }
+}
+
+// Every request the page makes, with the content type the SHIPPING table chose for it. That table is the
+// thing under test: a .wasm served as application/octet-stream is what costs WebAssembly streaming
+// instantiation, and it degrades to a console warning rather than a native error.
+internal sealed class LoggingWebViewClient(string origin, Func<string, byte[]?> readStaticFile) : WebViewClient
+{
+    // The page boots long after OnPageFinished (the runtime downloads and starts asynchronously), so the
+    // stylesheet probe is deferred rather than run immediately. It reports what actually reached the CSSOM,
+    // which is the difference between "the bytes were served" and "the styles applied".
+    public override void OnPageFinished(WebView? view, string? url)
+    {
+        base.OnPageFinished(view, url);
+        view?.PostDelayed(() => view.EvaluateJavascript(StyleProbe, null), 8000);
+    }
+
+    private const string StyleProbe = """
+        (function () {
+            var links = Array.prototype.map.call(document.querySelectorAll('link[rel=stylesheet]'), function (l) {
+                var rules = -1;
+                try { rules = l.sheet ? l.sheet.cssRules.length : -1; } catch (e) { rules = -2; }
+                return l.getAttribute('href') + ' sheet=' + (l.sheet ? 'yes' : 'NO') + ' rules=' + rules;
+            });
+            console.log('[probe] styleSheets=' + document.styleSheets.length + ' links=' + links.length);
+            links.forEach(function (l) { console.log('[probe] ' + l); });
+            var b = document.body;
+            console.log('[probe] body.bg=' + getComputedStyle(b).backgroundColor +
+                        ' font=' + getComputedStyle(b).fontFamily);
+            Array.prototype.forEach.call(document.querySelectorAll('link[rel=stylesheet]'), function (l) {
+                console.log('[probe] node parent=' + l.parentNode.nodeName + ' html=' + l.outerHTML);
+            });
+            fetch('/global.css').then(function (r) {
+                console.log('[probe] fetch /global.css status=' + r.status + ' type=' + r.headers.get('content-type'));
+                return r.text();
+            }).then(function (t) {
+                console.log('[probe] fetch /global.css len=' + t.length + ' head=' + JSON.stringify(t.slice(0, 80)));
+            }).catch(function (e) { console.log('[probe] fetch failed ' + e); });
+        })();
+        """;
+
+    public override WebResourceResponse? ShouldInterceptRequest(WebView? view, IWebResourceRequest? request)
+    {
+        var url = request?.Url?.ToString();
+        if (url is null || !url.StartsWith(origin, StringComparison.Ordinal))
+        {
+            return base.ShouldInterceptRequest(view, request);
+        }
+
+        var path = new Uri(url).AbsolutePath;
+
+        // FINDING (#780), the same on both platforms: NativeOriginAssets.Resolve claims "/", "/index.html"
+        // and "/index.native.html" for the NATIVE boot shell before it ever consults the bundle, so the
+        // published WASM shell at the origin root is unreachable THROUGH IT. This interceptor takes those
+        // paths back for the app's own index.html — which is the mode the resolver itself needs, and the
+        // shape of the fix #780 owes.
+        //
+        // Serving it anywhere else is not merely cosmetic. The iOS spike used /app.html and the router
+        // seeded /app.html as the initial route and rendered "Page not found"; at the root the same bundle
+        // reports `initial path=/` and renders the real home page. The document's path is load-bearing.
+        (byte[] Body, string ContentType)? resolved;
+        if (path is "/" or "/index.html" or "/app.html")
+        {
+            resolved = readStaticFile("index.html") is { } shell ? (shell, "text/html") : null;
+        }
+        else
+        {
+            resolved = NativeOriginAssets.Resolve(path, readStaticFile);
+        }
+
+        if (resolved is not { } asset)
+        {
+            Console.WriteLine($"[spike/miss] {path}");
+            return new WebResourceResponse("text/plain", "UTF-8", 404, "Not Found",
+                new Dictionary<string, string>(), new MemoryStream([]));
+        }
+
+        Console.WriteLine($"[spike/serve] {path} -> {asset.ContentType} ({asset.Body.Length} bytes)");
+
+        // "UTF-8" is what the SHIPPING ShowcaseWebViewClient passes, so that is what is under test here.
+        return new WebResourceResponse(asset.ContentType, "UTF-8", 200, "OK",
+            new Dictionary<string, string>(), new MemoryStream(asset.Body));
+    }
+}
+
+internal sealed class ConsoleSink : WebChromeClient
+{
+    public override bool OnConsoleMessage(ConsoleMessage? message)
+    {
+        if (message is not null)
+        {
+            Console.WriteLine(
+                $"[spike/page] {message.InvokeMessageLevel()}: {message.Message()} @ {message.SourceId()}:{message.LineNumber()}");
+        }
+
+        return true;
+    }
+}

--- a/samples/WasmInWebViewSpike/WasmInWebViewSpike.csproj
+++ b/samples/WasmInWebViewSpike/WasmInWebViewSpike.csproj
@@ -1,21 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <!--
-    SPIKE (#775, epic #774) — "does a published Rask WASM client boot inside a WKWebView, served from the
-    app's own custom-scheme origin?" That is the one unknown behind the `wasm` hosting model (#780), so it
-    is answered here before any of that model's design depends on it.
+    SPIKE (#775, epic #774) — "does a published Rask WASM client boot inside a platform WebView, served from
+    the app's own bundled-asset origin?" That is the one unknown behind the `wasm` hosting model (#780), so
+    it is answered here before any of that model's design depends on it. Both heads answer it: iOS over the
+    `raskapp://local/` custom scheme, Android over `https://appassets.rask/`.
 
     Deliberately NOT in Rask.slnx: it is throwaway evidence, it needs a WASM publish on disk to build, and
     nothing in the default gates should depend on either.
 
-    Build it by pointing RaskSpikeWasmBundle at a published Rask WASM app's wwwroot:
+    Build it by pointing RaskSpikeWasmBundle at a published Rask WASM app's wwwroot. Note "-t:Build;Run" —
+    -t:Run alone REPLACES the default target, so it deploys whatever is already in bin/ without compiling.
 
         dotnet publish samples/Rask.Example.Wasm -c Release -o /tmp/wasmpub
-        dotnet build samples/WasmInWebViewSpike -f net10.0-ios -p:RaskNativeHeads=ios \
+        dotnet build samples/WasmInWebViewSpike "-t:Build;Run" -f net10.0-ios -p:RaskNativeHeads=ios \
+          -p:RaskSpikeWasmBundle=/tmp/wasmpub/wwwroot
+        dotnet build samples/WasmInWebViewSpike "-t:Build;Run" -f net10.0-android -p:RaskNativeHeads=android \
           -p:RaskSpikeWasmBundle=/tmp/wasmpub/wwwroot
   -->
   <PropertyGroup>
-    <TargetFramework>net10.0-ios</TargetFramework>
+    <TargetFrameworks>net10.0-ios;net10.0-android</TargetFrameworks>
+    <!-- Mirrors the same switch on Rask.Native and on the two runnable native samples — keep them in step,
+         or a value that builds the library still fails here on the workload the other head needs. Only
+         TargetFrameworks is set: a singular TargetFramework silently WINS over it, which is how a value
+         missing from the condition ends up "succeeding" having compiled no head at all. -->
+    <TargetFrameworks Condition="'$(RaskNativeHeads)' == 'android'">net10.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="'$(RaskNativeHeads)' == 'ios'">net10.0-ios</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -27,14 +37,31 @@
     <ApplicationId>com.rask.example.wasmspike</ApplicationId>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>
-    <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
-    <MtouchLink>None</MtouchLink>
     <NoWarn>$(NoWarn);CA1422</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
+  <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">
+    <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
+    <MtouchLink>None</MtouchLink>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework.Contains('-android'))">
+    <SupportedOSPlatformVersion>24.0</SupportedOSPlatformVersion>
+    <AndroidManifest>Platforms/Android/AndroidManifest.xml</AndroidManifest>
+    <AndroidLinkMode>None</AndroidLinkMode>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
     <None Remove="Platforms/iOS/Info.plist"/>
     <None Include="Platforms/iOS/Info.plist" Link="Info.plist"/>
+  </ItemGroup>
+
+  <!-- Each platform head compiles only for its own TFM. -->
+  <ItemGroup Condition="!$(TargetFramework.Contains('-ios'))">
+    <Compile Remove="Platforms/iOS/**/*.cs"/>
+  </ItemGroup>
+  <ItemGroup Condition="!$(TargetFramework.Contains('-android'))">
+    <Compile Remove="Platforms/Android/**/*.cs"/>
   </ItemGroup>
 
   <ItemGroup>
@@ -42,15 +69,20 @@
   </ItemGroup>
 
   <!--
-    The published WASM client, bundled at the app-bundle wwwroot ROOT rather than a sub-folder: the shell's
+    The published WASM client, bundled at the origin ROOT rather than a sub-folder: the shell's
     <base href="/"> resolves main.js and _framework/* from the origin root regardless of the document path,
-    so the bundle only works at the root. The .br/.gz siblings are excluded — there is no HTTP content
-    negotiation behind a custom scheme handler, so they would be ~8 MB of dead weight in the IPA.
+    so the bundle only works at the root. The .br/.gz siblings are excluded — neither head does HTTP content
+    negotiation, so they would be ~8 MB of dead weight in the package (20 MB with them, 12 MB without).
   -->
-  <ItemGroup Condition="'$(RaskSpikeWasmBundle)' != ''">
+  <ItemGroup Condition="'$(RaskSpikeWasmBundle)' != '' And $(TargetFramework.Contains('-ios'))">
     <BundleResource Include="$(RaskSpikeWasmBundle)\**\*"
                     Exclude="$(RaskSpikeWasmBundle)\**\*.br;$(RaskSpikeWasmBundle)\**\*.gz"
                     Link="wwwroot\%(RecursiveDir)%(Filename)%(Extension)"/>
+  </ItemGroup>
+  <ItemGroup Condition="'$(RaskSpikeWasmBundle)' != '' And $(TargetFramework.Contains('-android'))">
+    <AndroidAsset Include="$(RaskSpikeWasmBundle)\**\*"
+                  Exclude="$(RaskSpikeWasmBundle)\**\*.br;$(RaskSpikeWasmBundle)\**\*.gz"
+                  Link="Assets\%(RecursiveDir)%(Filename)%(Extension)"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes the last Phase 0 evidence gap in the four-models epic (#774): **Spike A on Android**.

The `wasm` hosting model (#780) rests on one unknown — does a published Rask WASM client boot inside a
platform WebView, served from the app's own bundled assets? iOS answered yes in #790. Android now answers
yes too, so **Phase 0 is complete on both platforms in both spikes**.

## What this adds

`samples/WasmInWebViewSpike` grows an Android head beside the iOS one, multi-targeting under the same
`RaskNativeHeads` switch the library and both runnable native samples use (only `TargetFrameworks` is
set — a singular `TargetFramework` silently wins over it, which is how a missing value "succeeds" having
compiled no head at all). Resolution still goes through the shipping `NativeOriginAssets.Resolve` +
`AndroidBundledAssets.Read`, and the WebView is configured exactly as `RaskAndroidWebView` configures its
own; only the logging is local.

## Result

74 assets served, **zero misses**, entirely offline. `.wasm` served as `application/wasm` with no
streaming-compilation fallback. ~390 ms to the activity, ~1.2 s more to `first render applied`.

Three answers that differ from iOS, all of which belong to #780:

- **Package size is 7.5 MB, not 12 MB.** 20 MB published, 12 MB once the `.br`/`.gz` siblings are dropped
  (neither head negotiates content encoding) — but an APK deflates its assets where an IPA stores them.
- **The origin-root claim reproduces, and the workaround is worse than it looked.** The router seeds the
  *document's* path, so at `/app.html` the app rendered **Not found**. This interceptor takes `/` back for
  the app's own `index.html` — the mode the resolver itself needs — and the same bundle then reports
  `initial path=/` and renders the real home page. That is the shape of the fix #780 owes, demonstrated
  rather than argued.
- **The service worker is never even requested**, on either platform, even though Android's origin is a
  secure context.

## Defect found: #807

The app renders **completely unstyled** on the bundled-asset origin. Every `<link rel="stylesheet">` the
head morph manages (the keyed ones) is fetched, served `200 text/css`, and never becomes a CSSOM
stylesheet — 2 of 7 links load, and scoped CSS is in the failing set.

Ruled out before filing: not the asset path (a `fetch()` from the page returns the correct bytes), not the
spike's plumbing (same WebView settings as shipping; `"UTF-8"` vs `null` encoding makes no difference), not
the `/app.html` route seed (reproduces at the root), and not a general WASM fault (the same published
bundle is fully styled in desktop Chromium over HTTP). It blocks #780, not Phase 0.

## Docs

`docs/native.md` still said neither `INativeSurface` backend had been run on a simulator, emulator or
device. Both have now — iOS on an iPhone 17 Pro simulator, Android on an API 36 emulator — so that status
block says what was actually run, on what, and with what result.

## Testing

- Format + unit gate: **green** (325 tests).
- Pre-push browser E2E gate: **green**.
- On device: API 36 emulator, the run described above. The spike is deliberately outside `Rask.slnx`, so
  no default gate builds it — it is evidence, run by hand.

No framework code changed, so no benchmarks apply.
