### PR TITLE
fix: ignore .claude/worktrees, which an IDE was indexing as 18 more copies of the framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,12 @@ coverage*.info
 
 # Claude Code
 .claude/settings.local.json
+
+# Linked git worktrees created by tooling live INSIDE the repo, so without this an IDE opened on the repo
+# root indexes a complete second copy of the framework per worktree. Every component type then exists
+# N times over, the generator injects its chain entries into each copy, and a bare `Div` stops resolving
+# to an entry — CS0119 on essentially every file, with nothing wrong in the code itself.
+.claude/worktrees/
 .claude/scheduled_tasks.lock
 
 # Other


### PR DESCRIPTION
Reported as **CS0119 on every file** in the IDE, on `main`.

It is not a code break. A clean clone of `main` at 422ba2de builds Debug with **zero CS0119 and zero AD0001**, and the Debug generator assembly is present and current.

The cause is that linked worktrees created by tooling live *inside* the repo, and nothing ignored them:

```
.claude/worktrees/   18 worktrees, 1986 .csproj files, a Rask.slnx apiece
```

An IDE opened on the repo root indexes all of it as project content. Every component type then exists ~19 times, the generator injects its chain entries into each copy, and a bare `Div` can no longer resolve to a single entry — which surfaces as CS0119 essentially everywhere, with nothing wrong in the source.

Nothing under `.claude/worktrees` was ever tracked (`git ls-files` → 0), so this only stops the directory being offered to tools that scan the working tree.

**After merging**, the IDE needs its caches invalidated once to drop what it already indexed — the ignore rule stops it being re-added, it does not evict the existing index.