### PR TITLE
feat(native): let a NativeWebView point at a URL, so the UI can come from an app you host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,17 @@ them until tagged releases begin.
   `samples/Rask.Example.Native.Server` is now written this way — one `ServerShellApp` with a header bar and
   a `NativeWebView.Url(…)`, run by the ordinary `RaskWkWebView`/`RaskAndroidWebView` head, instead of the
   separate `RaskServerViewController` / `RaskServerWebView` classes. Same app, same behaviour, and the
-  Server model stops being a parallel code path with no session and no chrome.
+  Server model stops being a parallel code path with no session and no chrome. Verified on an iPhone 17 Pro
+  simulator against a real `Rask.Example.Server`: a native `UINavigationBar` at the top, the remote app
+  rendering fully styled below it.
+
+  **A URL-mode app still loads the boot shell first**, which is worth knowing because it is not obvious.
+  `RunLocalAsync` defers the first render to the client's `ready` handshake, and the client lives in the
+  shell — so with no shell there is no handshake, no first frame, and therefore no address to navigate to.
+  Skipping `LoadShell()` produces a blank white screen and no bars, which is exactly what the first device
+  run showed. The shell is loaded, the first frame carries the `Url`, and the WebView navigates away from
+  it. Giving the host a way to render the first frame without a handshake — as `RunNativeAsync` already
+  does for the pure-native model — would remove the extra document load, and is the obvious follow-up.
 
   Also fixed on the way: `CLAUDE.md` claimed the diagnostic range was RASK001–048 with only RASK047
   retired. `docs/diagnostics.md` has said RASK001–053 for a while, and RASK030 and RASK042 are retired too.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **`NativeWebView` can point at a URL instead of hosting markup.** It had one mode: its children are the
+  page. It has two now — give it a `Url` and the WebView loads that address, so the UI comes from a Rask
+  server or a WASM app you host rather than from components rendering on the device:
+
+  ```csharp
+  protected override Component? Render() =>
+  [
+      NativeHeaderBar.Title("Home"),
+      NativeWebView.Url("https://app.example.com/"),
+  ];
+  ```
+
+  The bars around it are still native, still declared in the same `Render()`, and the page reaches the
+  device backends through the capability bridge. What changes is only where the UI comes from — which is
+  the four-models epic's whole claim, now expressible in markup rather than only by picking a different
+  platform head.
+
+  `.Url(…)` takes a `string` or a `Uri`. Both must be an absolute `http`/`https` address, checked in the
+  property setter so neither way in can skip it. That check earns its place: on Unix
+  `Uri.TryCreate("/relative", Absolute, …)` **succeeds**, as `file:///relative` — and `javascript:` and
+  `data:` parse absolutely too. All three would otherwise have been handed to a WebView carrying the
+  capability bridge.
+
+  **The two modes are exclusive**, and the compiler says so rather than the framework discarding work
+  silently. `RASK049` is one `NativeWebView` that sets a `Url` *and* takes children — it shows one
+  document, so the children could only be built and thrown away. `RASK050` is one component that could
+  render either: in URL mode the session keeps no HTML diff baseline, so the markup arm has nothing to
+  paint against. A pure-native `NativeScreen` is unaffected by both and still composes beside either.
+
+  RASK050 is scoped to the declaring **type**, and the first cut got that wrong. Scoped to the compilation
+  it read "one app", which a compilation is not — this repo's own native test assembly holds many app
+  roots, and every markup one lit up. An assembly with more than one app is ordinary; one component that
+  could render either page is the actual mistake.
+
+  **The Local heads had no navigation policy at all**, which this change could not leave alone.
+  `RaskWkWebView` was not a `WKNavigationDelegate`, and `RaskAndroidWebView`'s client overrode only
+  `ShouldInterceptRequest` and let off-origin requests through — while Android's `__raskBridge`
+  `@JavascriptInterface` was already bound to that WebView. Loading a remote page into it would have
+  exposed the bridge to that page *and to anywhere it navigated*. Both heads now carry the policy the
+  Server heads always had: inject for the declared origin, and send an off-origin navigation to the system
+  browser. The grant is to the page you named; this is what stops it travelling.
+
+  Pointing `.Url(…)` at a site you do not control still gives that site your device APIs. That is inherent,
+  not an oversight, and the docs say so where the feature is introduced.
+
+  `samples/Rask.Example.Native.Server` is now written this way — one `ServerShellApp` with a header bar and
+  a `NativeWebView.Url(…)`, run by the ordinary `RaskWkWebView`/`RaskAndroidWebView` head, instead of the
+  separate `RaskServerViewController` / `RaskServerWebView` classes. Same app, same behaviour, and the
+  Server model stops being a parallel code path with no session and no chrome.
+
+  Also fixed on the way: `CLAUDE.md` claimed the diagnostic range was RASK001–048 with only RASK047
+  retired. `docs/diagnostics.md` has said RASK001–053 for a while, and RASK030 and RASK042 are retired too.
+
 ### Changed
 - **`rask new --template native` says what each hosting model actually costs you** (#776, the four-models
   epic). The chooser used to say only where the UI comes from. The epic's rule is that exactly three

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,11 +88,11 @@ dotnet run --project samples/Rask.Example.Server
 Routing/lifecycle (`docs/routing.md`, `docs/lifecycle.md`), scoped CSS/JS + typed browser APIs
 (`docs/js-interop.md`, `docs/browser-apis.md` — the 50-wrapper map), forms +
 validation (`docs/forms.md`), auth (`docs/authentication.md`), context/callbacks (`docs/composition.md`),
-diagnostics RASK001–048, RASK047 retired (`docs/diagnostics.md` — analyzer descriptors are the source of truth), getting
+diagnostics RASK001–053, RASK030/042/047 retired (`docs/diagnostics.md` — analyzer descriptors are the source of truth), getting
 started / migration / testing / architecture (`docs/`). Trimming: `samples/Rask.Example.Wasm` must
 `dotnet publish -c Release` with zero IL warnings — new reflection needs a DAM annotation or justified suppression.
 
 ## Conventions
 - **New HTML tag** → `add-html-tag` skill (`src/Rask.Html/Components/{Tag}.cs` + `tests/Rask.Html.Tests/Components/{Tag}Tests.cs`).
-- **New diagnostic** → `add-diagnostic` skill. Diagnostic IDs RASK001–048 are documented in `docs/diagnostics.md`
-  (RASK047 is retired — routes are attribute arguments, constant by construction).
+- **New diagnostic** → `add-diagnostic` skill. Diagnostic IDs RASK001–053 are documented in `docs/diagnostics.md`
+  (RASK030/042/047 are retired; RASK051–052 are free).

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -83,6 +83,8 @@ dotnet_analyzer_diagnostic.category-Rask.severity = warning
 | [RASK046](#rask046) | Warning | Key must open a component's chain |
 | RASK047 | — | *retired* — routes are `[Route]` attribute arguments, constant by construction |
 | [RASK048](#rask048) | Error | HTML nested inside a native screen |
+| [RASK049](#rask049) | Error | NativeWebView sets a Url and takes children |
+| [RASK050](#rask050) | Error | One component uses both of NativeWebView's modes |
 | [RASK053](#rask053) | Error | Remote message has no wire encoding |
 
 ---
@@ -1049,6 +1051,67 @@ protected override Component? Render() => NativeWebView[Div["Hello"]];
 or put the markup inside a `NativeWebView` instead. An app is free to compose both — one route rendering a
 `NativeWebView` and the next a `NativeScreen` is the supported mixed-surface setup; see
 [native](native.md).
+
+---
+
+## RASK049
+**NativeWebView sets a Url and takes children** · Error
+
+`NativeWebView` shows **one** document. Either it hosts markup — its children are the page — or it takes a
+`Url` and shows a Rask server or hosted WASM app you deploy. Setting both means the children are built and
+then thrown away: accepted where you wrote them, gone by the time the frame is pushed. That is the failure
+the chain's mode system exists to prevent elsewhere, and this is the same rule for the same reason.
+
+```csharp
+// ✗ RASK049 — the children can never render; the page at the Url is what shows
+protected override Component? Render() =>
+    NativeWebView.Url("https://app.example.com/")[Div["Hello"]];
+
+// ✓ markup mode — the children ARE the page
+protected override Component? Render() => NativeWebView[Router];
+
+// ✓ URL mode — the hosted app renders the page, and the native bars still frame it
+protected override Component? Render() =>
+[
+    NativeHeaderBar.Title("Home"),
+    NativeWebView.Url("https://app.example.com/"),
+];
+```
+
+**Fix:** drop one. Keep the children and remove the `Url`, or keep the `Url` and let the hosted app render
+the page. See [native](native.md).
+
+---
+
+## RASK050
+**One component uses both of NativeWebView's modes** · Error
+
+A component renders one kind of page. In URL mode the WebView is showing a document the session did not
+render and holds no HTML diff baseline for, so a markup arm in the same component has nothing to paint
+against — it would be diffing against someone else's page.
+
+```csharp
+// ✗ RASK050 — this component could render either
+protected override Component? Render() =>
+    Remote ? NativeWebView.Url("https://app.example.com/") : NativeWebView[Router];   // ← reported here
+
+// ✓ one mode per component
+protected override Component? Render() =>
+[
+    NativeHeaderBar.Title("Home"),
+    NativeWebView.Url("https://app.example.com/"),
+];
+```
+
+It is reported on the **markup** arm: the `Url` is the deliberate choice, and the markup is the half that
+has quietly stopped working.
+
+The rule is scoped to the declaring **type**, not the compilation — an assembly with more than one app
+root, or a test project, legitimately contains both modes in different components, and those are fine.
+
+**Fix:** pick a mode for the component, or split the two into components of their own. A pure-native
+`NativeScreen` is unaffected and composes beside either mode — that is the supported
+[mixed-surface](native.md) setup.
 
 ---
 

--- a/docs/native.md
+++ b/docs/native.md
@@ -33,6 +33,7 @@ one route served as HTML, the next fully native.
 - [Device capabilities & chrome](native-devices.md) — safe-area insets, device backends, native header/footer.
 
 Also in this doc: [How it fits](#how-it-fits), [Pure-native screens](#pure-native-screens-no-webview),
+[A WebView pointed at your own app](#a-webview-pointed-at-your-own-app),
 [Get started](#get-started), [Files, downloads and sign-out](#files-downloads-and-sign-out),
 [Honest framing](#honest-framing), [Roadmap](#roadmap).
 
@@ -129,6 +130,44 @@ JS state survive) and returning to a native route patches the retained view tree
 
 Putting HTML inside a `NativeScreen` is a compile error ([RASK048](diagnostics.md#rask048)), as is putting
 a native component inside the HTML tree ([RASK032](diagnostics.md#rask032)).
+
+### A WebView pointed at your own app
+
+A `NativeWebView` has a second mode. Instead of hosting markup, give it a `Url` and it loads that address —
+a Rask server, or a WASM app you host — so the UI ships when you deploy rather than when the store approves:
+
+```csharp
+protected override Component? Render() =>
+[
+    NativeHeaderBar.Title("Home"),
+    NativeWebView.Url("https://app.example.com/"),
+    NativeTabBar.Tabs([...]),
+];
+```
+
+The bars around it are still native, still declared in the same `Render()`, and still projected onto a real
+`UINavigationBar` / Android top bar. The page reaches the device backends through the
+[capability bridge](native-bridge.md#native-device-apis-from-a-server-app-the-capability-bridge). What
+changes is only where the UI comes from.
+
+`.Url(…)` takes a `string` or a `Uri`, and both must be an absolute `http`/`https` address — a relative one,
+or a `javascript:` / `data:` / `file:` one, is rejected where you write it rather than becoming a blank
+WebView on a device.
+
+The two modes are exclusive. One `NativeWebView` that sets a `Url` *and* takes children is
+[RASK049](diagnostics.md#rask049) — it shows one document, so the children could only be discarded — and a
+component that uses both modes is [RASK050](diagnostics.md#rask050), because in URL mode the session holds
+no HTML baseline for a markup arm to paint against. A pure-native `NativeScreen` is
+unaffected by both and composes beside either.
+
+> **The page you name gets your device APIs.** The head keeps the WebView on that origin — an off-origin
+> link opens in the system browser instead — but that confines where the grant travels, not what the site
+> you pointed at can do with it. Point it at an origin you control.
+
+> **Cleartext is blocked by default.** A `--host native` app ships with no ATS exception on iOS and no
+> `usesCleartextTraffic` on Android, so a `Url` of `http://localhost:5000` loads **nothing, silently**. Use
+> `https://`, or add the narrow exception the remote templates use while developing (see
+> [the CLI docs](cli.md)).
 
 ### Wiring it up
 

--- a/samples/Rask.Example.Native.Server/Platforms/Android/ServerActivity.cs
+++ b/samples/Rask.Example.Native.Server/Platforms/Android/ServerActivity.cs
@@ -45,9 +45,12 @@ public class ServerActivity : Activity
         host.Services.AddSingleton<INativeChrome>(webView);
         host.Services.AddSingleton(new ServerOrigin(ServerUrl));
 
-        // No LoadShell(): this app hosts no markup of its own, so the first frame's Url is what the WebView
-        // navigates to.
         _app = await host.RunLocalAsync<ServerShellApp>(webView);
+
+        // The boot shell still loads first, even though this app hosts no markup: RunLocalAsync defers the
+        // first render to the client's `ready` handshake, and the client lives in the shell. That first
+        // frame is what carries the Url, so the WebView navigates away from the shell immediately after.
+        webView.LoadShell();
     }
 
     protected override void OnDestroy()

--- a/samples/Rask.Example.Native.Server/Platforms/Android/ServerActivity.cs
+++ b/samples/Rask.Example.Native.Server/Platforms/Android/ServerActivity.cs
@@ -1,24 +1,58 @@
 using Android.App;
 using Android.OS;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Client.Browser;
 using Rask.Native;
 
 namespace Rask.Example.Native.Server;
 
-// Native + Server: a thin native shell over a REMOTE Rask.Example.Server. All the WebView machinery — the
-// capability bridge, the trusted-origin gating, and the off-origin-to-system-browser diversion — lives in
-// Rask.Native's RaskServerWebView; this head just points it at the dev server and supplies the native
-// share backend.
+// Native + Server (Android): a thin native shell over a REMOTE Rask.Example.Server — written as an ordinary
+// Rask app whose single page is a NativeWebView pointed at that server.
+//
+// The mirror of the iOS head, and the same shape as the in-process showcase: one RaskAndroidWebView, one
+// NativeAppHost, one RunLocalAsync. What makes it the Server model is the Url on the component, not a
+// different platform class — the bars still render as real Android chrome around the remote page, and the
+// capability bridge (trusted-origin gating, off-origin links to the system browser) is applied because the
+// component named an address.
 [Activity(Label = "Rask Showcase (Server)", MainLauncher = true, Exported = true,
     Theme = "@android:style/Theme.Material.Light.NoActionBar")]
 public class ServerActivity : Activity
 {
     // The Android emulator reaches the host machine at 10.0.2.2. Publish + run Rask.Example.Server bound to
     // 0.0.0.0:5080 first (a real deployment is https). See docs/native.md.
-    private static readonly Uri ServerOrigin = new("http://10.0.2.2:5080/");
+    private static readonly Uri ServerUrl = new("http://10.0.2.2:5080/");
+
+    private NativeApp? _app;
 
     protected override void OnCreate(Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
-        SetContentView(RaskServerWebView.Create(this, ServerOrigin, new NativeShare(this)));
+
+        var webView = new RaskAndroidWebView(this);
+        // ChromeView, not the bare WebView, so the app's NativeHeaderBar becomes a real top bar around the
+        // remote page.
+        SetContentView(webView.ChromeView);
+
+        _ = StartAsync(webView);
+    }
+
+    private async Task StartAsync(RaskAndroidWebView webView)
+    {
+        var host = NativeAppHost.CreateDefault();
+        // The remote page reaches the device backends through the capability bridge, so registering them
+        // here is what gives that page a real Android share chooser.
+        host.Services.AddSingleton<IShare>(_ => new NativeShare(this));
+        host.Services.AddSingleton<INativeChrome>(webView);
+        host.Services.AddSingleton(new ServerOrigin(ServerUrl));
+
+        // No LoadShell(): this app hosts no markup of its own, so the first frame's Url is what the WebView
+        // navigates to.
+        _app = await host.RunLocalAsync<ServerShellApp>(webView);
+    }
+
+    protected override void OnDestroy()
+    {
+        _ = _app?.DisposeAsync();
+        base.OnDestroy();
     }
 }

--- a/samples/Rask.Example.Native.Server/Platforms/iOS/ServerAppDelegate.cs
+++ b/samples/Rask.Example.Native.Server/Platforms/iOS/ServerAppDelegate.cs
@@ -1,31 +1,56 @@
 using Foundation;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Client.Browser;
 using Rask.Native;
 using UIKit;
 
 namespace Rask.Example.Native.Server;
 
-// Native + Server (iOS): a thin native shell over a REMOTE Rask.Example.Server. The WebView machinery — the
-// capability bridge, the trusted-origin gating, and the off-origin-to-Safari diversion — lives in
-// Rask.Native's RaskServerViewController; this head just points it at the dev server and supplies the
-// native share backend.
+// Native + Server (iOS): a thin native shell over a REMOTE Rask.Example.Server — written as an ordinary
+// Rask app whose single page is a NativeWebView pointed at that server.
+//
+// This is the same head shape as the in-process showcase: one RaskWkWebView, one NativeAppHost, one
+// RunLocalAsync. What makes it the Server model is the Url on the component, not a different platform
+// class — the bars are still declared in C# and still render as real UIKit chrome around the remote page,
+// and the capability bridge (trusted-origin gating, off-origin links to Safari) is applied by the head
+// because the component named an address.
 [Register("AppDelegate")]
 public class AppDelegate : UIApplicationDelegate
 {
     // The iOS simulator reaches the host machine at localhost. Publish + run Rask.Example.Server first
     // (a real deployment is https). See docs/native.md.
-    private static readonly Uri ServerOrigin = new("http://localhost:5080/");
+    private static readonly Uri ServerUrl = new("http://localhost:5080/");
 
     public override UIWindow? Window { get; set; }
+    private NativeApp? _app;
 
     public override bool FinishedLaunching(UIApplication application, NSDictionary? launchOptions)
     {
-        var shell = NativeAppHost.ConnectToServer(ServerOrigin);
-        Window = new UIWindow(UIScreen.MainScreen.Bounds)
-        {
-            RootViewController = new RaskServerViewController(
-                shell.ServerBaseUrl, new NativeShare(() => Window?.RootViewController))
-        };
+        Window = new UIWindow(UIScreen.MainScreen.Bounds);
+
+        var webView = new RaskWkWebView();
+        // ChromeView, not the bare WebView, so the app's NativeHeaderBar becomes a real UINavigationBar
+        // around the remote page.
+        Window.RootViewController = new UIViewController { View = webView.ChromeView };
         Window.MakeKeyAndVisible();
+
+        _ = StartAsync(webView);
         return true;
     }
+
+    private async Task StartAsync(RaskWkWebView webView)
+    {
+        var host = NativeAppHost.CreateDefault();
+        // The remote page reaches the device backends through the capability bridge, so registering them
+        // here is what gives that page a real iOS share sheet.
+        host.Services.AddSingleton<IShare>(_ => new NativeShare(() => Window?.RootViewController));
+        host.Services.AddSingleton<INativeChrome>(webView);
+        host.Services.AddSingleton(new ServerOrigin(ServerUrl));
+
+        // No LoadShell(): this app hosts no markup of its own, so the first frame's Url is what the WebView
+        // navigates to.
+        _app = await host.RunLocalAsync<ServerShellApp>(webView);
+    }
+
+    public override void WillTerminate(UIApplication application) => _ = _app?.DisposeAsync();
 }

--- a/samples/Rask.Example.Native.Server/Platforms/iOS/ServerAppDelegate.cs
+++ b/samples/Rask.Example.Native.Server/Platforms/iOS/ServerAppDelegate.cs
@@ -47,9 +47,12 @@ public class AppDelegate : UIApplicationDelegate
         host.Services.AddSingleton<INativeChrome>(webView);
         host.Services.AddSingleton(new ServerOrigin(ServerUrl));
 
-        // No LoadShell(): this app hosts no markup of its own, so the first frame's Url is what the WebView
-        // navigates to.
         _app = await host.RunLocalAsync<ServerShellApp>(webView);
+
+        // The boot shell still loads first, even though this app hosts no markup: RunLocalAsync defers the
+        // first render to the client's `ready` handshake, and the client lives in the shell. That first
+        // frame is what carries the Url, so the WebView navigates away from the shell immediately after.
+        webView.LoadShell();
     }
 
     public override void WillTerminate(UIApplication application) => _ = _app?.DisposeAsync();

--- a/samples/Rask.Example.Native.Server/ServerShellApp.cs
+++ b/samples/Rask.Example.Native.Server/ServerShellApp.cs
@@ -1,0 +1,38 @@
+using Rask.Core;
+using Rask.Native.Components;
+
+namespace Rask.Example.Native.Server;
+
+/// <summary>The remote app this shell points at. Registered by the platform head, which knows the origin.</summary>
+/// <param name="Url">
+///     The absolute address of the Rask server. The two heads differ here and nowhere else: the iOS
+///     simulator reaches the host machine at <c>localhost</c>, the Android emulator at <c>10.0.2.2</c>.
+/// </param>
+public sealed record ServerOrigin(Uri Url);
+
+/// <summary>
+///     Native + Server, written as markup. The UI comes from a remote <c>Rask.Example.Server</c>; the bars
+///     around it are this app's, declared here and projected onto a real <c>UINavigationBar</c> /
+///     Android top bar.
+///     <para>
+///         The whole app is one <c>NativeWebView.Url(…)</c>. That is the point of the mode: where the UI
+///         comes from is the only thing that differs from the in-process showcase, and it is one step in one
+///         component rather than a separate platform class.
+///     </para>
+/// </summary>
+/// <remarks>
+///     The origin arrives through the constructor rather than a settable property: a non-nullable property
+///     with no initializer would become a required chain step, and this component is built by the host, not
+///     by a chain.
+/// </remarks>
+public sealed partial class ServerShellApp(ServerOrigin origin) : Component
+{
+    protected override Component? Render() =>
+    [
+        NativeHeaderBar.Title("Rask (Server)"),
+
+        // The remote server renders every page, so this component composes no children-hosting
+        // NativeWebView — one component renders one kind of page (RASK050).
+        NativeWebView.Url(origin.Url),
+    ];
+}

--- a/src/Rask.Generators/Analyzers/NativeWebViewModeAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/NativeWebViewModeAnalyzer.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Rask.Generators.Analyzers;
+
+/// <summary>
+///     Guards <c>NativeWebView</c>'s two modes. It either hosts markup — its children are the page — or it
+///     takes a <c>Url</c> and shows an app you host. A WebView holds one document, so the two cannot both be
+///     true of it.
+///     <para>
+///         <b>RASK049</b> — one <c>NativeWebView</c> does both. The children would be built and then thrown
+///         away, which is the failure mode the chain's mode system exists to prevent elsewhere: accepted at
+///         the call site, silently dropped at render.
+///     </para>
+///     <para>
+///         <b>RASK050</b> — one component uses both modes, typically by switching on a condition. In URL mode
+///         the WebView shows a document this session did not render and holds no HTML diff baseline for, so
+///         the markup arm has nothing to paint against.
+///     </para>
+/// </summary>
+/// <remarks>
+///     RASK050 is scoped to the declaring <b>type</b>, deliberately, and not to the compilation. A
+///     compilation is not an app: a test project, a component library, or any assembly with more than one app
+///     root legitimately contains both modes in different types, and a compilation-wide rule reports every
+///     one of them — this repo's own native test assembly was the proof. The mistake worth catching is one
+///     component that could render either, and a per-type scope sees exactly that.
+///     <para>
+///         It reports on the <em>markup</em> usage: the <c>Url</c> is the deliberate choice, and the markup is
+///         the half that has quietly stopped working.
+///     </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class NativeWebViewModeAnalyzer : DiagnosticAnalyzer
+{
+    private const string NativeWebViewFullName = "Rask.Native.Components.NativeWebView";
+    private const string UrlStep = "Url";
+
+    private static readonly DiagnosticDescriptor Rask049 = new(
+        "RASK049",
+        "NativeWebView sets a Url and takes children",
+        "This NativeWebView sets a Url and also takes children. It shows one document: either the page at "
+        + "the Url, or these children. Drop one — put the children on a NativeWebView with no Url, or remove "
+        + "them and let the hosted app render the page.",
+        DiagnosticHelp.Category,
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A NativeWebView carrying a Url loads that address, so children composed into it would "
+                     + "be built and then discarded — accepted where you wrote them, gone by the time the "
+                     + "frame is pushed.",
+        helpLinkUri: DiagnosticHelp.Link("RASK049"));
+
+    private static readonly DiagnosticDescriptor Rask050 = new(
+        "RASK050",
+        "One component uses both of NativeWebView's modes",
+        "This NativeWebView hosts markup, but '{0}' also composes one with a Url. A component renders one "
+        + "kind of page — pick a mode, or split the two into components of their own.",
+        DiagnosticHelp.Category,
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "In URL mode the WebView shows a document the session did not render and keeps no HTML "
+                     + "diff baseline for, so a markup arm in the same component has nothing to paint "
+                     + "against. Native screens are unaffected and may be composed alongside either mode.",
+        helpLinkUri: DiagnosticHelp.Link("RASK050"));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(Rask049, Rask050);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterCompilationStartAction(static start =>
+        {
+            // Rask.Native declares the component itself; its own sources reference both shapes. Mirrors the
+            // RASK032 / RASK048 assembly skip.
+            if (string.Equals(start.Compilation.AssemblyName, "Rask.Native", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var webView = start.Compilation.GetTypeByMetadataName(NativeWebViewFullName);
+            if (webView is null)
+            {
+                return;
+            }
+
+            // One action per type declaration, so the two modes are compared within a component and nowhere
+            // wider. Everything the rule needs is inside the type, so no cross-action state is required.
+            start.RegisterSyntaxNodeAction(
+                ctx => AnalyzeType(ctx, webView),
+                SyntaxKind.ClassDeclaration,
+                SyntaxKind.RecordDeclaration,
+                SyntaxKind.StructDeclaration);
+        });
+    }
+
+    private static void AnalyzeType(SyntaxNodeAnalysisContext context, INamedTypeSymbol webView)
+    {
+        var declaration = (TypeDeclarationSyntax)context.Node;
+
+        var markupSites = new List<ElementAccessExpressionSyntax>();
+        var urlSites = new List<InvocationExpressionSyntax>();
+
+        foreach (var node in declaration.DescendantNodes())
+        {
+            // A nested type is analysed by its own action; skipping its nodes here keeps each report on the
+            // type that actually wrote the markup.
+            if (node != declaration && node is TypeDeclarationSyntax)
+            {
+                continue;
+            }
+
+            switch (node)
+            {
+                case ElementAccessExpressionSyntax access when IsWebViewChildren(context, access, webView):
+                    if (TakesUrlStep(access.Expression))
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(Rask049, access.GetLocation()));
+                    }
+                    else
+                    {
+                        markupSites.Add(access);
+                    }
+
+                    break;
+
+                case InvocationExpressionSyntax invocation when IsWebViewUrlStep(context, invocation, webView):
+                    urlSites.Add(invocation);
+                    break;
+            }
+        }
+
+        // Only a component that does BOTH is wrong. Either alone is a perfectly good app.
+        if (urlSites.Count == 0 || markupSites.Count == 0)
+        {
+            return;
+        }
+
+        var owner = declaration.Identifier.ValueText;
+        foreach (var site in markupSites)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Rask050, site.GetLocation(), owner));
+        }
+    }
+
+    // `NativeWebView[ … ]` with at least one child. `NativeWebView[]` composes nothing and is not markup mode.
+    private static bool IsWebViewChildren(
+        SyntaxNodeAnalysisContext context, ElementAccessExpressionSyntax access, INamedTypeSymbol webView) =>
+        access.ArgumentList.Arguments.Count > 0 && ResolvesToWebView(context, access.Expression, webView);
+
+    private static bool IsWebViewUrlStep(
+        SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation, INamedTypeSymbol webView) =>
+        invocation.Expression is MemberAccessExpressionSyntax member
+        && string.Equals(member.Name.Identifier.ValueText, UrlStep, StringComparison.Ordinal)
+        && ResolvesToWebView(context, member.Expression, webView);
+
+    // A chain hands back Build<T>, not T, so the type has to be unwrapped — without this every chain (which
+    // is all of them now) walks straight past.
+    private static bool ResolvesToWebView(
+        SyntaxNodeAnalysisContext context, ExpressionSyntax expression, INamedTypeSymbol webView)
+    {
+        var resolved = BuilderEntry.ChainedComponent(
+            ModelExtensions.GetTypeInfo(context.SemanticModel, expression, context.CancellationToken).Type);
+
+        return SymbolEqualityComparer.Default.Equals(resolved, webView);
+    }
+
+    // Walk the chain the indexer is applied to, looking for a `.Url(…)` step. Syntactic on purpose: the step
+    // is an extension method whose receiver is Build<NativeWebView>, and the name is what distinguishes it.
+    private static bool TakesUrlStep(ExpressionSyntax expression)
+    {
+        var current = expression;
+        while (true)
+        {
+            switch (current)
+            {
+                case InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax member }:
+                    if (string.Equals(member.Name.Identifier.ValueText, UrlStep, StringComparison.Ordinal))
+                    {
+                        return true;
+                    }
+
+                    current = member.Expression;
+                    continue;
+                case MemberAccessExpressionSyntax access:
+                    current = access.Expression;
+                    continue;
+                case ParenthesizedExpressionSyntax parenthesized:
+                    current = parenthesized.Expression;
+                    continue;
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/src/Rask.Native/Components/NativeWebView.cs
+++ b/src/Rask.Native/Components/NativeWebView.cs
@@ -3,17 +3,75 @@ using Rask.Core;
 namespace Rask.Native.Components;
 
 /// <summary>
-///     The HTML surface of a native page — its children are the ordinary page content, which the native host
-///     serializes into the platform WebView (Rask composes the document around the whole render, exactly as
-///     on the web). Compose it as a sibling of the native bars:
-///     <code>Render() => [NativeHeaderBar(Title: "Home"), NativeWebView()[Router()], NativeTabBar(...)];</code>
-///     It renders its children transparently (like a fragment), so on a web host — where you branch with
-///     <c>IsNative</c> and return the content alone — the same markup serializes identically. Only native
-///     chrome (bars) may sit outside it; putting a bar inside its HTML content is a <c>RASK032</c> error.
+///     The web surface of a native page. It has two modes, and they are mutually exclusive:
+///     <list type="number">
+///         <item>
+///             <b>Markup</b> — its children are the ordinary page content, which the native host serializes
+///             into the platform WebView (Rask composes the document around the whole render, exactly as on
+///             the web):
+///             <code>Render() => [NativeHeaderBar.Title("Home"), NativeWebView[Router], NativeTabBar(…)];</code>
+///             It renders its children transparently (like a fragment), so on a web host — where you branch
+///             with <c>IsNative</c> and return the content alone — the same markup serializes identically.
+///         </item>
+///         <item>
+///             <b>URL</b> — set <see cref="Url" /> and the WebView loads that address instead, so the UI
+///             comes from a Rask server or a hosted WASM app you deploy rather than from components running
+///             on the device:
+///             <code>Render() => [NativeHeaderBar.Title("Home"), NativeWebView.Url("https://app.example.com")];</code>
+///             The native bars still render natively around it, and the page reaches the device backends
+///             through the capability bridge, so the app is native everywhere except where the UI comes from.
+///         </item>
+///     </list>
+///     Only native chrome (bars) may sit outside it; putting a bar inside its HTML content is a
+///     <c>RASK032</c> error. Setting <see cref="Url" /> <em>and</em> passing children is <c>RASK049</c>, and
+///     using both modes anywhere in one app is <c>RASK050</c> — the WebView holds one document, so the two
+///     cannot both be true of it.
 /// </summary>
+/// <remarks>
+///     <b>Security.</b> The page loaded from <see cref="Url" /> is given the native capability bridge, so it
+///     can reach the device backends this app registered. Point it at an origin you control. The head keeps
+///     the WebView on that origin — an off-origin link opens in the system browser instead — but that
+///     confines where the bridge travels, not what the page you named can do with it.
+/// </remarks>
 public sealed partial class NativeWebView : NativeComponent
 {
+    /// <summary>
+    ///     An absolute URL to load into the WebView instead of hosting markup — a Rask server, or a WASM app
+    ///     you host. Leave it unset to use the children instead.
+    ///     <para>
+    ///         Nullable on purpose: a non-nullable property with no initializer would become a required chain
+    ///         step (RASK001/RASK038), which every existing <c>NativeWebView[…]</c> would then fail to take.
+    ///     </para>
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    ///     The value is not an absolute <c>http</c>/<c>https</c> URL. Checked in the setter rather than in the
+    ///     chain step so both ways in are covered — the generated <c>.Url(Uri)</c> step and a plain
+    ///     assignment — and so a <c>javascript:</c>, <c>data:</c> or <c>file:</c> address cannot reach a
+    ///     WebView that carries the capability bridge.
+    /// </exception>
+    public Uri? Url
+    {
+        get;
+        set
+        {
+            if (value is not null
+                && (!value.IsAbsoluteUri
+                    || (!string.Equals(value.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+                        && !string.Equals(value.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))))
+            {
+                throw new ArgumentException(
+                    $"'{value}' is not an absolute http:// or https:// URL. NativeWebView.Url takes the "
+                    + "address of the app the WebView should load, e.g. \"https://app.example.com/\".",
+                    nameof(value));
+            }
+
+            field = value;
+        }
+    }
+
     // Transparent HTML host: emit the children (the page shell) inline. A native component with children can't
-    // reuse the render cache (see Component.RenderForLive), so this re-projects on each render.
+    // reuse the render cache (see Component.RenderForLive), so this re-projects on each render. In URL mode
+    // there are no children and nothing to render — the session loads the address instead, and a frame that
+    // renders no HTML is exactly what tells it to.
     protected override Component? Render() => Children is null ? null : [.. Children];
 }

--- a/src/Rask.Native/Components/NativeWebViewUrlSetters.cs
+++ b/src/Rask.Native/Components/NativeWebViewUrlSetters.cs
@@ -1,0 +1,47 @@
+using Rask.Core;
+using Rask.Native.Components;
+
+// Global namespace, exactly like the generated RaskBuilderSetters classes: an extension method is only
+// found when its containing namespace is in scope, and the global namespace encloses every namespace — so
+// `NativeWebView.Url("https://…")` needs no using directive, the same way `.Class(…)` does not.
+
+/// <summary>
+///     The <c>string</c> overload of <see cref="NativeWebView.Url" />. The property is typed
+///     <see cref="Uri" /> so the address is parsed once, at the call site, rather than carried as text and
+///     discovered to be malformed on a device — but writing a URL as a literal is the common case, so the
+///     chain takes both.
+/// </summary>
+public static class RaskNativeWebViewUrlSetters
+{
+    /// <summary>
+    ///     Point the WebView at an absolute URL — a Rask server, or a WASM app you host.
+    /// </summary>
+    /// <param name="build">The chain.</param>
+    /// <param name="url">
+    ///     An absolute <c>http</c> or <c>https</c> URL, e.g. <c>https://app.example.com/</c>. Anything else
+    ///     throws here, where the call site is, instead of failing later as a blank WebView.
+    /// </param>
+    /// <exception cref="ArgumentException">The value is not an absolute http/https URL.</exception>
+    public static Build<NativeWebView> Url(this Build<NativeWebView> build, string url)
+    {
+        ArgumentNullException.ThrowIfNull(url);
+
+        // Absolute, and a web scheme. `IsAbsoluteUri` alone is not enough on either count: on Unix
+        // Uri.TryCreate("/relative", Absolute, …) SUCCEEDS as file:///relative, and `javascript:` and `data:`
+        // parse absolutely too. All three would be handed to a WebView that carries the capability bridge, so
+        // the scheme is checked rather than assumed.
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var parsed) || !IsWebScheme(parsed))
+        {
+            throw new ArgumentException(
+                $"'{url}' is not an absolute URL. NativeWebView.Url takes the full http:// or https:// "
+                + "address of the app the WebView should load, e.g. \"https://app.example.com/\".",
+                nameof(url));
+        }
+
+        return build.Url(parsed);
+    }
+
+    private static bool IsWebScheme(Uri url) =>
+        string.Equals(url.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+        || string.Equals(url.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Rask.Native/INativeWebView.cs
+++ b/src/Rask.Native/INativeWebView.cs
@@ -36,6 +36,20 @@ public interface INativeWebView
     ValueTask EvaluateJavaScriptAsync(string javaScript);
 
     /// <summary>
+    ///     Navigate the WebView to <paramref name="url" /> — the seam behind
+    ///     <c>NativeWebView.Url(…)</c>, where the UI comes from a Rask server or a hosted WASM app instead
+    ///     of from components rendering on the device. Called from <c>NativeLiveSession</c> when a frame
+    ///     names an address, and only when that address changes, so a re-render does not reload the page.
+    ///     <para>
+    ///         An implementation must marshal onto the UI thread, and must keep the WebView on this
+    ///         origin: inject the capability bridge for it, and send an off-origin navigation to the system
+    ///         browser rather than following it. The page is given the device backends, so where it is
+    ///         allowed to travel is the boundary of that grant.
+    ///     </para>
+    /// </summary>
+    ValueTask LoadUrlAsync(Uri url);
+
+    /// <summary>
     ///     Set by the host to receive JS → .NET messages: component events (<c>click</c>/<c>input</c>/
     ///     <c>submit</c>/<c>navigate</c>/…), <c>jsResult</c> replies, and <c>dotNetInvoke</c> calls — each
     ///     a UTF-8 JSON payload. The platform head calls this from its script-message handler.

--- a/src/Rask.Native/NativeLiveSession.cs
+++ b/src/Rask.Native/NativeLiveSession.cs
@@ -60,6 +60,13 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
     private byte[]? _lastPushedChrome;
     private Dictionary<string, Action> _chromeTapHandlers = new(StringComparer.Ordinal);
 
+    // A Url-mode NativeWebView: the address this frame says the WebView should be showing, collected fresh
+    // each walk exactly like the bars, and the one it was last actually sent to. Two fields rather than one
+    // for the same reason _lastPushedChrome exists — a re-render that names the same address must not reload
+    // the page, which would discard its scroll position, its form state and anything in flight.
+    private Uri? _pendingWebViewUrl;
+    private Uri? _loadedWebViewUrl;
+
     // Pure-native content. Optional in exactly the same way as _chrome: with no INativeSurface registered the
     // NativeScreen family is inert and every frame paints through the WebView, so existing apps are untouched.
     //
@@ -151,11 +158,15 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
 
     // Opt into the serializer's render-walk collection only when a backend is registered (else pure no-op).
     // Either backend needs it: the bars come from the same walk that the native view tree is rebuilt from.
-    protected override bool CollectsNativeChromeCore => _chrome is not null || _surface is not null;
+    //
+    // A WebView counts too, and not only for the bars: a NativeWebView carrying a Url is reported through
+    // this same walk, and an app in that mode may register neither of the other two backends.
+    protected override bool CollectsNativeChromeCore =>
+        _chrome is not null || _surface is not null || _webView is not null;
 
     // The serializer hands us every user component it walks; pick out the native bars composed in the tree —
     // a NativeHeaderBar becomes the header, a NativeTabBar/NativeToolbar the footer. Last of each kind wins
-    // (the deepest layout in the walk). NativeWebView and bar items pass through here and are ignored.
+    // (the deepest layout in the walk). Bar items pass through here and are ignored.
     protected override void ReportNativeComponentCore(Component component)
     {
         switch (component)
@@ -165,6 +176,12 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
                 break;
             case NativeTabBar or NativeToolbar or TabStrip:
                 _pendingFooter = component;
+                break;
+            // A NativeWebView hosting markup is transparent and stays ignored — its children ARE the frame.
+            // One carrying a Url is the opposite: it says this frame has no HTML of its own and names the
+            // address the WebView should be showing instead. Last one wins, like the bars.
+            case NativeWebView { Url: { } url }:
+                _pendingWebViewUrl = url;
                 break;
         }
 
@@ -193,6 +210,10 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
         _pendingHeader = null;
         _pendingFooter = null;
 
+        // Same reasoning for the address: a frame that no longer composes a Url-mode NativeWebView reports
+        // none, and the session is back to hosting its own HTML.
+        _pendingWebViewUrl = null;
+
         // Reset the collected view tree too, so a frame that renders no NativeScreen reports none — that is
         // exactly the signal that this frame's content is the WebView.
         _treeBuilder.Reset();
@@ -206,7 +227,24 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
     private async Task PushNativeFrameAsync()
     {
         await PushChromeAsync().ConfigureAwait(false);
+        await PushWebViewUrlAsync().ConfigureAwait(false);
         await PushSurfaceAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Navigate the WebView when this frame names an address it is not already showing. Guarded the same
+    ///     way the chrome push is: a re-render that produces the same URL must not reload the page, which
+    ///     would throw away its scroll position, its form state and any work in flight.
+    /// </summary>
+    private ValueTask PushWebViewUrlAsync()
+    {
+        if (_pendingWebViewUrl is not { } url || _webView is not { } webView || url == _loadedWebViewUrl)
+        {
+            return default;
+        }
+
+        _loadedWebViewUrl = url;
+        return webView.LoadUrlAsync(url);
     }
 
     /// <summary>
@@ -218,12 +256,19 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
     private bool IsNativeFrame => _surface is not null && _treeBuilder.Root is not null;
 
     /// <summary>
-    ///     The emit gate every send in this session goes through. On a native frame it reports "nothing sent"
-    ///     WITHOUT touching the base's double-buffered baseline, so <c>_lastSentBuffer</c> keeps describing the
-    ///     HTML the WebView is actually still showing.
+    ///     Whether the frame just walked hands the WebView an address instead of HTML. The WebView is then
+    ///     showing a document this session did not render and must not diff against — the page belongs to
+    ///     whatever is serving that URL.
+    /// </summary>
+    private bool IsRemoteFrame => _pendingWebViewUrl is not null;
+
+    /// <summary>
+    ///     The emit gate every send in this session goes through. On a native OR a remote frame it reports
+    ///     "nothing sent" WITHOUT touching the base's double-buffered baseline, so <c>_lastSentBuffer</c> keeps
+    ///     describing the HTML the WebView last actually received.
     /// </summary>
     private ValueTask<bool> EmitFrameAsync(bool force) =>
-        IsNativeFrame ? ValueTask.FromResult(false) : TryEmitFrameAsync(force);
+        IsNativeFrame || IsRemoteFrame ? ValueTask.FromResult(false) : TryEmitFrameAsync(force);
 
     /// <summary>
     ///     Commit the frame just built — paint it, then push the bars and the native content — and return the
@@ -233,10 +278,14 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
     ///     A native frame paints through the surface and emits no HTML at all, so it must NOT take the
     ///     "nothing was emitted, bail out" path the HTML callers use: that would skip the surface push and the
     ///     screen would never update. Navigating from a web route to a native one goes through exactly here.
+    ///     <para>
+    ///         A remote frame is the same shape for the same reason — it emits no HTML either, and its work
+    ///         (the bars, and the navigation itself) is all in the push.
+    ///     </para>
     /// </remarks>
     private async Task<byte[]> CommitFrameAsync(bool force)
     {
-        if (IsNativeFrame)
+        if (IsNativeFrame || IsRemoteFrame)
         {
             await PushNativeFrameAsync().ConfigureAwait(false);
             return Array.Empty<byte>();

--- a/src/Rask.Native/Platforms/Android/RaskAndroidWebView.cs
+++ b/src/Rask.Native/Platforms/Android/RaskAndroidWebView.cs
@@ -53,6 +53,27 @@ public sealed partial class RaskAndroidWebView : INativeWebView, INativeChrome
     /// <summary>Load the boot shell once the session is wired (call from the Activity).</summary>
     public void LoadShell() => _webView.LoadUrl(_origin + "index.native.html");
 
+    // The origin a Url-mode NativeWebView named, once one has been loaded. Null while the app hosts its own
+    // markup, and the policy below is inert then.
+    private Uri? _remoteOrigin;
+
+    /// <inheritdoc />
+    public ValueTask LoadUrlAsync(Uri url)
+    {
+        ArgumentNullException.ThrowIfNull(url);
+
+        _remoteOrigin = url;
+        _webView.Post(() =>
+        {
+            // Swapped in rather than configured up front, so an app that never names a Url keeps exactly the
+            // client it had. The asset interceptor is still wanted: scoped CSS/JS and the app's own bundled
+            // files are served from the app origin regardless of what the page is.
+            _webView.SetWebViewClient(new ShowcaseWebViewClient(_origin, _readStaticFile, url));
+            _webView.LoadUrl(url.ToString());
+        });
+        return default;
+    }
+
     /// <inheritdoc />
     public ValueTask ApplyRenderAsync(ReadOnlyMemory<byte> frameUtf8)
     {
@@ -93,7 +114,13 @@ internal sealed class RaskJsBridge(RaskAndroidWebView owner) : Java.Lang.Object
 // Serves the app origin from NativeOriginAssets (shell/client + scoped assets + bundled static files);
 // under-origin misses return an empty 200 so the page never hangs, and off-origin requests fall through to
 // the real network.
-internal sealed class ShowcaseWebViewClient(string origin, Func<string, byte[]?> readStaticFile) : WebViewClient
+//
+// When remoteOrigin is set the app is in Url mode, and this client also carries the policy that mode needs:
+// inject the capability bridge for that origin, and keep the WebView on it.
+internal sealed class ShowcaseWebViewClient(
+    string origin,
+    Func<string, byte[]?> readStaticFile,
+    Uri? remoteOrigin = null) : WebViewClient
 {
     public override WebResourceResponse? ShouldInterceptRequest(WebView? view, IWebResourceRequest? request)
     {
@@ -111,6 +138,37 @@ internal sealed class ShowcaseWebViewClient(string origin, Func<string, byte[]?>
 
         // Under-origin miss (favicon we don't ship, …) — empty 200 so nothing blocks the render.
         return new WebResourceResponse("text/plain", "UTF-8", new MemoryStream([]));
+    }
+
+    // The page loaded from a Url gets the capability bridge, so it can reach the device backends this app
+    // registered — but only the origin the app actually named.
+    public override void OnPageStarted(WebView? view, string? url, Android.Graphics.Bitmap? favicon)
+    {
+        base.OnPageStarted(view, url, favicon);
+
+        if (remoteOrigin is { } trusted && NativeCapabilities.IsTrustedOrigin(trusted, url))
+        {
+            view?.EvaluateJavascript(NativeCapabilities.BridgeScript, null);
+        }
+    }
+
+    // Keep the WebView on that origin. Anything else opens in the system browser — the grant is to the page
+    // you pointed at, and this is what stops it travelling with the user somewhere you did not.
+    //
+    // This matters more on Android than the equivalent does on iOS: __raskBridge is a @JavascriptInterface
+    // bound to the WebView itself, so it is reachable by whatever document the WebView holds.
+    public override bool ShouldOverrideUrlLoading(WebView? view, IWebResourceRequest? request)
+    {
+        var url = request?.Url?.ToString();
+        if (remoteOrigin is not { } trusted || url is null || NativeCapabilities.IsTrustedOrigin(trusted, url))
+        {
+            return base.ShouldOverrideUrlLoading(view, request);
+        }
+
+        var intent = new Intent(Intent.ActionView, Android.Net.Uri.Parse(url));
+        intent.AddFlags(ActivityFlags.NewTask);
+        view?.Context?.StartActivity(intent);
+        return true;
     }
 }
 

--- a/src/Rask.Native/Platforms/iOS/RaskWkWebView.cs
+++ b/src/Rask.Native/Platforms/iOS/RaskWkWebView.cs
@@ -15,7 +15,8 @@ namespace Rask.Native;
 ///     <see cref="IosBundledAssets" />). Assign <see cref="View" /> to a view controller, wire the session
 ///     (<c>RunLocalAsync</c>), then <see cref="LoadShell" />.
 /// </summary>
-public sealed partial class RaskWkWebView : NSObject, INativeWebView, IWKScriptMessageHandler, INativeChrome
+public sealed partial class RaskWkWebView : NSObject, INativeWebView, IWKScriptMessageHandler, INativeChrome,
+    IWKNavigationDelegate
 {
     /// <summary>The default custom scheme + app origin the shell + client + assets are served from.</summary>
     public const string DefaultScheme = "raskapp";
@@ -63,6 +64,63 @@ public sealed partial class RaskWkWebView : NSObject, INativeWebView, IWKScriptM
     /// <summary>Load the boot shell once the session is wired (call from the AppDelegate).</summary>
     public void LoadShell() =>
         View.LoadRequest(new NSUrlRequest(new NSUrl(_origin + "index.native.html")));
+
+    // The origin a Url-mode NativeWebView named, once one has been loaded. Null while the app hosts its own
+    // markup, and the navigation policy below is inert then — the boot shell is served over the custom
+    // scheme, which is not http/https and is this app's own origin anyway.
+    private Uri? _remoteOrigin;
+
+    /// <inheritdoc />
+    public ValueTask LoadUrlAsync(Uri url)
+    {
+        ArgumentNullException.ThrowIfNull(url);
+
+        _remoteOrigin = url;
+        DispatchQueue.MainQueue.DispatchAsync(() =>
+        {
+            // Assigned here rather than in the constructor so an app that never uses a Url keeps exactly the
+            // behaviour it had: no delegate, no policy, nothing to go wrong.
+            View.NavigationDelegate = this;
+            View.LoadRequest(new NSUrlRequest(new NSUrl(url.ToString())));
+        });
+        return default;
+    }
+
+    // The page loaded from a Url gets the capability bridge, so it can reach the device backends this app
+    // registered. Injected per navigation, after commit, and only for the origin the app named.
+    [Export("webView:didCommitNavigation:")]
+    public void DidCommitNavigation(WKWebView webView, WKNavigation navigation)
+    {
+        if (_remoteOrigin is { } origin && NativeCapabilities.IsTrustedOrigin(origin, webView.Url?.AbsoluteString))
+        {
+            webView.EvaluateJavaScript(new NSString(NativeCapabilities.BridgeScript), null);
+        }
+    }
+
+    // Keep the WebView on the origin the app named. A tapped link, a 302, a window.location or a form POST
+    // that leaves it opens in Safari instead — the bridge is granted to the page you pointed at, and this is
+    // what stops that grant travelling with the user to somewhere you did not.
+    [Export("webView:decidePolicyForNavigationAction:decisionHandler:")]
+    public void DecidePolicy(WKWebView webView, WKNavigationAction navigationAction,
+        Action<WKNavigationActionPolicy> decisionHandler)
+    {
+        var url = navigationAction.Request.Url;
+        var scheme = url?.Scheme;
+        var isWeb = string.Equals(scheme, "http", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(scheme, "https", StringComparison.OrdinalIgnoreCase);
+
+        // Only http/https is policed, and only once a remote origin exists: the boot shell rides the custom
+        // scheme, and about:blank arrives before any of this.
+        if (_remoteOrigin is not { } origin || !isWeb
+            || NativeCapabilities.IsTrustedOrigin(origin, url?.AbsoluteString))
+        {
+            decisionHandler(WKNavigationActionPolicy.Allow);
+            return;
+        }
+
+        UIApplication.SharedApplication.OpenUrl(url!, new NSDictionary(), null);
+        decisionHandler(WKNavigationActionPolicy.Cancel);
+    }
 
     /// <inheritdoc />
     public ValueTask ApplyRenderAsync(ReadOnlyMemory<byte> frameUtf8)

--- a/tests/Rask.Generators.Tests/NativeWebViewModeAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/NativeWebViewModeAnalyzerTests.cs
@@ -1,0 +1,181 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Rask.Generators.Analyzers;
+
+namespace Rask.Generators.Tests;
+
+/// <summary>
+///     <c>NativeWebView</c> shows one document: the page at its <c>Url</c>, or the children composed into it.
+///     RASK049 catches one NativeWebView claiming both; RASK050 catches one component that could render
+///     either.
+/// </summary>
+public class NativeWebViewModeAnalyzerTests
+{
+    [Fact]
+    public async Task UrlAndChildrenOnOneWebView_ReportsRask049()
+    {
+        var src = """
+                  using Rask.Core;
+                  namespace Demo;
+                  public sealed partial class Page : Component
+                  {
+                      protected override Component? Render() =>
+                          NativeWebView.Url("https://app.example.com/")[Div[Span]];
+                  }
+                  """;
+
+        var d = Assert.Single(await GetDiagnosticsAsync(src, id: "RASK049"));
+        Assert.Equal("RASK049", d.Id);
+        Assert.Contains("one document", d.GetMessage(), StringComparison.Ordinal);
+    }
+
+    /// <summary>The typed step is the same mistake and must not slip past the syntactic name check.</summary>
+    [Fact]
+    public async Task UrlAsUriAndChildren_ReportsRask049()
+    {
+        var src = """
+                  using System;
+                  using Rask.Core;
+                  namespace Demo;
+                  public sealed partial class Page : Component
+                  {
+                      protected override Component? Render() =>
+                          NativeWebView.Url(new Uri("https://app.example.com/"))[Div];
+                  }
+                  """;
+
+        Assert.Single(await GetDiagnosticsAsync(src, id: "RASK049"));
+    }
+
+    /// <summary>A step after the Url must not hide it — the walk goes up the whole chain, not one link.</summary>
+    [Fact]
+    public async Task UrlFollowedByAnotherStepThenChildren_ReportsRask049()
+    {
+        var src = """
+                  using Rask.Core;
+                  namespace Demo;
+                  public sealed partial class Page : Component
+                  {
+                      protected override Component? Render() =>
+                          NativeWebView.Url("https://app.example.com/").Key("k")[Div];
+                  }
+                  """;
+
+        Assert.Single(await GetDiagnosticsAsync(src, id: "RASK049"));
+    }
+
+    [Fact]
+    public async Task MarkupModeAlone_ReportsNothing()
+    {
+        var src = """
+                  using Rask.Core;
+                  namespace Demo;
+                  public sealed partial class Page : Component
+                  {
+                      protected override Component? Render() => NativeWebView[Div[Span]];
+                  }
+                  """;
+
+        Assert.Empty(await GetDiagnosticsAsync(src, id: null));
+    }
+
+    [Fact]
+    public async Task UrlModeAlone_ReportsNothing()
+    {
+        var src = """
+                  using Rask.Core;
+                  namespace Demo;
+                  public sealed partial class Page : Component
+                  {
+                      protected override Component? Render() =>
+                          [NativeHeaderBar.Title("Remote"), NativeWebView.Url("https://app.example.com/")];
+                  }
+                  """;
+
+        Assert.Empty(await GetDiagnosticsAsync(src, id: null));
+    }
+
+    [Fact]
+    public async Task BothModesInOneComponent_ReportsRask050()
+    {
+        var src = """
+                  using Rask.Core;
+                  namespace Demo;
+                  public sealed partial class Page : Component
+                  {
+                      public bool Remote { get; set; }
+                      protected override Component? Render() =>
+                          Remote ? NativeWebView.Url("https://app.example.com/") : NativeWebView[Div[Span]];
+                  }
+                  """;
+
+        var d = Assert.Single(await GetDiagnosticsAsync(src, id: "RASK050"));
+        Assert.Equal("RASK050", d.Id);
+        // It reports on the MARKUP arm — the Url is the deliberate choice, the markup is what silently
+        // stopped working — and names the component that holds both.
+        Assert.Contains("pick a mode", d.GetMessage(), StringComparison.Ordinal);
+        Assert.Contains("Page", d.GetMessage(), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     A compilation is NOT an app. A test project, a component library, or any assembly with more than
+    ///     one app root legitimately holds both modes in different types — a compilation-wide rule reported
+    ///     every one of them, which is how this scope was found.
+    /// </summary>
+    [Fact]
+    public async Task TheTwoModesInSeparateComponents_ReportsNothing()
+    {
+        var src = """
+                  using Rask.Core;
+                  namespace Demo;
+                  public sealed partial class Remote : Component
+                  {
+                      protected override Component? Render() => NativeWebView.Url("https://app.example.com/");
+                  }
+                  public sealed partial class Local : Component
+                  {
+                      protected override Component? Render() => NativeWebView[Div[Span]];
+                  }
+                  """;
+
+        Assert.Empty(await GetDiagnosticsAsync(src, id: null));
+    }
+
+    /// <summary>
+    ///     A pure-native screen is not a third mode and must not be dragged in: it paints through the surface,
+    ///     not the WebView, and composing one beside either mode is the existing mixed-surface feature.
+    /// </summary>
+    [Fact]
+    public async Task ANativeScreenBesideUrlMode_ReportsNothing()
+    {
+        var src = """
+                  using Rask.Core;
+                  namespace Demo;
+                  public sealed partial class Page : Component
+                  {
+                      public bool Native { get; set; }
+                      protected override Component? Render() =>
+                          Native ? NativeScreen[NativeLabel["hi"]] : NativeWebView.Url("https://app.example.com/");
+                  }
+                  """;
+
+        Assert.Empty(await GetDiagnosticsAsync(src, id: null));
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(
+        string source, string assemblyName = "TestAssembly", string? id = "RASK049")
+    {
+        // Analyze the POST-generator compilation, so `NativeWebView.Url(…)` binds to the real generated step
+        // rather than sitting there as an error type — a chain test against bare source reports nothing and
+        // passes for the wrong reason.
+        var generated = BuilderGeneratorHarness.Compile(source, assemblyName);
+
+        var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new NativeWebViewModeAnalyzer());
+        var all = await generated.WithAnalyzers(analyzers).GetAnalyzerDiagnosticsAsync();
+
+        // id: null asks for "nothing at all", which is stronger than filtering to one rule and finding it
+        // empty — that would pass while the other rule false-positives.
+        return id is null ? all : all.Where(d => d.Id == id).ToImmutableArray();
+    }
+}

--- a/tests/Rask.Native.Tests/Infrastructure/FakeNativeWebView.cs
+++ b/tests/Rask.Native.Tests/Infrastructure/FakeNativeWebView.cs
@@ -16,6 +16,13 @@ internal sealed class FakeNativeWebView : INativeWebView
     /// <summary>Every script the host evaluated via <see cref="EvaluateJavaScriptAsync" /> (IJSRuntime interop).</summary>
     public List<string> Evaluated { get; } = new();
 
+    /// <summary>
+    ///     Every address the session navigated to via <see cref="LoadUrlAsync" />, in order — a Url-mode
+    ///     <c>NativeWebView</c>. The count is the point as much as the values: a re-render naming the same
+    ///     address must not reload the page.
+    /// </summary>
+    public List<Uri> LoadedUrls { get; } = new();
+
     public Func<byte[], Task>? OnMessage { get; set; }
 
     public ValueTask ApplyRenderAsync(ReadOnlyMemory<byte> frameUtf8)
@@ -28,6 +35,12 @@ internal sealed class FakeNativeWebView : INativeWebView
     public ValueTask EvaluateJavaScriptAsync(string javaScript)
     {
         Evaluated.Add(javaScript);
+        return default;
+    }
+
+    public ValueTask LoadUrlAsync(Uri url)
+    {
+        LoadedUrls.Add(url);
         return default;
     }
 

--- a/tests/Rask.Native.Tests/Session/NativeWebViewUrlTests.cs
+++ b/tests/Rask.Native.Tests/Session/NativeWebViewUrlTests.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core;
+using Rask.Core.Live;
+using Rask.Native.Components;
+using Rask.Native.Tests.Infrastructure;
+
+#pragma warning disable RASK019 // test apps predate framework-managed <head>
+
+namespace Rask.Native.Tests.Session;
+
+/// <summary>
+///     A <see cref="NativeWebView" /> carrying a <c>Url</c> gets its UI from a Rask server or a hosted WASM
+///     app instead of from components rendering on the device. The session's job is then narrow and
+///     specific: navigate once, keep the native bars, and push no HTML — because the document belongs to
+///     whatever is serving that address, and diffing against it would be diffing against someone else's page.
+/// </summary>
+[Collection("NativeSession")]
+public class NativeWebViewUrlTests() : ResettingTestBase(LiveDiffMode.DisabledFull)
+{
+    private static Uri Remote => RemoteUrls.App;
+
+    [Fact]
+    public async Task A_url_navigates_the_webview()
+    {
+        var (_, webView, _) = await NewSessionAsync<UrlApp>(diffMode: DiffMode);
+
+        Assert.Equal(Remote, Assert.Single(webView.LoadedUrls));
+    }
+
+    /// <summary>
+    ///     The whole reason the mode exists: the page is not ours to render. Pushing HTML at it would fight
+    ///     the document the remote app is serving.
+    /// </summary>
+    [Fact]
+    public async Task A_url_frame_pushes_no_html()
+    {
+        var (_, webView, _) = await NewSessionAsync<UrlApp>(diffMode: DiffMode);
+
+        Assert.Empty(webView.Frames);
+    }
+
+    /// <summary>
+    ///     A re-render that names the same address must not reload — a reload throws away the page's scroll
+    ///     position, its form state and any request in flight, which is a data-loss bug wearing a repaint's
+    ///     clothes.
+    /// </summary>
+    [Fact]
+    public async Task Re_rendering_the_same_url_does_not_reload_the_page()
+    {
+        var (app, webView, _) = await NewSessionAsync<UrlApp>(diffMode: DiffMode);
+
+        await app.Session.RequestRenderAsync();
+        await app.Session.RequestRenderAsync();
+
+        Assert.Equal(Remote, Assert.Single(webView.LoadedUrls));
+    }
+
+    /// <summary>
+    ///     Changing the address is the one thing that should navigate again.
+    /// </summary>
+    [Fact]
+    public async Task Changing_the_url_navigates_again()
+    {
+        var (app, webView, _) = await NewSessionAsync<SwitchingUrlApp>(diffMode: DiffMode);
+
+        SwitchingUrlApp.Target = RemoteUrls.Other;
+        await app.Session.RequestRenderAsync();
+
+        Assert.Equal(
+            [Remote, RemoteUrls.Other],
+            webView.LoadedUrls);
+    }
+
+    /// <summary>
+    ///     The point of putting this in markup rather than in the head: the bars are still Rask's, rendered
+    ///     natively around a page it did not render.
+    /// </summary>
+    [Fact]
+    public async Task Native_chrome_still_renders_around_a_url_page()
+    {
+        var chrome = new FakeNativeChrome();
+        _ = await NewSessionAsync<UrlApp>(
+            configure: s => s.AddSingleton<INativeChrome>(chrome), diffMode: DiffMode);
+
+        var pushed = Assert.Single(chrome.Pushed);
+        using var doc = JsonDocument.Parse(pushed);
+        Assert.Equal("Remote", doc.RootElement.GetProperty("header").GetProperty("title").GetString());
+    }
+
+    /// <summary>
+    ///     An app with no <c>Url</c> anywhere is untouched — this mode is opt-in per render, and the ordinary
+    ///     markup-hosting path must not have acquired a navigation.
+    /// </summary>
+    [Fact]
+    public async Task A_markup_app_never_navigates()
+    {
+        var (_, webView, _) = await NewSessionAsync(diffMode: DiffMode);
+
+        Assert.Empty(webView.LoadedUrls);
+        Assert.NotEmpty(webView.Frames);
+    }
+
+    /// <summary>
+    ///     The <c>string</c> overload parses at the call site rather than carrying text to a device and
+    ///     failing there as a blank WebView.
+    /// </summary>
+    [Theory]
+    [InlineData("/relative")]              // on Unix this parses ABSOLUTELY, as file:///relative
+    [InlineData("app.example.com")]
+    [InlineData("not a url at all")]
+    [InlineData("javascript:alert(1)")]    // parses absolutely, and would run in a bridged WebView
+    [InlineData("data:text/html,<b>x</b>")]
+    [InlineData("file:///etc/passwd")]
+    public void A_url_that_is_not_an_http_address_is_rejected_where_it_is_written(string bad)
+    {
+        var ex = Assert.Throws<ArgumentException>(() => NativeWebViewUrlProbe.Build(bad));
+
+        Assert.Contains("http:// or https://", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     The same guard, reached through the <see cref="Uri" /> step rather than the string one — the
+    ///     property is where it lives precisely so neither way in can skip it.
+    /// </summary>
+    [Fact]
+    public void A_non_http_uri_is_rejected_through_the_typed_step()
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => new NativeWebView { Url = new Uri("javascript:alert(1)") });
+
+        Assert.Contains("http:// or https://", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void An_absolute_url_string_reaches_the_component() =>
+        Assert.Equal(Remote, NativeWebViewUrlProbe.Build(Remote.ToString()).Url);
+
+}
+
+// Declared at namespace level, not nested: chain entries are injected into a markup host's own partial, and
+// a type nested inside a non-host test class does not get them.
+
+/// <summary>A probe that writes the chain the way an app does, so the string overload is tested as used.</summary>
+internal sealed partial class NativeWebViewUrlProbe : Component
+{
+    public static NativeWebView Build(string url) => NativeWebView.Url(url);
+}
+
+/// <summary>
+/// A plain holder, not a component: inside a markup host a component's name is the chain's entry, so
+/// `UrlApp.Remote` would resolve against `Build&lt;UrlApp&gt;` rather than the type.
+/// </summary>
+internal static class RemoteUrls
+{
+    public static readonly Uri App = new("https://app.example.com/");
+    public static readonly Uri Other = new("https://other.example.com/");
+}
+
+internal sealed partial class UrlApp : Component
+{
+    protected override Component? Render() =>
+    [
+        NativeHeaderBar.Title("Remote"),
+        NativeWebView.Url(RemoteUrls.App),
+    ];
+}
+
+internal sealed partial class SwitchingUrlApp : Component
+{
+    public static Uri Target { get; set; } = RemoteUrls.App;
+
+    protected override Component? Render() =>
+    [
+        NativeHeaderBar.Title("Remote"),
+        NativeWebView.Url(Target),
+    ];
+}


### PR DESCRIPTION
`NativeWebView` had one mode: its children are the page. It has two now — give it a `Url` and the WebView
loads that address, so the UI comes from a Rask server or a WASM app you host rather than from components
rendering on the device.

```csharp
protected override Component? Render() =>
[
    NativeHeaderBar.Title("Home"),
    NativeWebView.Url("https://app.example.com/"),
];
```

The bars around it are still native, still declared in the same `Render()`, and the page reaches the device
backends through the capability bridge. What changes is only where the UI comes from — which is the
four-models epic's (#774) whole claim, now expressible in markup instead of only by picking a different
platform head.

## The session gains a third content signal

`IsNativeFrame` was the only discriminator, and the session never saw `NativeWebView` at all. A URL-mode
one is now reported through the same render walk the bars use; it suppresses the HTML emit **without**
touching the diff baseline (the rule a native frame already follows), and navigates only when the address
changes — a re-render naming the same URL must not reload the page and discard its scroll position, its
form state and anything in flight.

## Security: the Local heads had no navigation policy at all

This is the part the feature could not leave alone. `RaskWkWebView` was not a `WKNavigationDelegate`, and
`RaskAndroidWebView`'s client overrode only `ShouldInterceptRequest` and explicitly let off-origin requests
through — while Android's `__raskBridge` `@JavascriptInterface` was already bound to that same WebView.
Loading a remote page into it would have exposed the bridge to that page **and to anywhere it navigated**.

Both heads now carry the policy the Server heads always had: inject for the declared origin, and send an
off-origin navigation to the system browser. Ported, not invented — the code came from
`RaskServerViewController` / `RaskServerWebView`.

Pointing `.Url(…)` at a site you do not control still gives that site your device APIs. That is inherent to
the feature, and the docs say so where it is introduced rather than implying a guard removes it.

`.Url(…)` validates in the **property setter**, so neither the `string` nor the `Uri` path can skip it. That
check earns its place: on Unix `Uri.TryCreate("/relative", Absolute, …)` **succeeds**, as `file:///relative`
— and `javascript:` and `data:` parse absolutely too. All three would otherwise have been handed to a
WebView carrying the bridge.

## Two diagnostics

The alternative is the framework discarding work silently, which is what the chain's mode system exists to
prevent elsewhere.

- **RASK049** — one `NativeWebView` sets a `Url` *and* takes children.
- **RASK050** — one component could render either.

RASK050's scope was wrong in the first cut and the build caught it. Written against the compilation it read
"one app" — but a compilation is not an app: this repo's own native test assembly holds many app roots and
every markup one lit up. Scoped to the declaring type it catches the real mistake and leaves ordinary
multi-app assemblies alone. Both the wrong shape and the right one are pinned by tests.

## Sample

`samples/Rask.Example.Native.Server` is now written this way — one `ServerShellApp` with a header bar and a
`NativeWebView.Url(…)`, run by the ordinary head, instead of the separate `RaskServerViewController` /
`RaskServerWebView` classes. Same app, same behaviour, and the Server model stops being a parallel code
path with no session and no chrome.

**A URL-mode app still loads the boot shell first**, which is not obvious and is worth knowing.
`RunLocalAsync` defers the first render to the client's `ready` handshake, and the client lives in the
shell — so with no shell there is no client, no handshake, no first frame, and therefore no address to
navigate to. Skipping `LoadShell()` produces a blank white screen and no bars, which is exactly what the
first device run showed (fixed in the second commit). Letting the host render the first frame without a
handshake, as `RunNativeAsync` already does for the pure-native model, would remove the extra document load
and is the obvious follow-up.

## Testing

- 14 session tests (`NativeWebViewUrlTests`) — navigates once, pushes no HTML, does not reload on
  re-render, navigates again when the address changes, keeps native chrome, leaves a markup app untouched,
  and rejects every non-http address through both the `string` and `Uri` paths.
- 8 analyzer tests, each guard proved by **failing** it.
- Format + `-warnaserror` + full unit gate green; pre-push browser E2E green.
- **On an iPhone 17 Pro simulator against a live `Rask.Example.Server`**: a native `UINavigationBar` at the
  top, the remote app rendering fully styled below it.

## Follow-on

With this working, `RaskServerViewController` and `RaskServerWebView` are doing a job the ordinary head can
now do. Collapsing them is the natural sequel, and #782's `RaskNativeModelContracts` is where it would be
pinned.

Also corrected: `CLAUDE.md` claimed RASK001–048 with only RASK047 retired; the docs have said RASK001–053
for a while, and RASK030 and RASK042 are retired too.
