### PR TITLE
feat(native): scaffold a pure-native app, and wire Android's Back button to its own history (#777)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Changed
+- **`rask new --template native --host native` scaffolds a pure-native app** (#777, the four-models
+  epic). The scaffold still emitted the WebView-hybrid shape — `NativeWebView[Router]` and a page of
+  plain HTML — so the model the epic renamed to `native`, meaning *pure-native screens*, was the one
+  thing `rask new` could not produce. The App shell is now `NativeScreen[Router]`, the welcome page is
+  `NativeLabel` / `NativeStack` / `NativeDivider`, and both heads call `RunNativeAsync`. A comment shows
+  how to put a `NativeWebView` on one route if you want markup somewhere.
+
+  The scaffolded `NativeStack` always states its `Orientation`, because leaving it unset renders
+  differently on the two platforms (#791) and a starter template is the worst place to inherit that.
+
+### Added
+- **`NativeApp.GoBackAsync()` and `NativeApp.CanGoBack`** — back navigation a platform head can actually
+  reach. `GoBackAsync` already existed on `NativeLiveSession`, but `NativeApp.Session` is internal, so
+  "wire the hardware Back button" was not expressible in app code at all. `CanGoBack` answers
+  synchronously, because the caller that needs it — Android's back handler — must decide in the moment
+  whether to handle the press or let it close the activity.
+
+  It is false for an app with a WebView, and that is the safe answer rather than a missing feature: the
+  page owns that history and reading it needs a round trip. Such a head keeps the platform's default
+  Back, exactly as before.
+
+### Fixed
+- **A navigation performed by a handler built no back history in the pure-native model.** Only
+  navigations arriving as a `navigate` *message* reached `RecordNativeHistory`; the ones a handler
+  performed through `Navigator.NavigateTo` consumed their history entry and handed it to the payload
+  instead. With a WebView that difference is invisible — the client calls `pushState`, and the page's
+  history is the only one that exists — so it survived until a pure-native app was driven on a device,
+  where a button that navigated left no trace and the hardware Back button closed the app from the
+  second page. All three dispatch paths now go through one helper, so a fourth cannot reintroduce it.
+
+- **The scaffolded Android head wired Back through `OnBackPressed`, which modern Android never calls.**
+  For an app targeting API 35+ predictive back is on by default and the override is dead — it compiles,
+  it looks right, and Back silently closes the app mid-navigation. The scaffold registers an
+  `OnBackInvokedDispatcher` callback on API 33+ and keeps the override only for API 32 and earlier.
+  Registering a callback also takes over closing the app, so the handler calls `Finish()` itself when
+  there is nothing to pop — without which Back would be dead on the first page instead.
+
+  Verified on an API 36 emulator against a freshly scaffolded app: Back returns from the second page to
+  the first, and at the root it closes the app.
+
+- **The scaffolded iOS head did not compile.** It registered `NativeNotifications` and `NativeBadge`
+  directly, and both are `internal` — so `rask new --template native --platform ios` emitted an
+  `AppDelegate` with two `CS0122`s in it. Nothing caught this: `NativeTemplateCompileTests` deliberately
+  excludes `Platforms/**` (it needs the workloads), and `CliBuildE2E` cannot build the native template at
+  all. Both heads now call `host.UsePlatform(new ApplePlatform(…))` / `new AndroidPlatform(this)`, which
+  is what the docs and the samples already recommended — one line, no internals, and all **fifteen**
+  device backends instead of the three the template hand-registered.
+
+
 ### Added
 - **`NativeWebView` can point at a URL instead of hosting markup.** It had one mode: its children are the
   page. It has two now — give it a `Url` and the WebView loads that address, so the UI comes from a Rask

--- a/docs/native.md
+++ b/docs/native.md
@@ -34,6 +34,7 @@ one route served as HTML, the next fully native.
 
 Also in this doc: [How it fits](#how-it-fits), [Pure-native screens](#pure-native-screens-no-webview),
 [A WebView pointed at your own app](#a-webview-pointed-at-your-own-app),
+[The hardware Back button](#the-hardware-back-button),
 [Get started](#get-started), [Files, downloads and sign-out](#files-downloads-and-sign-out),
 [Honest framing](#honest-framing), [Roadmap](#roadmap).
 
@@ -168,6 +169,47 @@ unaffected by both and composes beside either.
 > `usesCleartextTraffic` on Android, so a `Url` of `http://localhost:5000` loads **nothing, silently**. Use
 > `https://`, or add the narrow exception the remote templates use while developing (see
 > [the CLI docs](cli.md)).
+
+### The hardware Back button
+
+A pure-native app has no page, so there is no `window.history` for Back to pop — the session keeps its
+own history instead, and the head routes the button through it:
+
+```csharp
+private void RegisterBackHandler()
+{
+    if (!OperatingSystem.IsAndroidVersionAtLeast(33) || OnBackInvokedDispatcher is not { } dispatcher)
+    {
+        return;
+    }
+
+    _backCallback = new BackInvokedCallback(this);
+    dispatcher.RegisterOnBackInvokedCallback(0, _backCallback);
+}
+
+private void HandleBack()
+{
+    if (_app is { CanGoBack: true } app)
+    {
+        _ = app.GoBackAsync();
+        return;
+    }
+
+    Finish();   // nothing to pop — Back closes the app, as it should at the root of a task
+}
+```
+
+`rask new --template native` writes this for you. Two things about it are easy to get wrong:
+
+- **Use `OnBackInvokedDispatcher`, not the `OnBackPressed` override.** For an app targeting API 35+
+  predictive back is enabled by default and `OnBackPressed` is **never called** — the override compiles,
+  looks correct, and Back silently closes the app mid-navigation. Keep the override only as the API 32
+  and earlier path.
+- **Registering a callback means you own closing the app too.** The system stops doing it for you, so
+  `HandleBack` must call `Finish()` when `CanGoBack` is false, or Back is dead on the first page.
+
+`CanGoBack` is false for an app that has a WebView: the page owns that history, and reading it needs a
+round trip the back handler cannot wait for. A hybrid app therefore keeps the platform's default Back.
 
 ### Wiring it up
 

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.Native.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.Native.cs
@@ -435,41 +435,25 @@ internal static partial class ProjectGenerator
     private const string NativeAppShell =
         """
         using Rask.Core.Routing;
+        using Rask.Native.Components;
 
-        // NativeHeaderBar / NativeWebView are chain entries the generator emits into this markup host
+        // NativeHeaderBar / NativeScreen are chain entries the generator emits into this markup host
         // (hence `partial`) for any project referencing Rask.Native — no import needed here.
 
         namespace Company.RaskServer.Features.Shared;
 
         public sealed partial class App : Component
         {
-            protected override Component? HeadAssets =>
-            [
-                Title["Rask App"],
-                Meta.Charset("utf-8"),
-                Meta.Name("viewport").Content("width=device-width, initial-scale=1, viewport-fit=cover")
-            ];
-
-            // Rask builds the document around Render(); override Shell when its HtmlLang / BodyClass hooks
-            // are not enough. Here the body is padded by the device safe-area insets so content clears the
-            // status bar / notch / home indicator (the boot shell asks for an edge-to-edge viewport with
-            // viewport-fit=cover). head is the framework's <head> — place it, or the page loses every head
-            // asset.
-            protected override Component Shell(Component head, Component body) =>
-                Html.Lang("en")[
-                    head,
-                    Body.Style("margin:0;padding:env(safe-area-inset-top) env(safe-area-inset-right) " +
-                                "env(safe-area-inset-bottom) env(safe-area-inset-left)")[body]
-                ];
-
             protected override Component? Render() =>
             [
-                // Real native top bar. Opt in by hosting webView.ChromeView + registering the head as INativeChrome —
-                // see Platforms/iOS/AppDelegate.cs and Platforms/Android/MainActivity.cs.
+                // A real UINavigationBar / Android top bar. The head registers itself as the INativeChrome
+                // backend — see Platforms/iOS/AppDelegate.cs and Platforms/Android/MainActivity.cs.
                 NativeHeaderBar.Title("Rask App"),
 
-                // The HTML surface — its children are the page content, morphed into the platform WebView.
-                NativeWebView[Router]
+                // The pure-native content surface: everything inside paints as real platform views, with no
+                // WebView and no HTML anywhere. Router works here exactly as it does on the web, so [Route]
+                // pages, route parameters and type-safe navigation are unchanged.
+                NativeScreen[Router]
 
                 // Add a real native bottom tab bar here once you have somewhere to navigate:
                 //   NativeTabBar.Tabs([NativeTab.Title("Home").Icon(NativeIcon.Home).To(Routes.HomePage())])
@@ -477,34 +461,42 @@ internal static partial class ProjectGenerator
             ];
         }
 
+        // Want a web page on one route instead? Compose a NativeWebView on it and the host swaps surfaces as
+        // you navigate, keeping both alive:
+        //
+        //     OnDocs ? NativeWebView[Router] : NativeScreen[Router]
+        //
+        // Putting HTML inside a NativeScreen is a compile error (RASK048), as is putting a native component
+        // inside the HTML tree (RASK032) — the two families do not mix within one surface.
+
         """;
 
     // The welcome screen, its own Features/Home slice — a new native project already models the CLI's
-    // "screens are feature slices" convention.
+    // "screens are feature slices" convention. Pure-native: every element here is a real UILabel /
+    // TextView, not HTML in a WebView.
     private const string NativeHomePage =
         """
         using Rask.Core.Routing;
+        using Rask.Native.Components;
 
         namespace Company.RaskServer.Features.Home;
 
         [Route("/")]
         public sealed partial class HomePage : Component
         {
+            // NativeStack always states its Orientation. Left unset the two platforms disagree — iOS stacks
+            // vertically, Android horizontally — so a screen that looks right on one is a single squashed row
+            // on the other.
             protected override Component? Render() =>
-                Div.Style("padding:1.25rem;font-family:system-ui,-apple-system,sans-serif")[
-                    H1.Style("font-size:1.5rem;margin:0 0 .5rem")["Hello, Rask! 👋"],
-                    P.Style("margin:0 0 1rem;color:#374151")["Your native app is ready. Scaffold the rest with the rask CLI:"],
-                    Ul.Style("margin:0 0 1rem;padding-left:1.1rem;line-height:1.75;color:#374151")[
-                        Li[A.Href("https://github.com/pal-tamas/rask/blob/main/docs/tutorial/00-overview.md")["The tutorial"], " — pages, components and features, step by step"]
-                    ],
-                    P.Style("margin:0;font-size:.9rem;color:#6b7280")[
-                        "Edit this page in ",
-                        Code["HomePage.cs"],
-                        " — drop a ",
-                        Code["HomePage.css"],
-                        " beside it and its rules are scoped to this page. Full guides at ",
-                        A.Href("https://github.com/pal-tamas/rask")["the Rask docs"],
-                        "."
+                NativeScreen[
+                    NativeStack.Orientation(NativeOrientation.Vertical).Spacing(12).Padding(20)[
+                        NativeLabel.FontSize(28).FontWeight(NativeFontWeight.Bold)["Hello, Rask! 👋"],
+                        NativeLabel[
+                            "Your native app is ready. Every control on this screen is a real platform view."],
+                        NativeDivider,
+                        NativeLabel.FontSize(14)[
+                            "Edit this page in HomePage.cs. Add a route with [Route(\"/next\")] and the tab bar "
+                            + "or a NativeButton can navigate to it."]
                     ]
                 ];
         }
@@ -530,8 +522,6 @@ internal static partial class ProjectGenerator
         using Company.RaskServer.Features.Shared;
         using Foundation;
         using Microsoft.Extensions.DependencyInjection;
-        using Rask.Client.Browser;
-        using Rask.Core.Browser;
         using Rask.Native;
         using UIKit;
 
@@ -548,15 +538,13 @@ internal static partial class ProjectGenerator
                 Window = new UIWindow(UIScreen.MainScreen.Bounds);
 
                 var webView = new RaskWkWebView();
-                // Host ChromeView (the container that lays the native header/footer bars around the WebView) rather
-                // than the bare WebView, so the App's composed NativeHeaderBar/NativeTabBar become a real
+                // Host ChromeView (the container that lays the native header/footer bars around the content) rather
+                // than the bare view, so the App's composed NativeHeaderBar/NativeTabBar become a real
                 // UINavigationBar/UITabBar. The INativeChrome backend is registered below; without it the bars render
-                // nothing (the WebView fills the screen), so a native app that navigates via the tab bar should keep it.
+                // nothing, so a native app that navigates via the tab bar should keep that registration.
                 Window.RootViewController = new UIViewController { View = webView.ChromeView };
                 Window.MakeKeyAndVisible();
 
-                // Wire the in-process session BEFORE loading the shell, so the session is ready to receive the
-                // client's `ready` handshake and push the first frame. Native + Local mode.
                 _ = StartAsync(webView);
                 return true;
             }
@@ -564,16 +552,18 @@ internal static partial class ProjectGenerator
             private async Task StartAsync(RaskWkWebView webView)
             {
                 var host = NativeAppHost.CreateDefault();
-                // Native device backends: override Rask.Native's JS-backed defaults with the platform APIs. Register
-                // any native backend on host.Services before RunLocalAsync — the last registration wins. See
-                // docs/native.md "Native device backends".
-                host.Services.AddSingleton<IShare>(_ => new NativeShare(() => Window?.RootViewController));  // share sheet
-                host.Services.AddSingleton<INotifications>(_ => new NativeNotifications());                 // UNUserNotificationCenter
-                host.Services.AddSingleton<IBadge>(_ => new NativeBadge());                                 // app-icon badge
+                // All fifteen native device backends in one line — share, geolocation, clipboard, vibration,
+                // wake lock, network info, battery, speech, screen info, orientation/motion, notifications,
+                // badge and permissions. The framework resolves each native-first over the WebView's JS
+                // default. Call UsePlatform before running the app. See docs/native.md.
+                host.UsePlatform(new ApplePlatform(() => Window?.RootViewController));
                 host.Services.AddSingleton<INativeChrome>(webView);                                         // native header/footer bars
                 // host.Services.AddSingleton<IMyService, MyService>();   // register app services here
-                _app = await host.RunLocalAsync<App>(webView);
-                webView.LoadShell();
+
+                // RunNativeAsync, not RunLocalAsync: the app paints real platform views through the surface
+                // backend, so there is no HTML, no boot shell to load, and no `ready` handshake to wait for —
+                // the host renders the first frame itself and returns with the app already on screen.
+                _app = await host.RunNativeAsync<App>(webView);
             }
 
             public override void WillTerminate(UIApplication application) => _ = _app?.DisposeAsync();
@@ -667,8 +657,6 @@ internal static partial class ProjectGenerator
         using Android.OS;
         using Company.RaskServer.Features.Shared;
         using Microsoft.Extensions.DependencyInjection;
-        using Rask.Client.Browser;
-        using Rask.Core.Browser;
         using Rask.Native;
 
         namespace Company.RaskServer;
@@ -693,30 +681,85 @@ internal static partial class ProjectGenerator
                 }
 
                 _webView = new RaskAndroidWebView(this);
-                // Host ChromeView (the container that lays the native header/footer bars around the WebView) rather
-                // than the bare WebView, so the App's composed NativeHeaderBar/NativeTabBar become real top/bottom bars.
-                // The INativeChrome backend is registered below; without it the bars render nothing (the WebView fills
-                // the screen), so a native app that navigates via the tab bar should keep that registration.
+                // Host ChromeView (the container that lays the native header/footer bars around the content) rather
+                // than the bare view, so the App's composed NativeHeaderBar/NativeTabBar become real top/bottom bars.
+                // The INativeChrome backend is registered below; without it the bars render nothing, so a native app
+                // that navigates via the tab bar should keep that registration.
                 SetContentView(_webView.ChromeView);
 
-                // Wire the in-process session before loading the shell so it's ready for the client's `ready`
-                // handshake. Native + Local mode.
                 _ = StartAsync(_webView);
+                RegisterBackHandler();
             }
 
             private async Task StartAsync(RaskAndroidWebView webView)
             {
                 var host = NativeAppHost.CreateDefault();
-                // Native device backends: override Rask.Native's JS-backed defaults with the platform APIs. Register
-                // any native backend on host.Services before RunLocalAsync — the last registration wins. See
-                // docs/native.md "Native device backends".
-                host.Services.AddSingleton<IShare>(_ => new NativeShare(this));                  // OS share sheet
-                host.Services.AddSingleton<INotifications>(_ => new NativeNotifications(this));   // NotificationManager
-                host.Services.AddSingleton<IBadge>(_ => new NativeBadge(this));                   // app badge notification
+                // All fifteen native device backends in one line — share, geolocation, clipboard, vibration,
+                // wake lock, network info, battery, speech, screen info, orientation/motion, notifications,
+                // badge and permissions. The framework resolves each native-first over the WebView's JS
+                // default. Call UsePlatform before running the app. See docs/native.md.
+                host.UsePlatform(new AndroidPlatform(this));
                 host.Services.AddSingleton<INativeChrome>(webView);                              // native header/footer bars
                 // host.Services.AddSingleton<IMyService, MyService>();   // register app services here
-                _app = await host.RunLocalAsync<App>(webView);
-                webView.LoadShell();
+
+                // RunNativeAsync, not RunLocalAsync: the app paints real platform views through the surface
+                // backend, so there is no HTML, no boot shell to load, and no `ready` handshake to wait for —
+                // the host renders the first frame itself and returns with the app already on screen.
+                _app = await host.RunNativeAsync<App>(webView);
+            }
+
+            // Route the hardware Back button through the app's own history instead of the activity stack, so
+            // Back means "the previous page" the way it does in any other Android app.
+            //
+            // This uses OnBackInvokedDispatcher, NOT the OnBackPressed override. For an app targeting API 35+
+            // predictive back is on by default and OnBackPressed is NEVER CALLED — wiring only that override
+            // compiles, looks right, and silently closes the app mid-navigation. The override is kept below
+            // for API 32 and earlier, where the dispatcher does not exist.
+            private BackInvokedCallback? _backCallback;
+
+            private void RegisterBackHandler()
+            {
+                if (!OperatingSystem.IsAndroidVersionAtLeast(33) || OnBackInvokedDispatcher is not { } dispatcher)
+                {
+                    return;
+                }
+
+                _backCallback = new BackInvokedCallback(this);
+                // PRIORITY_DEFAULT. Registering a callback takes over the gesture entirely, so this handler
+                // owns closing the app too — see HandleBack.
+                dispatcher.RegisterOnBackInvokedCallback(0, _backCallback);
+            }
+
+            // Nothing to go back to means the press should close the app, which is what a user expects at
+            // the root of a task. The system no longer does that for us once a callback is registered, so
+            // Finish() is ours to call — without it Back would be dead on the first page.
+            private void HandleBack()
+            {
+                if (_app is { CanGoBack: true } app)
+                {
+                    _ = app.GoBackAsync();
+                    return;
+                }
+
+                Finish();
+            }
+
+            private sealed class BackInvokedCallback(MainActivity owner)
+                : Java.Lang.Object, Android.Window.IOnBackInvokedCallback
+            {
+                public void OnBackInvoked() => owner.HandleBack();
+            }
+
+            // API 32 and earlier: no dispatcher, and this override is still delivered.
+            public override void OnBackPressed()
+            {
+                if (_app is { CanGoBack: true } app)
+                {
+                    _ = app.GoBackAsync();
+                    return;
+                }
+
+                base.OnBackPressed();
             }
 
             // Forward runtime-permission results so NativeNotifications' RequestPermissionAsync can await the grant.
@@ -728,6 +771,12 @@ internal static partial class ProjectGenerator
 
             protected override void OnDestroy()
             {
+                if (_backCallback is { } cb && OperatingSystem.IsAndroidVersionAtLeast(33))
+                {
+                    OnBackInvokedDispatcher?.UnregisterOnBackInvokedCallback(cb);
+                    _backCallback = null;
+                }
+
                 _ = _app?.DisposeAsync();
                 base.OnDestroy();
             }

--- a/src/Rask.Native/NativeAppHost.cs
+++ b/src/Rask.Native/NativeAppHost.cs
@@ -531,6 +531,29 @@ public sealed class NativeApp : IAsyncDisposable
     /// <summary>The app's service provider — resolve app services or the framework's browser APIs from it.</summary>
     public IServiceProvider Services => _provider;
 
+    /// <summary>
+    ///     Whether <see cref="GoBackAsync" /> has somewhere to go. Answered synchronously, because the caller
+    ///     that needs it — Android's <c>OnBackPressed</c> — has to decide in the moment whether to handle the
+    ///     press or let it close the activity:
+    ///     <code>
+    ///     public override void OnBackPressed()
+    ///     {
+    ///         if (_app is { CanGoBack: true } app) { _ = app.GoBackAsync(); return; }
+    ///         base.OnBackPressed();   // nothing to pop — let Back close the app
+    ///     }
+    ///     </code>
+    ///     False for an app with a WebView: the page owns that history and reading it needs a round trip,
+    ///     which a synchronous answer cannot afford. Such a head keeps the platform's default Back behaviour.
+    /// </summary>
+    public bool CanGoBack => Session.CanGoBack;
+
+    /// <summary>
+    ///     Navigate back one entry, if there is one. The counterpart of the platform's own back affordance,
+    ///     for a head that wants to route the hardware button through the app's history rather than the
+    ///     activity stack. A no-op when <see cref="CanGoBack" /> is false.
+    /// </summary>
+    public ValueTask GoBackAsync() => Session.GoBackAsync();
+
     public async ValueTask DisposeAsync()
     {
         Session.Dispose();

--- a/src/Rask.Native/NativeLiveSession.cs
+++ b/src/Rask.Native/NativeLiveSession.cs
@@ -691,6 +691,35 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
     /// <summary>Whether this session owns its back history — true exactly when there is no WebView.</summary>
     internal bool OwnsBackHistory => _webView is null;
 
+    /// <summary>
+    ///     Whether <see cref="GoBackAsync" /> has somewhere to go — the question a platform head must answer
+    ///     <b>synchronously</b>, because Android's <c>OnBackPressed</c> has to decide right there whether to
+    ///     handle the press or let it close the activity.
+    /// </summary>
+    /// <remarks>
+    ///     False whenever a WebView is present, and that is not a gap. The page's own history is the single
+    ///     source of truth there, and it lives in the page — a session cannot read it without a round trip,
+    ///     which is exactly what a synchronous answer cannot afford. A hybrid head therefore keeps the
+    ///     platform's default Back behaviour, unchanged from before this existed.
+    /// </remarks>
+    internal bool CanGoBack
+    {
+        get
+        {
+            if (!OwnsBackHistory)
+            {
+                return false;
+            }
+
+            lock (_nativeHistory)
+            {
+                // Two entries: the one showing, and the one underneath it to return to. At one, back is a
+                // deliberate no-op so Android's Back closes the app rather than trapping the user at the root.
+                return _nativeHistory.Count >= 2;
+            }
+        }
+    }
+
     /// <summary>This session's back history, current entry last. Empty unless it owns one.</summary>
     internal IReadOnlyList<string> BackHistory
     {
@@ -701,6 +730,37 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
                 return _nativeHistory.ToArray();
             }
         }
+    }
+
+    /// <summary>
+    ///     Take the history entry a handler's <c>Navigator.NavigateTo</c> left behind, and — with no WebView —
+    ///     record it in this session's own history so Back has somewhere to go.
+    /// </summary>
+    /// <remarks>
+    ///     Every navigation must reach <see cref="RecordNativeHistory" />, and before this the ones that
+    ///     arrived as a <c>navigate</c> MESSAGE did while the ones a handler performed did not. With a
+    ///     WebView that difference is invisible: the consumed url is handed to the payload, the client calls
+    ///     pushState, and the page's history — the only one that exists — is correct either way. With no
+    ///     WebView there is no client to do that, so a button calling NavigateTo moved the route and left no
+    ///     trace, and the hardware Back button closed the app from the second page.
+    ///     <para>
+    ///         One helper for all three consume sites rather than three copies, so a fourth dispatch path
+    ///         cannot quietly reintroduce the gap.
+    ///     </para>
+    /// </remarks>
+    private (string? Url, bool Replace) ConsumeHistory(Navigator navigator)
+    {
+        if (!navigator.TryConsumeHistory(out var url, out var replace))
+        {
+            return (null, false);
+        }
+
+        if (url is not null)
+        {
+            RecordNativeHistory(url, replace);
+        }
+
+        return (url, replace);
     }
 
     private void RecordNativeHistory(string fullUrl, bool replace)
@@ -776,13 +836,7 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
                     return Array.Empty<byte>();
                 }
 
-                string? historyUrl = null;
-                var historyReplace = false;
-                if (navigator.TryConsumeHistory(out var url, out var replace))
-                {
-                    historyUrl = url;
-                    historyReplace = replace;
-                }
+                var (historyUrl, historyReplace) = ConsumeHistory(navigator);
 
                 await _renderLock.WaitAsync().ConfigureAwait(false);
                 try
@@ -854,13 +908,7 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
                     return Array.Empty<byte>();
                 }
 
-                string? historyUrl = null;
-                var historyReplace = false;
-                if (navigator.TryConsumeHistory(out var url, out var replace))
-                {
-                    historyUrl = url;
-                    historyReplace = replace;
-                }
+                var (historyUrl, historyReplace) = ConsumeHistory(navigator);
 
                 await _renderLock.WaitAsync().ConfigureAwait(false);
                 try
@@ -1073,13 +1121,7 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
                         return Array.Empty<byte>();
                     }
 
-                    string? historyUrl = null;
-                    var historyReplace = false;
-                    if (navigator.TryConsumeHistory(out var url, out var replace))
-                    {
-                        historyUrl = url;
-                        historyReplace = replace;
-                    }
+                    var (historyUrl, historyReplace) = ConsumeHistory(navigator);
 
                     // Acquire _renderLock only around the render (not the handler above): an in-handler
                     // InvokeWithRenderingAsync renders inline under _renderLock first, so holding it across

--- a/tests/Rask.Native.Tests/Session/PureNativeBootTests.cs
+++ b/tests/Rask.Native.Tests/Session/PureNativeBootTests.cs
@@ -72,6 +72,81 @@ public sealed class PureNativeBootTests : ResettingTestBase
     }
 
     /// <summary>
+    ///     The head cannot reach the session — it is internal — so the same back navigation has to be
+    ///     reachable from <see cref="NativeApp" />, which is what an Android activity actually holds.
+    ///     Without this, "wire the hardware Back button" is not expressible in app code at all.
+    /// </summary>
+    [Fact]
+    public async Task Back_navigation_is_reachable_from_the_app_a_head_holds()
+    {
+        var (app, _) = await NewPureNativeAsync();
+        var routeState = app.Services.GetRequiredService<RouteState>();
+
+        // One entry: nothing to pop, and OnBackPressed must fall through and close the activity.
+        Assert.False(app.CanGoBack);
+
+        await app.Session.DispatchAsync(Message("""{"type":"navigate","path":"/second"}"""));
+        Assert.True(app.CanGoBack);
+
+        await app.GoBackAsync();
+
+        Assert.Equal("/", routeState.Path);
+        Assert.False(app.CanGoBack);
+
+        await app.DisposeAsync();
+    }
+
+    /// <summary>The route the navigating stub sends you to.</summary>
+    internal const string SecondPath = "/second";
+
+    /// <summary>
+    ///     A navigation a HANDLER performs must build back history too, not only one that arrives as a
+    ///     `navigate` message. With a WebView the difference is invisible — the client calls pushState and
+    ///     the page's history is the only one there is — so this gap survived until a pure-native app was
+    ///     driven on a device, where a button calling NavigateTo moved the route, left no trace, and the
+    ///     hardware Back button closed the app from the second page.
+    /// </summary>
+    [Fact]
+    public async Task A_navigation_from_a_handler_records_back_history()
+    {
+        var host = NativeAppHost.CreateDefault();
+        var surface = new FakeNativeSurface();
+        var app = await host.RunNativeAsync<NavigatingStubApp>(surface);
+        var routeState = app.Services.GetRequiredService<RouteState>();
+
+        Assert.False(app.CanGoBack);
+
+        // Exactly what a NativeButton's OnClick does when it calls Navigator.NavigateTo.
+        var tapId = FindTapId(surface.Tree!);
+        await surface.OnSurfaceEvent!(new NativeSurfaceEvent(tapId, NativeSurfaceEventKind.Tap, null));
+
+        Assert.Equal(SecondPath, routeState.Path);
+        Assert.True(app.CanGoBack);
+
+        await app.GoBackAsync();
+
+        Assert.Equal("/", routeState.Path);
+        Assert.False(app.CanGoBack);
+
+        await app.DisposeAsync();
+    }
+
+    /// <summary>
+    ///     A hybrid app answers false, and that is the safe answer rather than a missing feature: the page
+    ///     owns that history and reading it needs a round trip, which <c>OnBackPressed</c> cannot wait for.
+    ///     Such a head keeps the platform's default Back, exactly as before this API existed.
+    /// </summary>
+    [Fact]
+    public async Task An_app_with_a_webview_reports_that_it_cannot_go_back()
+    {
+        var (app, _, _) = await NewSessionAsync();
+
+        Assert.False(app.CanGoBack);
+
+        await app.DisposeAsync();
+    }
+
+    /// <summary>
     ///     At the first entry back does nothing, so on Android the hardware button falls through to the
     ///     activity and closes the app — the platform behaviour at the root of a task. Swallowing it would
     ///     trap the user.
@@ -213,6 +288,18 @@ internal sealed partial class PureNativeStubApp : Component
                 NativeLabel[$"path={_routeState.Path}"],
                 NativeLabel[$"taps={_taps}"],
                 NativeButton.OnClick(() => _taps++)["bump"]
+            ]
+        ];
+}
+
+/// <summary>A pure-native app whose only button navigates, so the tap under test is the navigation.</summary>
+internal sealed partial class NavigatingStubApp(Navigator nav, RouteState routeState) : Component
+{
+    protected override Component? Render() =>
+        NativeScreen[
+            NativeStack[
+                NativeLabel[$"path={routeState.Path}"],
+                NativeButton.OnClick(() => nav.NavigateTo(PureNativeBootTests.SecondPath))["go"]
             ]
         ];
 }


### PR DESCRIPTION
Closes #777 (Phase 2 of the four-models epic, #774). #806 made the *session* able to boot with no
WebView; this is the rest — the scaffold that actually produces such an app, and the Back button it needs.

## The scaffold

The epic renamed `local` to `native` and defined it as **pure-native screens**, but the scaffold still
emitted the WebView-hybrid shape — `NativeWebView[Router]` and a page of plain HTML — so the model the
axis is named after was the one thing `rask new` could not produce.

The App shell is `NativeScreen[Router]` now, the welcome page is `NativeLabel` / `NativeStack` /
`NativeDivider`, and both heads call `RunNativeAsync`. A comment shows how to put a `NativeWebView` on one
route if you want markup somewhere. The scaffolded `NativeStack` always states its `Orientation`, because
leaving it unset renders differently on the two platforms (#791) and a starter template is the worst place
to inherit that.

## Back navigation needed a public API first

`GoBackAsync` lived on `NativeLiveSession`, but `NativeApp.Session` is `internal` — so "wire the hardware
Back button" was not expressible in app code at all. `NativeApp` gains `GoBackAsync()` and `CanGoBack`.

`CanGoBack` is synchronous on purpose: Android's back handler has to decide **in the moment** whether to
handle the press or let it close the activity. It is false for an app with a WebView, where the page owns
the history and reading it needs a round trip the handler cannot wait for — such a head keeps the platform
default, unchanged from before.

## Three bugs the device run found, none of which a gate could have

**A navigation performed by a handler built no back history.** Only navigations arriving as a `navigate`
*message* reached `RecordNativeHistory`; the ones a handler performed through `Navigator.NavigateTo`
consumed their history entry and handed it to the payload instead. With a WebView that difference is
invisible — the client calls `pushState`, and the page's history is the only one that exists — so it
survived until a pure-native app was driven on a device, where a button that navigated left no trace and
Back closed the app from the second page. All three dispatch paths go through one helper now, so a fourth
cannot reintroduce it. The regression test was proved by reverting the fix and watching it fail.

**The obvious Back wiring is dead on modern Android.** For an app targeting API 35+ predictive back is
enabled by default and `OnBackPressed` is **never called** — it compiles, it looks right, and Back
silently closes the app mid-navigation. The scaffold registers an `OnBackInvokedDispatcher` callback on
API 33+ and keeps the override only for API 32 and earlier. Registering a callback also takes over
*closing* the app, so the handler calls `Finish()` itself when there is nothing to pop — without which
Back would be dead on the first page instead.

**The scaffolded iOS head did not compile.** It registered `NativeNotifications` and `NativeBadge`
directly and both are `internal`, so `rask new --template native --platform ios` emitted an `AppDelegate`
with two `CS0122`s in it. Nothing caught it: `NativeTemplateCompileTests` deliberately excludes
`Platforms/**` because it needs the workloads, and `CliBuildE2E` cannot build the native template at all.
Both heads call `host.UsePlatform(…)` now — what the docs and samples already recommended — which is one
line, exposes no internals, and registers all **fifteen** device backends instead of the three the
template hand-registered.

That third one is worth noting beyond this PR: the gap that let it ship is still there. Nothing compiles
`Platforms/**`, which is #782's territory.

## Testing

- `NativeApp.CanGoBack` / `GoBackAsync` pinned, including the hybrid case answering false.
- The handler-navigation regression test, proved by failing it.
- `NativeTemplateCompileTests` compiles the new component code (it has a negative control and an
  empty-sources guard, so the pass is real).
- Format + `-warnaserror` + full unit gate green; pre-push browser E2E green.
- **On an API 36 emulator, against a freshly scaffolded app**: real native views with no WebView showing,
  Back returns from the second page to the first, and Back at the root closes the app. Both heads of the
  emitted scaffold compile for their own TFM.
