### PR TITLE
feat(native): reach every native backend from every model, over an envelope that answers (#778)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **Every native backend is reachable from every model** (#778, the four-models epic). `NativeCapabilities`
+  advertised a hardcoded `["share"]` and its dispatcher took a single `IShare`, so fourteen of the fifteen
+  native backends the platform modules register were unreachable from a remote shell — a page running as a
+  *server* app silently got the WebView's JS instead. All fifteen cross the bridge now, in every model.
+
+  **The envelope had no way to answer.** `invoke(component, data)` posted and returned nothing: no
+  correlation id, no reply path. That is why `share` was the only capability that ever worked — it returns
+  nothing. **Twenty-two of the thirty-five members** across the fifteen interfaces return a value, and none
+  of them could cross. The envelope carries an id now and the host answers on
+  `window.__raskNative.capabilityResult`, so an invoke is a promise — the same shape `jsResult` and
+  `dotNetInvoke` already used in the other direction.
+
+  **Every outcome answers.** An unknown capability, a backend the head never registered, and a backend that
+  threw each send a reply carrying the reason. Previously anything but `share` was consumed as a
+  forward-compatible no-op, which left the page's `await` pending for ever — the worst way to report that
+  there is nothing there.
+
+  **The six pushing members work too** — the geolocation and battery watches, the device orientation and
+  motion streams, speech recognition, and the wake lock's held sentinel. They hand back an
+  `IAsyncDisposable`, which a JSON envelope cannot carry, so the handle stays native-side and the page
+  refers to it by id. The **page mints that id** rather than receiving it in the reply: a sensor can deliver
+  a reading before the reply arrives, and an id the page has not seen yet is one it cannot route, so the
+  first readings would vanish — silently, and only on a fast device. Releasing is one path for all six, and
+  the app disposes whatever is still live, because a GPS watch or a wake lock that outlives its app is a
+  battery complaint with no visible cause.
+
+  Readings still reach your C# through the page's own `DotNet.invokeMethodAsync` path, exactly as the web
+  implementation delivers them. The bridge replaces *where a reading comes from*, not how it gets home,
+  which is why nothing in the app half changes and no `IsNative` branch appears anywhere.
+
+- **`window.__raskNative.capabilities` is derived, not declared.** It comes from probing the platform
+  module's own `Register`, so adding a sixteenth backend advertises it with nothing else to edit — the
+  drift G1 describes cannot happen. Asking the live container instead would have advertised everything:
+  the framework registers a JS-backed default for every one of these interfaces and a module uses `TryAdd`,
+  so "is it registered" cannot tell a native backend from the WebView's own JS. A head with no platform
+  module advertises nothing and the page keeps its web APIs.
+
+### Changed
+- **The capability envelope now carries an `op`.** It was `{ component, data }`, which could only ever name
+  one operation per backend; it is `{ id, component, op, data }` now. The old two-field form only ever
+  routed `share`, and both clients ship in this repo, so nothing outside it can have depended on the shape.
+
+- **The remote heads take the app's services, not a lone `IShare`.** `RaskServerViewController` and
+  `RaskServerWebView` had their own private notion of what a capability was, which is why they could only
+  ever forward one. They share the in-process dispatcher and its reply channel now, so the two models
+  cannot drift apart — the same envelope, the same backends, the same answers.
+
+
 ### Changed
 - **`rask new --template native --host native` scaffolds a pure-native app** (#777, the four-models
   epic). The scaffold still emitted the WebView-hybrid shape — `NativeWebView[Router]` and a page of

--- a/docs/native-bridge.md
+++ b/docs/native-bridge.md
@@ -61,6 +61,48 @@ generated head injects `BridgeScript` only for your origin and opens off-origin 
 leaves your origin and no other page can reach native; the bridge is a fixed component envelope, not open
 native RPC. (For a local `http://10.0.2.2:<port>` dev server, allow cleartext in `AndroidManifest.xml`.)
 
+### Every native backend, in every model
+
+The bridge is not a share channel with room for more — all fifteen backends are reachable through it, in
+every model. A page running as a *server* app inside the shell calls `IGeolocation`, `IBadge`, `IClipboard`
+and the rest exactly as it does on the web, and the native implementation answers.
+
+Three things make that work:
+
+- **The head advertises what it actually backs.** `window.__raskNative.capabilities` is derived from what
+  the platform module registered — probing its own `Register` — so adding a sixteenth backend advertises
+  it with nothing else to edit, and a head with no platform module advertises nothing and the page keeps
+  using its own web APIs. There is no `IsNative` branch in app code either way.
+- **An invoke returns a value.** The envelope carries a correlation id and the host answers on
+  `window.__raskNative.capabilityResult`, so `invoke` is a promise. Twenty-two of the thirty-five members
+  across the fifteen interfaces return something; before this leg existed none of them could cross.
+- **Streams work too.** The six pushing members — the geolocation and battery watches, the two sensor
+  streams, speech recognition, and the wake lock's held sentinel — hand back an `IAsyncDisposable` that a
+  JSON envelope cannot carry, so the handle stays native-side and the page refers to it by id.
+
+```js
+// One-shot: a promise, resolved by the native backend.
+const position = await window.__raskNative.invoke("geolocation", "getCurrentPosition", { enableHighAccuracy: true });
+
+// A stream: the page mints the id, so a reading that beats the reply still has somewhere to land.
+const sub = await window.__raskNative.subscribe("battery", "watch", null, reading => { /* … */ });
+await window.__raskNative.unsubscribe("battery", "unwatch", sub);
+```
+
+The readings still reach your C# through the page's own `DotNet.invokeMethodAsync` path, exactly as the
+web implementation delivers them. The bridge changes *where a reading comes from*, not how it gets home —
+which is why nothing in the app half changes.
+
+**Every outcome answers.** An unknown capability, a backend the head never registered, and a backend that
+threw all send a reply carrying the reason. That matters more than it sounds: the page is `await`ing, and
+a silently-consumed envelope leaves it pending for ever — which is what happened to everything except
+`share` before.
+
+> **Security.** Injecting the bridge exposes these backends to any JS on that page, so a head injects it
+> only for its trusted origin and sends off-origin navigations to the system browser. Widening the bridge
+> from one capability to fifteen widens what that grant is worth; it is still a fixed envelope of named
+> operations, not an open native-RPC channel.
+
 ## The `INativeWebView` bridge
 
 `Rask.Native` **ships the platform WebView heads** — `RaskWkWebView` (iOS, `WKWebView`) and

--- a/samples/Rask.Example.Native.Server/Platforms/Android/ServerActivity.cs
+++ b/samples/Rask.Example.Native.Server/Platforms/Android/ServerActivity.cs
@@ -1,7 +1,6 @@
 using Android.App;
 using Android.OS;
 using Microsoft.Extensions.DependencyInjection;
-using Rask.Client.Browser;
 using Rask.Native;
 
 namespace Rask.Example.Native.Server;
@@ -39,9 +38,11 @@ public class ServerActivity : Activity
     private async Task StartAsync(RaskAndroidWebView webView)
     {
         var host = NativeAppHost.CreateDefault();
-        // The remote page reaches the device backends through the capability bridge, so registering them
-        // here is what gives that page a real Android share chooser.
-        host.Services.AddSingleton<IShare>(_ => new NativeShare(this));
+        // UsePlatform, not a hand-picked service or two. The remote page reaches these through the
+        // capability bridge, and the bridge advertises exactly what the platform module registered — so
+        // registering IShare by hand would give the page ONE backend and leave the other fourteen falling
+        // back to the WebView's JS, which is the gap #778 exists to close.
+        host.UsePlatform(new AndroidPlatform(this));
         host.Services.AddSingleton<INativeChrome>(webView);
         host.Services.AddSingleton(new ServerOrigin(ServerUrl));
 

--- a/samples/Rask.Example.Native.Server/Platforms/iOS/ServerAppDelegate.cs
+++ b/samples/Rask.Example.Native.Server/Platforms/iOS/ServerAppDelegate.cs
@@ -1,6 +1,5 @@
 using Foundation;
 using Microsoft.Extensions.DependencyInjection;
-using Rask.Client.Browser;
 using Rask.Native;
 using UIKit;
 
@@ -41,9 +40,11 @@ public class AppDelegate : UIApplicationDelegate
     private async Task StartAsync(RaskWkWebView webView)
     {
         var host = NativeAppHost.CreateDefault();
-        // The remote page reaches the device backends through the capability bridge, so registering them
-        // here is what gives that page a real iOS share sheet.
-        host.Services.AddSingleton<IShare>(_ => new NativeShare(() => Window?.RootViewController));
+        // UsePlatform, not a hand-picked service or two. The remote page reaches these through the
+        // capability bridge, and the bridge advertises exactly what the platform module registered — so
+        // registering IShare by hand would give the page ONE backend and leave the other fourteen falling
+        // back to the WebView's JS, which is the gap #778 exists to close.
+        host.UsePlatform(new ApplePlatform(() => Window?.RootViewController));
         host.Services.AddSingleton<INativeChrome>(webView);
         host.Services.AddSingleton(new ServerOrigin(ServerUrl));
 

--- a/src/Rask.Core/Resources/rask-events.js
+++ b/src/Rask.Core/Resources/rask-events.js
@@ -223,9 +223,14 @@ document.addEventListener("click", function (e) {
     var raw = t.getAttribute("data-rask-share");
     if (!raw) { return; }
     var nativeCaps = window.__raskNative;
-    if (nativeCaps && nativeCaps.capabilities && nativeCaps.capabilities.indexOf &&
-        nativeCaps.capabilities.indexOf("share") !== -1 && typeof nativeCaps.invoke === "function") {
-        nativeCaps.invoke("share", raw);
+    if (nativeCaps && typeof nativeCaps.has === "function" && nativeCaps.has("share") &&
+        typeof nativeCaps.invoke === "function") {
+        var payload;
+        try { payload = JSON.parse(raw); } catch (err) { return; }
+        // invoke returns a promise now; a rejected share (user cancelled, unsupported payload) is not an
+        // error worth surfacing here, but an unhandled rejection would be.
+        var shared = nativeCaps.invoke("share", "share", payload);
+        if (shared && shared["catch"]) { shared["catch"](function () {}); }
         return;
     }
     if (navigator.share) {

--- a/src/Rask.Native/Assets/rask.native.js
+++ b/src/Rask.Native/Assets/rask.native.js
@@ -4068,9 +4068,14 @@ document.addEventListener("click", function (e) {
     var raw = t.getAttribute("data-rask-share");
     if (!raw) { return; }
     var nativeCaps = window.__raskNative;
-    if (nativeCaps && nativeCaps.capabilities && nativeCaps.capabilities.indexOf &&
-        nativeCaps.capabilities.indexOf("share") !== -1 && typeof nativeCaps.invoke === "function") {
-        nativeCaps.invoke("share", raw);
+    if (nativeCaps && typeof nativeCaps.has === "function" && nativeCaps.has("share") &&
+        typeof nativeCaps.invoke === "function") {
+        var payload;
+        try { payload = JSON.parse(raw); } catch (err) { return; }
+        // invoke returns a promise now; a rejected share (user cancelled, unsupported payload) is not an
+        // error worth surfacing here, but an unhandled rejection would be.
+        var shared = nativeCaps.invoke("share", "share", payload);
+        if (shared && shared["catch"]) { shared["catch"](function () {}); }
         return;
     }
     if (navigator.share) {
@@ -4643,12 +4648,85 @@ function endDotNetInvoke(resultJson) {
 
 // The host reaches applyRender/beginInvokeJS/endDotNetInvoke through EvaluateJavaScript. capabilities +
 // invoke() are the native device-capability bridge the shared client uses (e.g. Shareable): invoke() posts
-// a capability message the host routes to the registered service (IShare) — see NativeAppHost. On the Native
-// host, sharing is always available, so it's advertised here; invoke() needs no user activation.
+// a capability message the host routes to the backend the head registered — see NativeAppHost.
+//
+// capabilities is EMPTY here and filled in by the host (NativeCapabilityRegistry), because what this app
+// backs natively is a property of the platform module it was given, not of the client. It used to be a
+// hardcoded ["share"], which is why share was the only capability that ever worked.
+const capabilityPending = new Map();
+const capabilitySubs = new Map();
+let nextCapabilityId = 1;
+
 window.__raskNative = {
     applyRender, beginInvokeJS, endDotNetInvoke,
-    capabilities: ["share"],
-    invoke: function (component, data) { send({ type: "capability", component: component, data: data }); }
+    capabilities: [],
+    has: function (name) { return window.__raskNative.capabilities.indexOf(name) !== -1; },
+
+    // Returns a promise, resolved by capabilityResult below. The same correlation-id shape jsResult and
+    // dotNetInvoke already use in the other direction — without it an invoke could only be fire-and-forget,
+    // and every capability that returns a value was unreachable.
+    invoke: function (component, op, data) {
+        const id = String(nextCapabilityId++);
+        return new Promise((resolve, reject) => {
+            capabilityPending.set(id, { resolve, reject });
+            send({
+                type: "capability", id: id, component: component, op: op,
+                data: data === undefined || data === null ? null : JSON.stringify(data)
+            });
+        });
+    },
+
+// Streams. The subscription id is minted HERE, not returned by the host: a sensor can deliver a reading
+    // before the reply arrives, and an id the page has not seen yet is one it cannot route — the first
+    // readings would vanish, silently and only on a fast device. Registering the callback first removes the
+    // race entirely.
+    subscribe: function (component, op, data, onEvent) {
+        const sub = "s" + String(nextCapabilityId++);
+        capabilitySubs.set(sub, onEvent);
+        const payload = Object.assign({ sub: sub }, data || {});
+        return window.__raskNative.invoke(component, op, payload).then(() => sub, (err) => {
+            capabilitySubs.delete(sub);
+            throw err;
+        });
+    },
+
+    unsubscribe: function (component, op, sub) {
+        capabilitySubs.delete(sub);
+        return window.__raskNative.invoke(component, op, sub);
+    },
+
+    // Host → page: one reading. Handed to the callback the page registered, which forwards it to C#
+    // exactly as the web implementation would — the bridge changes where a reading comes from, not how it
+    // gets home.
+    capabilityEvent: function (json) {
+        let msg;
+        try { msg = JSON.parse(json); } catch (e) { return; }
+        const cb = capabilitySubs.get(msg.sub);
+        if (!cb) return;
+        let value = null;
+        if (msg.payload !== null && msg.payload !== undefined) {
+            try { value = JSON.parse(msg.payload); } catch (e) { value = msg.payload; }
+        }
+        cb(value);
+    },
+
+    // Host → page: settle the promise the invoke above is waiting on.
+    capabilityResult: function (json) {
+        let msg;
+        try { msg = JSON.parse(json); } catch (e) { console.error("[Rask.Native] capabilityResult bad JSON", e); return; }
+        const pending = capabilityPending.get(msg.id);
+        if (!pending) return;
+        capabilityPending.delete(msg.id);
+        if (msg.success) {
+            let value = null;
+            if (msg.result !== null && msg.result !== undefined) {
+                try { value = JSON.parse(msg.result); } catch (e) { value = msg.result; }
+            }
+            pending.resolve(value);
+        } else {
+            pending.reject(new Error(msg.error || "The native capability failed."));
+        }
+    }
 };
 
 // Signal readiness so the host fires its first render only now (see NativeAppHost.RouteMessageAsync).

--- a/src/Rask.Native/INativeWebView.cs
+++ b/src/Rask.Native/INativeWebView.cs
@@ -50,6 +50,14 @@ public interface INativeWebView
     ValueTask LoadUrlAsync(Uri url);
 
     /// <summary>
+    ///     What this head backs natively, set by the host from the platform module before the shell loads.
+    ///     The injected bridge script advertises it, so the page can decide per API whether to cross the
+    ///     bridge or use its own JS — and a head with no platform module advertises nothing and degrades to
+    ///     the WebView's web APIs, with no branch in app code either way.
+    /// </summary>
+    IReadOnlyList<string> Capabilities { get; set; }
+
+    /// <summary>
     ///     Set by the host to receive JS → .NET messages: component events (<c>click</c>/<c>input</c>/
     ///     <c>submit</c>/<c>navigate</c>/…), <c>jsResult</c> replies, and <c>dotNetInvoke</c> calls — each
     ///     a UTF-8 JSON payload. The platform head calls this from its script-message handler.

--- a/src/Rask.Native/NativeAppHost.cs
+++ b/src/Rask.Native/NativeAppHost.cs
@@ -85,6 +85,11 @@ public sealed class NativeAppHost
 
         // IJSRuntime backed by the native WebView bridge. Singleton — one runtime per app instance;
         // NativeLiveSession's ctor binds it to the session + WebView.
+        // Live capability subscriptions (a GPS watch, a held wake lock, the sensor streams). Singleton
+        // because the whole native app is one session, and disposed with the app so nothing it started
+        // outlives it.
+        Services.TryAddSingleton<NativeCapabilitySubscriptions>();
+
         Services.AddSingleton<NativeJSRuntime>();
         Services.AddSingleton<IJSRuntime>(sp => sp.GetRequiredService<NativeJSRuntime>());
     }
@@ -256,6 +261,11 @@ public sealed class NativeAppHost
 
         var session = new NativeLiveSession(root, provider, webView, _diffMode);
         var nativeApp = new NativeApp(session, provider);
+        // Derived from the module, not declared: adding a sixteenth backend advertises it, and a head with
+        // no module advertises nothing rather than promising backends it does not have.
+        nativeApp.Capabilities = _platform is null
+            ? []
+            : NativeCapabilityRegistry.AdvertisedFor(_platform);
 
         // The WebView drives everything through this single message channel: the initial-render handshake
         // (ready), IJSRuntime results (jsResult), JS-initiated [JSInvokable] (dotNetInvoke), and component
@@ -263,7 +273,12 @@ public sealed class NativeAppHost
         // Absent in the pure-native model, where the surface's own event channel below is the only input.
         if (webView is not null)
         {
-            webView.OnMessage = json => RouteMessageAsync(nativeApp, json);
+            webView.OnMessage = json => RouteMessageAsync(
+                nativeApp, json, script => webView.EvaluateJavaScriptAsync(script));
+
+            // Derived from the module, not declared: adding a sixteenth backend advertises it, and a head
+            // with no module advertises nothing rather than promising backends it does not have.
+            webView.Capabilities = nativeApp.Capabilities;
         }
 
         // If a native-chrome backend is registered, route its bar interactions through the SAME dispatcher —
@@ -309,7 +324,15 @@ public sealed class NativeAppHost
         }
     }
 
-    private static async Task RouteMessageAsync(NativeApp app, byte[] json)
+    /// <param name="app">The running app whose session and services the message targets.</param>
+    /// <param name="json">The raw UTF-8 message.</param>
+    /// <param name="evaluate">
+    ///     Evaluates JS in the WebView that sent the message — the capability bridge's reply channel.
+    ///     Null for input that did not come from a WebView (a native bar tap), which cannot carry a
+    ///     capability envelope and so never needs to answer one.
+    /// </param>
+    private static async Task RouteMessageAsync(
+        NativeApp app, byte[] json, Func<string, ValueTask>? evaluate = null)
     {
         if (json is null || json.Length == 0)
         {
@@ -336,6 +359,15 @@ public sealed class NativeAppHost
         switch (type)
         {
             case "ready":
+                // Tell the page what this head backs natively, BEFORE the first frame: a component that
+                // reaches for a device API while rendering must already know whether to cross the bridge.
+                // The in-process client ships with an empty list because what is native is a property of
+                // the platform module the head was given, not of the client.
+                if (evaluate is not null)
+                {
+                    await evaluate(NativeCapabilities.AdvertiseScript(app.Capabilities)).ConfigureAwait(false);
+                }
+
                 // First-render handshake: the client signals it has loaded and is ready to receive frames.
                 await app.Session.InitialRenderAsync().ConfigureAwait(false);
                 return;
@@ -350,9 +382,12 @@ public sealed class NativeAppHost
                 // NativeCapabilities dispatcher with the DI-registered service, so a declarative Shareable
                 // reaches the native backend the head registered — see docs/native.md. (A Native + Server
                 // head uses the same dispatcher with its own IShare.)
-                if (app.Services.GetService<IShare>() is { } capabilityShare)
+                // The reply channel is the WebView this session already drives. Handed in rather than
+                // reached for, so the remote heads — which have a WebView but no session — use the same
+                // dispatcher with their own.
+                if (evaluate is not null)
                 {
-                    await NativeCapabilities.TryHandleAsync(json, capabilityShare).ConfigureAwait(false);
+                    await NativeCapabilities.TryHandleAsync(json, app.Services, evaluate).ConfigureAwait(false);
                 }
 
                 return;
@@ -530,6 +565,12 @@ public sealed class NativeApp : IAsyncDisposable
 
     /// <summary>The app's service provider — resolve app services or the framework's browser APIs from it.</summary>
     public IServiceProvider Services => _provider;
+
+    /// <summary>
+    ///     What this app backs natively, derived from the platform module it was given. Empty when there is
+    ///     none, which is what makes a head with no module degrade to the WebView's own web APIs.
+    /// </summary>
+    internal IReadOnlyList<string> Capabilities { get; set; } = [];
 
     /// <summary>
     ///     Whether <see cref="GoBackAsync" /> has somewhere to go. Answered synchronously, because the caller

--- a/src/Rask.Native/NativeCapabilities.Envelope.cs
+++ b/src/Rask.Native/NativeCapabilities.Envelope.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using Rask.Core.Diagnostics;
+
+namespace Rask.Native;
+
+public static partial class NativeCapabilities
+{
+    /// <summary>
+    ///     Handle a <c>{ type:"capability" }</c> envelope and answer it.
+    /// </summary>
+    /// <param name="messageJson">The raw message the WebView posted.</param>
+    /// <param name="services">The app's services — where the native backends live.</param>
+    /// <param name="evaluate">
+    ///     Evaluates JavaScript in the WebView that sent the message. Passed in rather than taken from an
+    ///     <c>INativeWebView</c> because the remote heads have no session and no such object; they own a
+    ///     <c>WKWebView</c> / <c>android.webkit.WebView</c> directly, and this has to serve both.
+    /// </param>
+    /// <returns>
+    ///     <see langword="true" /> when the message was a capability envelope and is now dealt with;
+    ///     <see langword="false" /> when it is something else and the head should handle it.
+    /// </returns>
+    /// <remarks>
+    ///     Every outcome answers. An unknown capability, a missing backend and a backend that threw all send
+    ///     a reply carrying the reason — because the page is <c>await</c>ing, and the one thing worse than an
+    ///     error is a promise that never settles. That is what the previous fire-and-forget envelope did to
+    ///     anything other than <c>share</c>.
+    /// </remarks>
+    public static async Task<bool> TryHandleAsync(
+        ReadOnlyMemory<byte> messageJson, IServiceProvider services, Func<string, ValueTask> evaluate)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(evaluate);
+
+        NativeCapabilityRequest? request;
+        try
+        {
+            request = JsonSerializer.Deserialize(
+                messageJson.Span, NativeCapabilityJsonContext.Default.NativeCapabilityRequest);
+        }
+        catch (JsonException ex)
+        {
+            RaskDiagnostics.Report(RaskLogLevel.Warning, "Rask.Native",
+                "[Rask.Native] discarded a malformed capability message", ex);
+            return false;
+        }
+
+        if (request is not { Type: "capability" })
+        {
+            return false;
+        }
+
+        var id = request.Id;
+        try
+        {
+            var result = await NativeCapabilityDispatch
+                .InvokeAsync(
+                    services, request.Component ?? string.Empty, request.Op ?? string.Empty, request.Data, evaluate)
+                .ConfigureAwait(false);
+
+            await ReplyAsync(evaluate, id, true, result, null).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Reported as well as replied: the page learns its call failed, and the device log says why —
+            // a native backend throwing on a device is not something a browser console will ever show.
+            RaskDiagnostics.Report(RaskLogLevel.Warning, "Rask.Native",
+                $"[Rask.Native] capability '{request.Component}.{request.Op}' threw", ex);
+            await ReplyAsync(evaluate, id, false, null, ex.Message).ConfigureAwait(false);
+        }
+
+        return true;
+    }
+
+    private static async ValueTask ReplyAsync(
+        Func<string, ValueTask> evaluate, string? id, bool success, string? result, string? error)
+    {
+        // No id means the page did not keep a promise for this call, so there is nothing to resolve.
+        if (string.IsNullOrEmpty(id))
+        {
+            return;
+        }
+
+        var payload = JsonSerializer.Serialize(
+            new NativeCapabilityReply(id, success, result, error),
+            NativeCapabilityJsonContext.Default.NativeCapabilityReply);
+
+        // Same shape as NativeJSRuntime.EndInvokeDotNet: encode the JSON as a string literal and hand it to
+        // the client, so nothing depends on reflection-based serialization at the boundary.
+        await evaluate("window.__raskNative.capabilityResult(\"" + JsonEncodedText.Encode(payload) + "\")")
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Rask.Native/NativeCapabilities.cs
+++ b/src/Rask.Native/NativeCapabilities.cs
@@ -30,7 +30,7 @@ namespace Rask.Native;
 ///     external pages. The bridge is a fixed component envelope (<c>share</c>, …), not an open native-RPC
 ///     channel.
 /// </remarks>
-public static class NativeCapabilities
+public static partial class NativeCapabilities
 {
     /// <summary>
     ///     The document-start script a Native + Server head injects so the loaded page can reach native
@@ -38,59 +38,102 @@ public static class NativeCapabilities
     ///     which posts a <c>{ type:"capability" }</c> message over the same <c>window.__raskSend</c> /
     ///     <c>window.__raskBridge</c> channel the head already wires. Inject for your trusted origin only.
     /// </summary>
-    public static string BridgeScript { get; } =
-        """
-        (function () {
-            function send(s) {
-                if (typeof window.__raskSend === "function") { window.__raskSend(s); }
-                else if (window.__raskBridge && typeof window.__raskBridge.dispatch === "function") { window.__raskBridge.dispatch(s); }
-            }
-            var n = window.__raskNative = window.__raskNative || {};
-            n.capabilities = ["share"];
-            n.invoke = function (component, data) {
-                send(JSON.stringify({ type: "capability", component: component, data: data }));
-            };
-        })();
-        """;
-
     /// <summary>
-    ///     Handle a WebView → .NET message posted by <see cref="BridgeScript" />'s <c>invoke</c>. If it's a
-    ///     <c>{ type:"capability" }</c> envelope it's consumed (share is routed to <paramref name="share" />)
-    ///     and this returns <c>true</c>; a non-capability message returns <c>false</c> so the head can handle
-    ///     it otherwise. An unknown component is consumed as a no-op (forward-compatible), and a malformed
-    ///     payload is discarded without throwing.
+    ///     The document-start script a head injects so the loaded page can reach the native backends this
+    ///     app registered. Defines <c>window.__raskNative.capabilities</c> and an <c>invoke</c> that returns
+    ///     a promise, resolved by <c>capabilityResult</c> when the native side answers.
     /// </summary>
-    public static async Task<bool> TryHandleAsync(ReadOnlyMemory<byte> messageJson, IShare share)
+    /// <param name="capabilities">
+    ///     What this head actually backs natively — see <see cref="NativeCapabilityRegistry.AdvertisedFor" />.
+    ///     The page uses it to decide, per API, whether to cross the bridge or use its own JS, so a head that
+    ///     backs nothing degrades to the WebView's web APIs with no branch in app code.
+    /// </param>
+    /// <summary>
+    ///     A one-liner that tells an already-loaded client what this head backs natively. The in-process
+    ///     client defines <c>window.__raskNative</c> itself and ships with an empty list; this fills it.
+    /// </summary>
+    public static string AdvertiseScript(IEnumerable<string> capabilities)
     {
-        ArgumentNullException.ThrowIfNull(share);
+        ArgumentNullException.ThrowIfNull(capabilities);
 
-        string? component;
-        string? dataJson;
-        try
-        {
-            using var doc = JsonDocument.Parse(messageJson);
-            var root = doc.RootElement;
-            if (Str(root, "type") != "capability")
-            {
-                return false;
-            }
+        var list = string.Join(",", capabilities.Select(c => "\"" + JsonEncodedText.Encode(c) + "\""));
+        return "window.__raskNative.capabilities = [" + list + "];";
+    }
 
-            component = Str(root, "component");
-            dataJson = Str(root, "data");
-        }
-        catch (JsonException ex)
-        {
-            RaskDiagnostics.Report(RaskLogLevel.Warning, "Rask.Native",
-                "[Rask.Native] discarded a malformed capability message", ex);
-            return false;
-        }
+    public static string BridgeScript(IEnumerable<string> capabilities)
+    {
+        ArgumentNullException.ThrowIfNull(capabilities);
 
-        if (component == "share" && !string.IsNullOrEmpty(dataJson))
-        {
-            await DispatchShareAsync(dataJson, share).ConfigureAwait(false);
-        }
+        var list = string.Join(",", capabilities.Select(c => "\"" + JsonEncodedText.Encode(c) + "\""));
 
-        return true;
+        return """
+            (function () {
+                function send(s) {
+                    if (typeof window.__raskSend === "function") { window.__raskSend(s); }
+                    else if (window.__raskBridge && typeof window.__raskBridge.dispatch === "function") { window.__raskBridge.dispatch(s); }
+                }
+                var n = window.__raskNative = window.__raskNative || {};
+                n.capabilities = [__CAPS__];
+                n.has = function (name) { return n.capabilities.indexOf(name) !== -1; };
+
+                // Correlation ids and a promise table, the same shape jsResult/dotNetInvoke already use in
+                // the other direction. Without this an invoke could only be fire-and-forget, which is why
+                // share was the only capability that ever worked.
+                var pending = {}, subs = {}, nextId = 1;
+                n.invoke = function (component, op, data) {
+                    var id = String(nextId++);
+                    return new Promise(function (resolve, reject) {
+                        pending[id] = { resolve: resolve, reject: reject };
+                        send(JSON.stringify({
+                            type: "capability", id: id, component: component, op: op,
+                            data: data === undefined || data === null ? null : JSON.stringify(data)
+                        }));
+                    });
+                };
+                // Streams. The id is minted here, before the request is sent, so a reading that arrives
+                // ahead of the reply still has a callback to reach.
+                n.subscribe = function (component, op, data, onEvent) {
+                    var sub = "s" + String(nextId++);
+                    subs[sub] = onEvent;
+                    var payload = Object.assign({ sub: sub }, data || {});
+                    return n.invoke(component, op, payload).then(function () { return sub; }, function (err) {
+                        delete subs[sub];
+                        throw err;
+                    });
+                };
+                n.unsubscribe = function (component, op, sub) {
+                    delete subs[sub];
+                    return n.invoke(component, op, sub);
+                };
+                n.capabilityEvent = function (json) {
+                    var msg;
+                    try { msg = JSON.parse(json); } catch (e) { return; }
+                    var cb = subs[msg.sub];
+                    if (!cb) { return; }
+                    var value = null;
+                    if (msg.payload !== null && msg.payload !== undefined) {
+                        try { value = JSON.parse(msg.payload); } catch (e) { value = msg.payload; }
+                    }
+                    cb(value);
+                };
+                n.capabilityResult = function (json) {
+                    var msg;
+                    try { msg = JSON.parse(json); } catch (e) { return; }
+                    var p = pending[msg.id];
+                    if (!p) { return; }
+                    delete pending[msg.id];
+                    if (msg.success) {
+                        var value = null;
+                        if (msg.result !== null && msg.result !== undefined) {
+                            try { value = JSON.parse(msg.result); } catch (e) { value = msg.result; }
+                        }
+                        p.resolve(value);
+                    } else {
+                        p.reject(new Error(msg.error || "The native capability failed."));
+                    }
+                };
+            })();
+            """.Replace("__CAPS__", list, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -108,36 +151,6 @@ public static class NativeCapabilities
             && string.Equals(u.Scheme, origin.Scheme, StringComparison.OrdinalIgnoreCase)
             && string.Equals(u.Host, origin.Host, StringComparison.OrdinalIgnoreCase)
             && u.Port == origin.Port;
-    }
-
-    private static async Task DispatchShareAsync(string dataJson, IShare share)
-    {
-        ShareData? data;
-        try
-        {
-            data = JsonSerializer.Deserialize(dataJson, RaskBrowserJsonContext.Default.ShareData);
-        }
-        catch (JsonException ex)
-        {
-            RaskDiagnostics.Report(RaskLogLevel.Warning, "Rask.Native",
-                "[Rask.Native] discarded a malformed share capability payload", ex);
-            return;
-        }
-
-        if (data is null)
-        {
-            return;
-        }
-
-        try
-        {
-            await share.ShareAsync(data).ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            RaskDiagnostics.Report(RaskLogLevel.Warning, "Rask.Native",
-                "[Rask.Native] share capability invoke threw", ex);
-        }
     }
 
     private static string? Str(JsonElement root, string name) =>

--- a/src/Rask.Native/NativeCapabilityDispatch.Streams.cs
+++ b/src/Rask.Native/NativeCapabilityDispatch.Streams.cs
@@ -1,0 +1,144 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+internal static partial class NativeCapabilityDispatch
+{
+    /// <summary>
+    ///     The six members that push instead of returning: the geolocation and battery watches, the two
+    ///     sensor streams, speech recognition, and the wake lock's held sentinel.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         All six have the same shape — start, hold a handle, push until released — so they share one
+    ///         path rather than six. The handle stays native-side; the page refers to it by id.
+    ///     </para>
+    ///     <para>
+    ///         <b>The page mints that id</b>, rather than receiving it in the reply. A sensor can deliver a
+    ///         reading before the reply reaches the page, and an id the page has not seen yet is one it
+    ///         cannot route — the first readings would be dropped, silently and only on a fast device.
+    ///         Minting it caller-side means the callback is registered before the request is even sent.
+    ///     </para>
+    ///     <para>
+    ///         What does not change: readings still reach the app's C# through the page's own
+    ///         <c>DotNet.invokeMethodAsync</c> path, exactly as the web implementation delivers them. The
+    ///         bridge replaces where a reading comes from, not how it gets home.
+    ///     </para>
+    /// </remarks>
+    private static async ValueTask<string?> StreamAsync(
+        IServiceProvider services, string component, string op, string? dataJson, Func<string, ValueTask> evaluate)
+    {
+        var subscriptions = services.GetService<NativeCapabilitySubscriptions>()
+            ?? throw new NotSupportedException(
+                "This head cannot hold capability subscriptions — none is registered on it.");
+
+        // Every stream ends the same way, so one release path serves all of them.
+        if (op is "unwatch" or "stop" or "release")
+        {
+            await subscriptions.ReleaseAsync(Text(dataJson)).ConfigureAwait(false);
+            return null;
+        }
+
+        IAsyncDisposable handle;
+        string sub;
+
+        switch (component)
+        {
+            case "geolocation" when op == "watch":
+            {
+                var request = Parse(dataJson, NativeCapabilityJsonContext.Default.GeolocationWatchRequest)
+                    ?? throw Bad("geolocation.watch", "a subscription id");
+                sub = request.Sub;
+                handle = await Required<IGeolocation>(services, "geolocation")
+                    .WatchAsync(Push(sub, evaluate, NativeCapabilityJsonContext.Default.GeolocationPosition),
+                        request.Options).ConfigureAwait(false);
+                break;
+            }
+
+            case "speechRecognition" when op == "start":
+            {
+                var request = Parse(dataJson, NativeCapabilityJsonContext.Default.SpeechStartRequest)
+                    ?? throw Bad("speechRecognition.start", "a subscription id");
+                sub = request.Sub;
+                handle = await Required<ISpeechRecognition>(services, "speechRecognition")
+                    .StartAsync(Push(sub, evaluate, NativeCapabilityJsonContext.Default.RecognitionResult),
+                        request.Options).ConfigureAwait(false);
+                break;
+            }
+
+            case "battery" when op == "watch":
+            {
+                sub = SubIdOf(dataJson, "battery.watch");
+                handle = await Required<IBattery>(services, "battery")
+                    .WatchAsync(Push(sub, evaluate, NativeCapabilityJsonContext.Default.BatteryStatus))
+                    .ConfigureAwait(false);
+                break;
+            }
+
+            case "deviceOrientation" when op == "watch":
+            {
+                sub = SubIdOf(dataJson, "deviceOrientation.watch");
+                handle = await Required<IDeviceOrientation>(services, "deviceOrientation")
+                    .WatchAsync(Push(sub, evaluate, NativeCapabilityJsonContext.Default.OrientationReading))
+                    .ConfigureAwait(false);
+                break;
+            }
+
+            case "deviceMotion" when op == "watch":
+            {
+                sub = SubIdOf(dataJson, "deviceMotion.watch");
+                handle = await Required<IDeviceMotion>(services, "deviceMotion")
+                    .WatchAsync(Push(sub, evaluate, NativeCapabilityJsonContext.Default.MotionReading))
+                    .ConfigureAwait(false);
+                break;
+            }
+
+            case "wakeLock" when op == "request":
+            {
+                // A sentinel IS its handle — releasing it is DisposeAsync, the same contract a watch has, so
+                // it rides the same path rather than needing one of its own.
+                sub = SubIdOf(dataJson, "wakeLock.request");
+                handle = await Required<IWakeLock>(services, "wakeLock").RequestAsync().ConfigureAwait(false);
+                break;
+            }
+
+            default:
+                throw Unknown(component, op);
+        }
+
+        subscriptions.Add(sub, handle);
+        return null;
+    }
+
+    /// <summary>Which ops push rather than return, so the main switch can route them here.</summary>
+    private static bool IsStreamOp(string component, string op) =>
+        op is "unwatch" or "stop" or "release"
+        || (component, op) is ("geolocation", "watch")
+            or ("battery", "watch")
+            or ("deviceOrientation", "watch")
+            or ("deviceMotion", "watch")
+            or ("speechRecognition", "start")
+            or ("wakeLock", "request");
+
+    private static string SubIdOf(string? dataJson, string what) =>
+        (Parse(dataJson, NativeCapabilityJsonContext.Default.WatchRequest)
+         ?? throw Bad(what, "a subscription id")).Sub;
+
+    // One reading → one capabilityEvent. Serialized through the AOT context and encoded as a JS string
+    // literal, for the same reason every other push at this boundary is: nothing here may need reflection.
+    private static Func<T, Task> Push<T>(
+        string sub,
+        Func<string, ValueTask> evaluate,
+        System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> type) =>
+        async reading =>
+        {
+            var payload = JsonSerializer.Serialize(
+                new NativeCapabilityEvent(sub, JsonSerializer.Serialize(reading, type)),
+                NativeCapabilityJsonContext.Default.NativeCapabilityEvent);
+
+            await evaluate("window.__raskNative.capabilityEvent(\"" + JsonEncodedText.Encode(payload) + "\")")
+                .ConfigureAwait(false);
+        };
+}

--- a/src/Rask.Native/NativeCapabilityDispatch.cs
+++ b/src/Rask.Native/NativeCapabilityDispatch.cs
@@ -1,0 +1,322 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Client.Browser;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+/// <summary>
+///     Routes one capability invoke to the native backend the head registered — the switch behind
+///     <see cref="NativeCapabilities.TryHandleAsync" />.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>The wire shape is the JS helper's, not the C# method's.</b> A page reaches these APIs through
+///         its own <c>IJSRuntime</c> wrappers (<c>__raskApi.geolocation</c>, <c>__raskBadge.set</c>, …), and
+///         those already have a result shape its C# side knows how to read. The bridge substitutes *where the
+///         work happens*, not what comes back, so every op here returns exactly what its JS counterpart in
+///         <c>rask-api.js</c> / <c>rask-pwa.js</c> would have — which is why the app half needs no change and
+///         no <c>IsNative</c> branch.
+///     </para>
+///     <para>
+///         A hand-written switch rather than reflection: the iOS head is full-AOT, where a reflective
+///         dispatch is exactly the thing the trimmer removes and only fails on a device. It mirrors how
+///         <c>NativeChromeJsonContext</c> stays AOT-safe for the same reason.
+///     </para>
+/// </remarks>
+internal static partial class NativeCapabilityDispatch
+{
+    /// <summary>
+    ///     Run one <c>component.op</c> against the registered backend.
+    /// </summary>
+    /// <returns>
+    ///     The result as JSON, or <see langword="null" /> for an op that returns nothing. A component or op
+    ///     this build does not know throws, so the page's promise rejects with a message naming it rather
+    ///     than hanging for ever — the failure mode a silently-consumed envelope used to have.
+    /// </returns>
+    public static async ValueTask<string?> InvokeAsync(
+        IServiceProvider services, string component, string op, string? dataJson, Func<string, ValueTask> evaluate)
+    {
+        // The pushing members go somewhere else entirely — they hold a handle and deliver readings over
+        // time, which the request/response switch below has no shape for.
+        if (IsStreamOp(component, op))
+        {
+            return await StreamAsync(services, component, op, dataJson, evaluate).ConfigureAwait(false);
+        }
+
+        switch (component)
+        {
+            case "share":
+                return await ShareAsync(services, op, dataJson).ConfigureAwait(false);
+            case "geolocation":
+                return await GeolocationAsync(services, op, dataJson).ConfigureAwait(false);
+            case "clipboard":
+                return await ClipboardAsync(services, op, dataJson).ConfigureAwait(false);
+            case "vibration":
+                return await VibrationAsync(services, op, dataJson).ConfigureAwait(false);
+            case "networkInfo":
+                return await NetworkAsync(services, op).ConfigureAwait(false);
+            case "battery":
+                return await BatteryAsync(services, op).ConfigureAwait(false);
+            case "screenInfo":
+                return await ScreenAsync(services, op).ConfigureAwait(false);
+            case "speechSynthesis":
+                return await SpeechAsync(services, op, dataJson).ConfigureAwait(false);
+            case "notifications":
+                return await NotificationsAsync(services, op, dataJson).ConfigureAwait(false);
+            case "badge":
+                return await BadgeAsync(services, op, dataJson).ConfigureAwait(false);
+            case "permissions":
+                return await PermissionsAsync(services, op, dataJson).ConfigureAwait(false);
+            default:
+                throw new NotSupportedException(
+                    $"No native backend is bridged for capability '{component}'.");
+        }
+    }
+
+    private static async ValueTask<string?> ShareAsync(IServiceProvider services, string op, string? dataJson)
+    {
+        var share = Required<IShare>(services, "share");
+        switch (op)
+        {
+            case "share":
+                await share.ShareAsync(Parse(dataJson, NativeCapabilityJsonContext.Default.ShareData)
+                    ?? throw Bad("share", "a ShareData payload")).ConfigureAwait(false);
+                return null;
+            case "canShare":
+                return Bool(await share.CanShareAsync(
+                    Parse(dataJson, NativeCapabilityJsonContext.Default.ShareData)).ConfigureAwait(false));
+            default:
+                throw Unknown("share", op);
+        }
+    }
+
+    private static async ValueTask<string?> GeolocationAsync(
+        IServiceProvider services, string op, string? dataJson)
+    {
+        var geolocation = Required<IGeolocation>(services, "geolocation");
+        if (!string.Equals(op, "getCurrentPosition", StringComparison.Ordinal))
+        {
+            throw Unknown("geolocation", op);
+        }
+
+        // The JS helper takes three loose arguments; the envelope carries the options record the C# side
+        // already has, so nothing has to agree on argument order.
+        var options = Parse(dataJson, NativeCapabilityJsonContext.Default.GeolocationOptions);
+        var position = await geolocation.GetCurrentPositionAsync(options).ConfigureAwait(false);
+        return JsonSerializer.Serialize(position, NativeCapabilityJsonContext.Default.GeolocationPosition);
+    }
+
+    private static async ValueTask<string?> ClipboardAsync(
+        IServiceProvider services, string op, string? dataJson)
+    {
+        var clipboard = Required<IClipboard>(services, "clipboard");
+        switch (op)
+        {
+            case "writeText":
+                await clipboard.WriteTextAsync(Text(dataJson) ?? string.Empty).ConfigureAwait(false);
+                return null;
+            case "readText":
+                return JsonSerializer.Serialize(
+                    await clipboard.ReadTextAsync().ConfigureAwait(false),
+                    NativeCapabilityJsonContext.Default.String);
+            default:
+                throw Unknown("clipboard", op);
+        }
+    }
+
+    private static async ValueTask<string?> VibrationAsync(
+        IServiceProvider services, string op, string? dataJson)
+    {
+        var vibration = Required<IVibration>(services, "vibration");
+        switch (op)
+        {
+            case "vibrate":
+                var pattern = Parse(dataJson, NativeCapabilityJsonContext.Default.Int32Array) ?? [];
+                return Bool(await vibration.VibrateAsync(pattern).ConfigureAwait(false));
+            case "cancel":
+                return Bool(await vibration.CancelAsync().ConfigureAwait(false));
+            default:
+                throw Unknown("vibration", op);
+        }
+    }
+
+    private static async ValueTask<string?> NetworkAsync(IServiceProvider services, string op)
+    {
+        var network = Required<INetworkInfo>(services, "networkInfo");
+        switch (op)
+        {
+            case "isSupported":
+                return Bool(await network.IsSupportedAsync().ConfigureAwait(false));
+            case "getStatus":
+                var status = await network.GetStatusAsync().ConfigureAwait(false);
+                return status is null
+                    ? "null"
+                    : JsonSerializer.Serialize(status, NativeCapabilityJsonContext.Default.NetworkStatus);
+            default:
+                throw Unknown("networkInfo", op);
+        }
+    }
+
+    private static async ValueTask<string?> BatteryAsync(IServiceProvider services, string op)
+    {
+        var battery = Required<IBattery>(services, "battery");
+        switch (op)
+        {
+            case "isSupported":
+                return Bool(await battery.IsSupportedAsync().ConfigureAwait(false));
+            case "getStatus":
+                var status = await battery.GetStatusAsync().ConfigureAwait(false);
+                return status is null
+                    ? "null"
+                    : JsonSerializer.Serialize(status, NativeCapabilityJsonContext.Default.BatteryStatus);
+            default:
+                throw Unknown("battery", op);
+        }
+    }
+
+    private static async ValueTask<string?> ScreenAsync(IServiceProvider services, string op)
+    {
+        var screen = Required<IScreenInfo>(services, "screenInfo");
+        if (!string.Equals(op, "get", StringComparison.Ordinal))
+        {
+            throw Unknown("screenInfo", op);
+        }
+
+        return JsonSerializer.Serialize(
+            await screen.GetAsync().ConfigureAwait(false), NativeCapabilityJsonContext.Default.ScreenInfo);
+    }
+
+    private static async ValueTask<string?> SpeechAsync(
+        IServiceProvider services, string op, string? dataJson)
+    {
+        var speech = Required<ISpeechSynthesis>(services, "speechSynthesis");
+        switch (op)
+        {
+            case "isSupported":
+                return Bool(await speech.IsSupportedAsync().ConfigureAwait(false));
+            case "speak":
+                var request = Parse(dataJson, NativeCapabilityJsonContext.Default.SpeakRequest)
+                    ?? throw Bad("speechSynthesis.speak", "text to speak");
+                await speech.SpeakAsync(request.Text, request.Options).ConfigureAwait(false);
+                return null;
+            case "cancel":
+                await speech.CancelAsync().ConfigureAwait(false);
+                return null;
+            default:
+                throw Unknown("speechSynthesis", op);
+        }
+    }
+
+    private static async ValueTask<string?> NotificationsAsync(
+        IServiceProvider services, string op, string? dataJson)
+    {
+        var notifications = Required<INotifications>(services, "notifications");
+        switch (op)
+        {
+            case "isSupported":
+                return Bool(await notifications.IsSupportedAsync().ConfigureAwait(false));
+            case "permission":
+                return Enum(await notifications.PermissionAsync().ConfigureAwait(false));
+            case "requestPermission":
+                return Enum(await notifications.RequestPermissionAsync().ConfigureAwait(false));
+            case "show":
+                var request = Parse(dataJson, NativeCapabilityJsonContext.Default.ShowNotificationRequest)
+                    ?? throw Bad("notifications.show", "a title");
+                await notifications.ShowAsync(request.Title, request.Options).ConfigureAwait(false);
+                return null;
+            default:
+                throw Unknown("notifications", op);
+        }
+    }
+
+    private static async ValueTask<string?> BadgeAsync(IServiceProvider services, string op, string? dataJson)
+    {
+        var badge = Required<IBadge>(services, "badge");
+        switch (op)
+        {
+            case "isSupported":
+                return Bool(await badge.IsSupportedAsync().ConfigureAwait(false));
+            case "set":
+                // null and 0 both mean "a dot, no number" — preserved rather than coerced, because the two
+                // are different on the platforms that draw a count.
+                await badge.SetAsync(Parse(dataJson, NativeCapabilityJsonContext.Default.NullableInt32))
+                    .ConfigureAwait(false);
+                return null;
+            case "clear":
+                await badge.ClearAsync().ConfigureAwait(false);
+                return null;
+            default:
+                throw Unknown("badge", op);
+        }
+    }
+
+    private static async ValueTask<string?> PermissionsAsync(
+        IServiceProvider services, string op, string? dataJson)
+    {
+        var permissions = Required<IPermissions>(services, "permissions");
+        if (!string.Equals(op, "query", StringComparison.Ordinal))
+        {
+            throw Unknown("permissions", op);
+        }
+
+        // The page sends the same lowercase name the Permissions API uses ("camera", "geolocation"), so the
+        // envelope speaks the web's vocabulary rather than the enum's spelling.
+        var raw = Text(dataJson) ?? string.Empty;
+        if (!System.Enum.TryParse<PermissionName>(raw, ignoreCase: true, out var name))
+        {
+            throw new NotSupportedException($"'{raw}' is not a permission this build knows.");
+        }
+
+        return Enum(await permissions.QueryAsync(name).ConfigureAwait(false));
+    }
+
+    private static T Required<T>(IServiceProvider services, string component)
+        where T : class =>
+        services.GetService<T>()
+        ?? throw new NotSupportedException(
+            $"Capability '{component}' was invoked, but no {typeof(T).Name} is registered on this head.");
+
+    // Enums cross as the lowercase string the web API uses ("granted"), which is what the page's own
+    // wrapper already parses — the JS helper returns PermissionStatus.state, not a number.
+    private static string Enum<T>(T value)
+        where T : struct, Enum =>
+        JsonSerializer.Serialize(
+            value.ToString().ToLowerInvariant(), NativeCapabilityJsonContext.Default.String);
+
+    private static string Bool(bool value) => value ? "true" : "false";
+
+    private static string? Text(string? dataJson)
+    {
+        if (string.IsNullOrEmpty(dataJson))
+        {
+            return null;
+        }
+
+        // The page may send a bare string or a JSON string literal; accept both rather than making the
+        // caller guess.
+        return dataJson[0] == '"'
+            ? JsonSerializer.Deserialize(dataJson, NativeCapabilityJsonContext.Default.String)
+            : dataJson;
+    }
+
+    private static T? Parse<T>(string? dataJson, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> type)
+        where T : class =>
+        string.IsNullOrEmpty(dataJson) ? null : JsonSerializer.Deserialize(dataJson, type);
+
+    private static T? Parse<T>(string? dataJson, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T?> type)
+        where T : struct =>
+        string.IsNullOrEmpty(dataJson) ? null : JsonSerializer.Deserialize(dataJson, type);
+
+    private static NotSupportedException Unknown(string component, string op) =>
+        new($"'{component}' has no operation '{op}' in this build.");
+
+    private static ArgumentException Bad(string what, string expected) =>
+        new($"The '{what}' capability invoke carried no {expected}.");
+}
+
+/// <summary>The two arguments <c>speechSynthesis.speak</c> carries, so the envelope needs no argument order.</summary>
+internal sealed record SpeakRequest(string Text, SpeechOptions? Options);
+
+/// <summary>The two arguments <c>notifications.show</c> carries.</summary>
+internal sealed record ShowNotificationRequest(string Title, NotificationOptions? Options);

--- a/src/Rask.Native/NativeCapabilityJsonContext.cs
+++ b/src/Rask.Native/NativeCapabilityJsonContext.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+/// <summary>
+///     Source-generated JSON metadata for everything the capability bridge puts on the wire.
+/// </summary>
+/// <remarks>
+///     Its own context rather than an addition to <c>RaskBrowserJsonContext</c>, for the same reason
+///     <c>NativeChromeJsonContext</c> is its own: the iOS head is full-AOT, and a context that lives beside
+///     the code serializing through it is one that cannot be trimmed away from under it. Web defaults so the
+///     payloads match the shapes the page's JS wrappers already produce and read.
+/// </remarks>
+[JsonSourceGenerationOptions(JsonSerializerDefaults.Web)]
+[JsonSerializable(typeof(NativeCapabilityRequest))]
+[JsonSerializable(typeof(NativeCapabilityReply))]
+[JsonSerializable(typeof(SpeakRequest))]
+[JsonSerializable(typeof(ShowNotificationRequest))]
+[JsonSerializable(typeof(ShareData))]
+[JsonSerializable(typeof(GeolocationOptions))]
+[JsonSerializable(typeof(GeolocationPosition))]
+[JsonSerializable(typeof(NetworkStatus))]
+[JsonSerializable(typeof(BatteryStatus))]
+[JsonSerializable(typeof(ScreenInfo))]
+[JsonSerializable(typeof(SpeechOptions))]
+[JsonSerializable(typeof(NotificationOptions))]
+[JsonSerializable(typeof(NativeCapabilityEvent))]
+[JsonSerializable(typeof(WatchRequest))]
+[JsonSerializable(typeof(GeolocationWatchRequest))]
+[JsonSerializable(typeof(SpeechStartRequest))]
+[JsonSerializable(typeof(SpeechRecognitionOptions))]
+[JsonSerializable(typeof(RecognitionResult))]
+[JsonSerializable(typeof(OrientationReading))]
+[JsonSerializable(typeof(MotionReading))]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(int[]))]
+[JsonSerializable(typeof(int?))]
+internal sealed partial class NativeCapabilityJsonContext : JsonSerializerContext;
+
+/// <summary>
+///     One capability invoke from the page. <see cref="Id" /> is the page's correlation id — the bridge
+///     echoes it back so a reply reaches the promise that is waiting for it, exactly as
+///     <c>jsResult</c> / <c>dotNetInvoke</c> already do in the other direction.
+/// </summary>
+/// <param name="Type">Always <c>capability</c>; the head routes on it.</param>
+/// <param name="Id">The page's correlation id, or null for a call whose result nobody awaits.</param>
+/// <param name="Component">The capability name, e.g. <c>geolocation</c>.</param>
+/// <param name="Op">The operation on it, e.g. <c>getCurrentPosition</c>.</param>
+/// <param name="Data">The argument payload as JSON, or null.</param>
+internal sealed record NativeCapabilityRequest(
+    string? Type, string? Id, string? Component, string? Op, string? Data);
+
+/// <summary>
+///     The answer to a <see cref="NativeCapabilityRequest" />, delivered to
+///     <c>window.__raskNative.capabilityResult</c>.
+/// </summary>
+/// <param name="Id">The correlation id being answered.</param>
+/// <param name="Success">Whether the op ran. False carries <paramref name="Error" /> instead of a result.</param>
+/// <param name="Result">The op's result as JSON, or null for an op that returns nothing.</param>
+/// <param name="Error">
+///     Why it failed. A message rather than silence on purpose: an unknown capability used to be consumed as
+///     a no-op, which left the page's await pending for ever — the worst way to report "there is nothing
+///     here".
+/// </param>
+internal sealed record NativeCapabilityReply(string Id, bool Success, string? Result, string? Error);
+
+/// <summary>
+///     One reading from a live subscription, delivered to <c>window.__raskNative.capabilityEvent</c>.
+/// </summary>
+/// <param name="Sub">The subscription id the page chose when it started the stream.</param>
+/// <param name="Payload">The reading as JSON, in the shape the page's own JS wrapper would have produced.</param>
+internal sealed record NativeCapabilityEvent(string Sub, string? Payload);
+
+/// <summary>Starting a stream that takes no options.</summary>
+/// <param name="Sub">The id the page will use to route readings and later release the handle.</param>
+internal sealed record WatchRequest(string Sub);
+
+/// <summary>Starting a geolocation watch.</summary>
+internal sealed record GeolocationWatchRequest(string Sub, GeolocationOptions? Options);
+
+/// <summary>Starting speech recognition.</summary>
+internal sealed record SpeechStartRequest(string Sub, SpeechRecognitionOptions? Options);

--- a/src/Rask.Native/NativeCapabilityRegistry.cs
+++ b/src/Rask.Native/NativeCapabilityRegistry.cs
@@ -1,0 +1,85 @@
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Rask.Native;
+
+/// <summary>
+///     What a native head advertises to the page as reachable over the capability bridge.
+/// </summary>
+/// <remarks>
+///     The list is <b>derived</b> from what the platform module registers, not declared beside it. That
+///     matters more than it looks:
+///     <list type="bullet">
+///         <item>
+///             Asking the live container instead would advertise everything. The framework registers a
+///             JS-backed default for every one of these interfaces, and a platform module uses
+///             <c>TryAdd</c>, so <em>something</em> always resolves — "is it registered" cannot tell
+///             "native backend" from "the WebView's own JS", which is the only distinction the page cares
+///             about.
+///         </item>
+///         <item>
+///             A hand-written list beside <c>Register</c> would answer that, and would drift the first
+///             time someone added a sixteenth backend and forgot the other half. Probing the module's own
+///             <c>Register</c> cannot drift: adding a backend advertises it, and removing one stops
+///             advertising it, with nothing to keep in step.
+///         </item>
+///     </list>
+///     Probing is cheap and side-effect-free — <c>Register</c> adds descriptors, and a descriptor's factory
+///     is not invoked until something resolves it, which a throwaway collection never does.
+/// </remarks>
+public static class NativeCapabilityRegistry
+{
+    /// <summary>
+    ///     The capability names a page may invoke on this platform module, in registration order.
+    /// </summary>
+    /// <param name="platform">The module a head passed to <see cref="NativeAppHost.UsePlatform" />.</param>
+    public static IReadOnlyList<string> AdvertisedFor(INativePlatform platform)
+    {
+        ArgumentNullException.ThrowIfNull(platform);
+
+        var probe = new ServiceCollection();
+        platform.Register(probe);
+
+        var names = new List<string>();
+        foreach (var descriptor in probe)
+        {
+            if (descriptor.ServiceType is { IsInterface: true } service
+                && CapabilityName(service) is { } name
+                && !names.Contains(name, StringComparer.Ordinal))
+            {
+                names.Add(name);
+            }
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    ///     The wire name for a backend interface — <c>IGeolocation</c> → <c>geolocation</c>. One rule rather
+    ///     than a lookup table, so a new interface needs no entry anywhere and the name a page uses is
+    ///     predictable from the type it is asking for.
+    /// </summary>
+    /// <returns>The name, or <see langword="null" /> if the type is not an <c>I</c>-prefixed interface.</returns>
+    public static string? CapabilityName(Type serviceType)
+    {
+        ArgumentNullException.ThrowIfNull(serviceType);
+
+        var name = serviceType.Name;
+
+        // IShare → Share; anything not shaped like an interface name is not a capability.
+        if (name.Length < 2 || name[0] != 'I' || !char.IsUpper(name[1]))
+        {
+            return null;
+        }
+
+        var bare = name[1..];
+        return string.Create(
+            bare.Length,
+            bare,
+            static (span, source) =>
+            {
+                source.AsSpan().CopyTo(span);
+                span[0] = char.ToLower(span[0], CultureInfo.InvariantCulture);
+            });
+    }
+}

--- a/src/Rask.Native/NativeCapabilitySubscriptions.cs
+++ b/src/Rask.Native/NativeCapabilitySubscriptions.cs
@@ -1,0 +1,78 @@
+using System.Collections.Concurrent;
+
+namespace Rask.Native;
+
+/// <summary>
+///     The live subscriptions a page has opened over the capability bridge — a geolocation watch, a battery
+///     watch, the sensor streams, speech recognition, and a held wake lock.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Six of the thirty-five members across the fifteen backends are not request/response: they hand
+///         back an <c>IAsyncDisposable</c> and then push. A JSON envelope cannot carry a callback, so the
+///         handle stays here on the native side and the page gets an <b>id</b> for it. Starting one is an
+///         ordinary invoke whose result is that id; ending one is an invoke carrying it back.
+///     </para>
+///     <para>
+///         Note what does <em>not</em> change: the readings still reach the app's C# through the page's own
+///         <c>DotNet.invokeMethodAsync</c> push path, exactly as the web implementation delivers them. The
+///         bridge replaces where a reading comes from, not how it gets home — which is why the app half
+///         needs no native-specific code.
+///     </para>
+/// </remarks>
+internal sealed class NativeCapabilitySubscriptions : IAsyncDisposable
+{
+    private readonly ConcurrentDictionary<string, IAsyncDisposable> _live = new(StringComparer.Ordinal);
+
+    /// <summary>
+    ///     Keep a handle under the id the page chose for it. If that id is somehow already in use, the older
+    ///     handle is released rather than leaked — a page reusing an id means it has stopped listening to the
+    ///     first stream, and an orphaned GPS watch is a battery complaint with no visible cause.
+    /// </summary>
+    public void Add(string id, IAsyncDisposable handle)
+    {
+        if (_live.TryRemove(id, out var previous))
+        {
+            _ = previous.DisposeAsync();
+        }
+
+        _live[id] = handle;
+    }
+
+    /// <summary>
+    ///     End a subscription. Unknown ids are ignored rather than thrown: a page that reloads mid-stream
+    ///     will release handles this side has already dropped, and that is not a fault worth surfacing.
+    /// </summary>
+    public async ValueTask ReleaseAsync(string? id)
+    {
+        if (!string.IsNullOrEmpty(id) && _live.TryRemove(id, out var handle))
+        {
+            await handle.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    ///     Release everything. The app owns the sensors it started, and a GPS watch or a wake lock that
+    ///     outlived its app is a battery complaint with no visible cause.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var id in _live.Keys)
+        {
+            if (_live.TryRemove(id, out var handle))
+            {
+                try
+                {
+                    await handle.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    // One backend refusing to let go must not strand the rest.
+                    Core.Diagnostics.RaskDiagnostics.Report(
+                        Core.Diagnostics.RaskLogLevel.Warning, "Rask.Native",
+                        "[Rask.Native] a capability subscription threw while being released", ex);
+                }
+            }
+        }
+    }
+}

--- a/src/Rask.Native/Platforms/Android/RaskAndroidWebView.cs
+++ b/src/Rask.Native/Platforms/Android/RaskAndroidWebView.cs
@@ -29,6 +29,9 @@ public sealed partial class RaskAndroidWebView : INativeWebView, INativeChrome
     public Android.Views.View View => _webView;
 
     /// <inheritdoc />
+    public IReadOnlyList<string> Capabilities { get; set; } = [];
+
+    /// <inheritdoc />
     public Func<byte[], Task>? OnMessage { get; set; }
 
     /// <param name="context">The hosting activity/context.</param>
@@ -68,7 +71,7 @@ public sealed partial class RaskAndroidWebView : INativeWebView, INativeChrome
             // Swapped in rather than configured up front, so an app that never names a Url keeps exactly the
             // client it had. The asset interceptor is still wanted: scoped CSS/JS and the app's own bundled
             // files are served from the app origin regardless of what the page is.
-            _webView.SetWebViewClient(new ShowcaseWebViewClient(_origin, _readStaticFile, url));
+            _webView.SetWebViewClient(new ShowcaseWebViewClient(_origin, _readStaticFile, url, Capabilities));
             _webView.LoadUrl(url.ToString());
         });
         return default;
@@ -120,7 +123,8 @@ internal sealed class RaskJsBridge(RaskAndroidWebView owner) : Java.Lang.Object
 internal sealed class ShowcaseWebViewClient(
     string origin,
     Func<string, byte[]?> readStaticFile,
-    Uri? remoteOrigin = null) : WebViewClient
+    Uri? remoteOrigin = null,
+    IReadOnlyList<string>? remoteCapabilities = null) : WebViewClient
 {
     public override WebResourceResponse? ShouldInterceptRequest(WebView? view, IWebResourceRequest? request)
     {
@@ -148,7 +152,7 @@ internal sealed class ShowcaseWebViewClient(
 
         if (remoteOrigin is { } trusted && NativeCapabilities.IsTrustedOrigin(trusted, url))
         {
-            view?.EvaluateJavascript(NativeCapabilities.BridgeScript, null);
+            view?.EvaluateJavascript(NativeCapabilities.BridgeScript(remoteCapabilities ?? []), null);
         }
     }
 

--- a/src/Rask.Native/Platforms/Android/RaskServerWebView.cs
+++ b/src/Rask.Native/Platforms/Android/RaskServerWebView.cs
@@ -3,7 +3,6 @@ using Android.Content;
 using Android.Graphics;
 using Android.Webkit;
 using Java.Interop;
-using Rask.Client.Browser;
 
 namespace Rask.Native;
 
@@ -18,10 +17,16 @@ public static class RaskServerWebView
     /// <summary>Create a configured Native + Server WebView. Hand the result to <c>SetContentView</c>.</summary>
     /// <param name="context">The hosting activity/context.</param>
     /// <param name="origin">The trusted remote server origin (the bridge is exposed only here).</param>
-    /// <param name="share">The native share backend the bridge routes <c>share</c> to.</param>
-    public static WebView Create(Context context, Uri origin, IShare share)
+    /// <param name="services">
+    ///     The app services holding the native backends the bridge routes to — the whole provider, because
+    ///     every capability the head registered is reachable now, not just share.
+    /// </param>
+    /// <param name="capabilities">What to advertise to the page — see <see cref="NativeCapabilityRegistry" />.</param>
+    public static WebView Create(
+        Context context, Uri origin, IServiceProvider services, IReadOnlyList<string> capabilities)
     {
-        ArgumentNullException.ThrowIfNull(share);
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(capabilities);
         // Validates the origin is absolute (same contract a Native + Server head's ConnectToServer uses).
         var serverBaseUrl = NativeAppHost.ConnectToServer(origin).ServerBaseUrl;
 
@@ -31,32 +36,33 @@ public static class RaskServerWebView
         settings.DomStorageEnabled = true;
 
         // JS → native: window.__raskBridge.dispatch (used by NativeCapabilities.BridgeScript's send()).
-        webView.AddJavascriptInterface(new RaskServerBridge(share), "__raskBridge");
-        webView.SetWebViewClient(new RaskServerWebViewClient(serverBaseUrl));
+        webView.AddJavascriptInterface(new RaskServerBridge(services, webView), "__raskBridge");
+        webView.SetWebViewClient(new RaskServerWebViewClient(serverBaseUrl, capabilities));
         webView.LoadUrl(serverBaseUrl.ToString());
         return webView;
     }
 }
 
-// Routes a WebView → native message to the shared capability dispatcher with the head's native IShare.
+// Routes a WebView → native message to the shared capability dispatcher with the head's own services.
 // Only { type:"capability" } envelopes are honoured; the WebViewClient guarantees only the trusted origin
 // can reach this interface.
-internal sealed class RaskServerBridge(IShare share) : Java.Lang.Object
+internal sealed class RaskServerBridge(IServiceProvider services, WebView webView) : Java.Lang.Object
 {
     [JavascriptInterface]
     [Export("dispatch")]
     public void Dispatch(string message) =>
-        _ = NativeCapabilities.TryHandleAsync(Encoding.UTF8.GetBytes(message), share);
+        _ = NativeCapabilities.TryHandleAsync(Encoding.UTF8.GetBytes(message), services,
+            script => { webView.Post(() => webView.EvaluateJavascript(script, null)); return default; });
 }
 
-internal sealed class RaskServerWebViewClient(Uri origin) : WebViewClient
+internal sealed class RaskServerWebViewClient(Uri origin, IReadOnlyList<string> capabilities) : WebViewClient
 {
     // Inject the capability bridge (window.__raskNative) only for the trusted origin, as each page commits.
     public override void OnPageStarted(WebView? view, string? url, Bitmap? favicon)
     {
         if (view is not null && NativeCapabilities.IsTrustedOrigin(origin, url))
         {
-            view.EvaluateJavascript(NativeCapabilities.BridgeScript, null);
+            view.EvaluateJavascript(NativeCapabilities.BridgeScript(capabilities), null);
         }
     }
 

--- a/src/Rask.Native/Platforms/iOS/RaskServerViewController.cs
+++ b/src/Rask.Native/Platforms/iOS/RaskServerViewController.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Foundation;
-using Rask.Client.Browser;
 using UIKit;
 using WebKit;
 
@@ -16,16 +15,25 @@ namespace Rask.Native;
 public sealed class RaskServerViewController : UIViewController, IWKScriptMessageHandler, IWKNavigationDelegate
 {
     private readonly Uri _origin;
-    private readonly IShare _share;
+    private readonly IServiceProvider _services;
+    private readonly IReadOnlyList<string> _capabilities;
+    private WKWebView? _webView;
 
     /// <param name="origin">The trusted remote server origin (the bridge is exposed only here).</param>
-    /// <param name="share">The native share backend the bridge routes <c>share</c> to.</param>
-    public RaskServerViewController(Uri origin, IShare share)
+    /// <param name="services">
+    ///     The app services holding the native backends the bridge routes to. The whole provider rather
+    ///     than one interface, because every capability the head registered is reachable now, not just share.
+    /// </param>
+    /// <param name="capabilities">What to advertise to the page — see <see cref="NativeCapabilityRegistry" />.</param>
+    public RaskServerViewController(
+        Uri origin, IServiceProvider services, IReadOnlyList<string> capabilities)
     {
         ArgumentNullException.ThrowIfNull(origin);
-        ArgumentNullException.ThrowIfNull(share);
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(capabilities);
         _origin = origin;
-        _share = share;
+        _services = services;
+        _capabilities = capabilities;
     }
 
     /// <inheritdoc />
@@ -46,6 +54,7 @@ public sealed class RaskServerViewController : UIViewController, IWKScriptMessag
             AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight,
             NavigationDelegate = this
         };
+        _webView = webView;
         View = webView;
         webView.LoadRequest(new NSUrlRequest(new NSUrl(_origin.ToString())));
     }
@@ -55,7 +64,14 @@ public sealed class RaskServerViewController : UIViewController, IWKScriptMessag
     {
         if (message.Body is NSString s)
         {
-            _ = NativeCapabilities.TryHandleAsync(Encoding.UTF8.GetBytes(s.ToString()), _share);
+            _ = NativeCapabilities.TryHandleAsync(
+                Encoding.UTF8.GetBytes(s.ToString()),
+                _services,
+                script =>
+                {
+                    _webView?.EvaluateJavaScript(new NSString(script), null);
+                    return default;
+                });
         }
     }
 
@@ -65,7 +81,7 @@ public sealed class RaskServerViewController : UIViewController, IWKScriptMessag
     {
         if (NativeCapabilities.IsTrustedOrigin(_origin, webView.Url?.AbsoluteString))
         {
-            webView.EvaluateJavaScript(new NSString(NativeCapabilities.BridgeScript), null);
+            webView.EvaluateJavaScript(new NSString(NativeCapabilities.BridgeScript(_capabilities)), null);
         }
     }
 

--- a/src/Rask.Native/Platforms/iOS/RaskWkWebView.cs
+++ b/src/Rask.Native/Platforms/iOS/RaskWkWebView.cs
@@ -30,6 +30,9 @@ public sealed partial class RaskWkWebView : NSObject, INativeWebView, IWKScriptM
     public WKWebView View { get; }
 
     /// <inheritdoc />
+    public IReadOnlyList<string> Capabilities { get; set; } = [];
+
+    /// <inheritdoc />
     public Func<byte[], Task>? OnMessage { get; set; }
 
     /// <param name="origin">The app origin (default <see cref="DefaultOrigin" />).</param>
@@ -93,7 +96,7 @@ public sealed partial class RaskWkWebView : NSObject, INativeWebView, IWKScriptM
     {
         if (_remoteOrigin is { } origin && NativeCapabilities.IsTrustedOrigin(origin, webView.Url?.AbsoluteString))
         {
-            webView.EvaluateJavaScript(new NSString(NativeCapabilities.BridgeScript), null);
+            webView.EvaluateJavaScript(new NSString(NativeCapabilities.BridgeScript(Capabilities)), null);
         }
     }
 

--- a/src/Rask.Native/Resources/rask.native.js
+++ b/src/Rask.Native/Resources/rask.native.js
@@ -378,12 +378,85 @@ function endDotNetInvoke(resultJson) {
 
 // The host reaches applyRender/beginInvokeJS/endDotNetInvoke through EvaluateJavaScript. capabilities +
 // invoke() are the native device-capability bridge the shared client uses (e.g. Shareable): invoke() posts
-// a capability message the host routes to the registered service (IShare) — see NativeAppHost. On the Native
-// host, sharing is always available, so it's advertised here; invoke() needs no user activation.
+// a capability message the host routes to the backend the head registered — see NativeAppHost.
+//
+// capabilities is EMPTY here and filled in by the host (NativeCapabilityRegistry), because what this app
+// backs natively is a property of the platform module it was given, not of the client. It used to be a
+// hardcoded ["share"], which is why share was the only capability that ever worked.
+const capabilityPending = new Map();
+const capabilitySubs = new Map();
+let nextCapabilityId = 1;
+
 window.__raskNative = {
     applyRender, beginInvokeJS, endDotNetInvoke,
-    capabilities: ["share"],
-    invoke: function (component, data) { send({ type: "capability", component: component, data: data }); }
+    capabilities: [],
+    has: function (name) { return window.__raskNative.capabilities.indexOf(name) !== -1; },
+
+    // Returns a promise, resolved by capabilityResult below. The same correlation-id shape jsResult and
+    // dotNetInvoke already use in the other direction — without it an invoke could only be fire-and-forget,
+    // and every capability that returns a value was unreachable.
+    invoke: function (component, op, data) {
+        const id = String(nextCapabilityId++);
+        return new Promise((resolve, reject) => {
+            capabilityPending.set(id, { resolve, reject });
+            send({
+                type: "capability", id: id, component: component, op: op,
+                data: data === undefined || data === null ? null : JSON.stringify(data)
+            });
+        });
+    },
+
+// Streams. The subscription id is minted HERE, not returned by the host: a sensor can deliver a reading
+    // before the reply arrives, and an id the page has not seen yet is one it cannot route — the first
+    // readings would vanish, silently and only on a fast device. Registering the callback first removes the
+    // race entirely.
+    subscribe: function (component, op, data, onEvent) {
+        const sub = "s" + String(nextCapabilityId++);
+        capabilitySubs.set(sub, onEvent);
+        const payload = Object.assign({ sub: sub }, data || {});
+        return window.__raskNative.invoke(component, op, payload).then(() => sub, (err) => {
+            capabilitySubs.delete(sub);
+            throw err;
+        });
+    },
+
+    unsubscribe: function (component, op, sub) {
+        capabilitySubs.delete(sub);
+        return window.__raskNative.invoke(component, op, sub);
+    },
+
+    // Host → page: one reading. Handed to the callback the page registered, which forwards it to C#
+    // exactly as the web implementation would — the bridge changes where a reading comes from, not how it
+    // gets home.
+    capabilityEvent: function (json) {
+        let msg;
+        try { msg = JSON.parse(json); } catch (e) { return; }
+        const cb = capabilitySubs.get(msg.sub);
+        if (!cb) return;
+        let value = null;
+        if (msg.payload !== null && msg.payload !== undefined) {
+            try { value = JSON.parse(msg.payload); } catch (e) { value = msg.payload; }
+        }
+        cb(value);
+    },
+
+    // Host → page: settle the promise the invoke above is waiting on.
+    capabilityResult: function (json) {
+        let msg;
+        try { msg = JSON.parse(json); } catch (e) { console.error("[Rask.Native] capabilityResult bad JSON", e); return; }
+        const pending = capabilityPending.get(msg.id);
+        if (!pending) return;
+        capabilityPending.delete(msg.id);
+        if (msg.success) {
+            let value = null;
+            if (msg.result !== null && msg.result !== undefined) {
+                try { value = JSON.parse(msg.result); } catch (e) { value = msg.result; }
+            }
+            pending.resolve(value);
+        } else {
+            pending.reject(new Error(msg.error || "The native capability failed."));
+        }
+    }
 };
 
 // Signal readiness so the host fires its first render only now (see NativeAppHost.RouteMessageAsync).

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -5694,9 +5694,14 @@ document.addEventListener("click", function (e) {
     var raw = t.getAttribute("data-rask-share");
     if (!raw) { return; }
     var nativeCaps = window.__raskNative;
-    if (nativeCaps && nativeCaps.capabilities && nativeCaps.capabilities.indexOf &&
-        nativeCaps.capabilities.indexOf("share") !== -1 && typeof nativeCaps.invoke === "function") {
-        nativeCaps.invoke("share", raw);
+    if (nativeCaps && typeof nativeCaps.has === "function" && nativeCaps.has("share") &&
+        typeof nativeCaps.invoke === "function") {
+        var payload;
+        try { payload = JSON.parse(raw); } catch (err) { return; }
+        // invoke returns a promise now; a rejected share (user cancelled, unsupported payload) is not an
+        // error worth surfacing here, but an unhandled rejection would be.
+        var shared = nativeCaps.invoke("share", "share", payload);
+        if (shared && shared["catch"]) { shared["catch"](function () {}); }
         return;
     }
     if (navigator.share) {

--- a/tests/Rask.Native.Tests/Infrastructure/FakeNativeWebView.cs
+++ b/tests/Rask.Native.Tests/Infrastructure/FakeNativeWebView.cs
@@ -23,6 +23,9 @@ internal sealed class FakeNativeWebView : INativeWebView
     /// </summary>
     public List<Uri> LoadedUrls { get; } = new();
 
+    /// <summary>What the host advertised to the page — the derived native-backend set.</summary>
+    public IReadOnlyList<string> Capabilities { get; set; } = [];
+
     public Func<byte[], Task>? OnMessage { get; set; }
 
     public ValueTask ApplyRenderAsync(ReadOnlyMemory<byte> frameUtf8)

--- a/tests/Rask.Native.Tests/NativeCapabilitiesTests.cs
+++ b/tests/Rask.Native.Tests/NativeCapabilitiesTests.cs
@@ -1,76 +1,200 @@
 using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
 using Rask.Client.Browser;
 using Rask.Core.Browser;
 
 namespace Rask.Native.Tests;
 
-// The reusable capability dispatcher a Native + Server head uses (and the Native + Local router shares):
-// a { type:"capability" } envelope routes "share" to the supplied IShare; anything else is a no-op or a
-// pass-through. BridgeScript is the document-start JS the head injects for its trusted origin.
+/// <summary>
+///     The capability bridge: a <c>{ type:"capability" }</c> envelope routes to the native backend the head
+///     registered, and <b>answers</b>. The answer is the point — before it there was no correlation id and no
+///     reply path, so the only capability that could work was one that returns nothing (share). Everything
+///     else was accepted and silently dropped, leaving the page's await pending for ever.
+/// </summary>
 public class NativeCapabilitiesTests
 {
     [Fact]
-    public async Task TryHandle_ShareCapability_DispatchesToShare_ReturnsTrue()
+    public async Task A_capability_reaches_its_backend_and_the_page_is_told_it_worked()
     {
         var share = new RecordingShare();
+        var replies = new List<string>();
 
         var handled = await NativeCapabilities.TryHandleAsync(
-            Msg("""{"type":"capability","component":"share","data":"{\"title\":\"Rask\",\"url\":\"https://x\"}"}"""),
-            share);
+            Msg("""{"type":"capability","id":"1","component":"share","op":"share","data":"{\"title\":\"Rask\"}"}"""),
+            Services(s => s.AddSingleton<IShare>(share)),
+            Capture(replies));
 
         Assert.True(handled);
-        Assert.Equal("Rask", share.Last!.Title);
-        Assert.Equal("https://x", share.Last.Url);
+        Assert.Equal("Rask", share.Last?.Title);
+
+        var reply = Reply(replies);
+        Assert.Equal("1", reply.GetProperty("id").GetString());
+        Assert.True(reply.GetProperty("success").GetBoolean());
+    }
+
+    /// <summary>
+    ///     The half that did not exist: a capability with a RESULT. Twenty-two of the thirty-five members
+    ///     across the fifteen backends return a value, and none of them could cross the bridge before.
+    /// </summary>
+    [Fact]
+    public async Task A_capability_that_returns_a_value_sends_it_back()
+    {
+        var replies = new List<string>();
+
+        var handled = await NativeCapabilities.TryHandleAsync(
+            Msg("""{"type":"capability","id":"7","component":"clipboard","op":"readText"}"""),
+            Services(s => s.AddSingleton<IClipboard>(new StubClipboard("copied"))),
+            Capture(replies));
+
+        Assert.True(handled);
+
+        var reply = Reply(replies);
+        Assert.True(reply.GetProperty("success").GetBoolean());
+        // The result rides as JSON so the page parses it into whatever shape its own wrapper expects.
+        Assert.Equal("\"copied\"", reply.GetProperty("result").GetString());
+    }
+
+    /// <summary>
+    ///     A backend that throws must still answer. A page is awaiting; the only outcome worse than an error
+    ///     is a promise that never settles.
+    /// </summary>
+    [Fact]
+    public async Task A_backend_that_throws_answers_with_the_reason()
+    {
+        var replies = new List<string>();
+
+        await NativeCapabilities.TryHandleAsync(
+            Msg("""{"type":"capability","id":"2","component":"clipboard","op":"readText"}"""),
+            Services(s => s.AddSingleton<IClipboard>(new ThrowingClipboard())),
+            Capture(replies));
+
+        var reply = Reply(replies);
+        Assert.False(reply.GetProperty("success").GetBoolean());
+        Assert.Contains("clipboard is on fire", reply.GetProperty("error").GetString(), StringComparison.Ordinal);
     }
 
     [Fact]
-    public async Task TryHandle_NonCapabilityMessage_ReturnsFalse_WithoutDispatch()
+    public async Task An_unknown_capability_answers_instead_of_going_quiet()
     {
-        var share = new RecordingShare();
+        var replies = new List<string>();
 
-        var handled = await NativeCapabilities.TryHandleAsync(Msg("""{"type":"event","id":"h0"}"""), share);
+        var handled = await NativeCapabilities.TryHandleAsync(
+            Msg("""{"type":"capability","id":"3","component":"teleport","op":"go"}"""),
+            Services(_ => { }),
+            Capture(replies));
+
+        Assert.True(handled);
+
+        var reply = Reply(replies);
+        Assert.False(reply.GetProperty("success").GetBoolean());
+        Assert.Contains("teleport", reply.GetProperty("error").GetString(), StringComparison.Ordinal);
+    }
+
+    /// <summary>An op whose backend the head never registered is a failure the page can read, not a hang.</summary>
+    [Fact]
+    public async Task A_capability_with_no_backend_registered_answers_with_the_reason()
+    {
+        var replies = new List<string>();
+
+        await NativeCapabilities.TryHandleAsync(
+            Msg("""{"type":"capability","id":"4","component":"clipboard","op":"readText"}"""),
+            Services(_ => { }),
+            Capture(replies));
+
+        var reply = Reply(replies);
+        Assert.False(reply.GetProperty("success").GetBoolean());
+        Assert.Contains("IClipboard", reply.GetProperty("error").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_non_capability_message_is_left_for_the_head()
+    {
+        var replies = new List<string>();
+
+        var handled = await NativeCapabilities.TryHandleAsync(
+            Msg("""{"type":"navigate","path":"/x"}"""), Services(_ => { }), Capture(replies));
 
         Assert.False(handled);
-        Assert.Null(share.Last);
+        Assert.Empty(replies);
     }
 
+    /// <summary>A call the page does not await needs no reply, and must not manufacture one.</summary>
     [Fact]
-    public async Task TryHandle_UnknownComponent_ConsumedAsNoOp_ReturnsTrue()
+    public async Task An_envelope_with_no_id_is_run_without_a_reply()
     {
         var share = new RecordingShare();
+        var replies = new List<string>();
 
-        var handled = await NativeCapabilities.TryHandleAsync(
-            Msg("""{"type":"capability","component":"bogus","data":"{}"}"""), share);
+        await NativeCapabilities.TryHandleAsync(
+            Msg("""{"type":"capability","component":"share","op":"share","data":"{\"title\":\"Rask\"}"}"""),
+            Services(s => s.AddSingleton<IShare>(share)),
+            Capture(replies));
 
-        Assert.True(handled);
-        Assert.Null(share.Last);
+        Assert.Equal("Rask", share.Last?.Title);
+        Assert.Empty(replies);
     }
 
     [Fact]
-    public async Task TryHandle_MalformedSharePayload_Discarded_NoThrow_ReturnsTrue()
+    public async Task A_malformed_message_is_discarded_rather_than_thrown()
     {
-        var share = new RecordingShare();
+        var replies = new List<string>();
 
         var handled = await NativeCapabilities.TryHandleAsync(
-            Msg("""{"type":"capability","component":"share","data":"not json"}"""), share);
+            Msg("{ not json"), Services(_ => { }), Capture(replies));
 
-        Assert.True(handled);
-        Assert.Null(share.Last);
+        Assert.False(handled);
+        Assert.Empty(replies);
     }
 
     [Fact]
-    public void BridgeScript_DefinesRaskNativeCapabilitiesAndInvokeOverTheSendChannel()
+    public void The_bridge_script_advertises_exactly_what_it_was_given()
     {
-        var script = NativeCapabilities.BridgeScript;
+        var script = NativeCapabilities.BridgeScript(["share", "geolocation"]);
 
-        Assert.Contains("window.__raskNative", script);
-        Assert.Contains("capabilities", script);
-        Assert.Contains("\"share\"", script);
-        Assert.Contains("invoke", script);
-        Assert.Contains("__raskSend", script);
+        Assert.Contains("""n.capabilities = ["share","geolocation"];""", script, StringComparison.Ordinal);
+        // The promise table is what makes a result possible at all.
+        Assert.Contains("capabilityResult", script, StringComparison.Ordinal);
     }
 
-    private static byte[] Msg(string json) => Encoding.UTF8.GetBytes(json);
+    /// <summary>
+    ///     A head with no platform module promises nothing, so the page uses its own web APIs — the "no
+    ///     IsNative branch in app code" property, from the other direction.
+    /// </summary>
+    [Fact]
+    public void A_head_that_backs_nothing_advertises_nothing()
+    {
+        var script = NativeCapabilities.BridgeScript([]);
+
+        Assert.Contains("n.capabilities = [];", script, StringComparison.Ordinal);
+    }
+
+    private static ReadOnlyMemory<byte> Msg(string json) => Encoding.UTF8.GetBytes(json);
+
+    private static IServiceProvider Services(Action<IServiceCollection> configure)
+    {
+        var services = new ServiceCollection();
+        configure(services);
+        return services.BuildServiceProvider();
+    }
+
+    private static Func<string, ValueTask> Capture(List<string> into) =>
+        script =>
+        {
+            into.Add(script);
+            return default;
+        };
+
+    // The reply arrives as `window.__raskNative.capabilityResult("<escaped json>")`; unwrap it to the object.
+    private static JsonElement Reply(List<string> replies)
+    {
+        var script = Assert.Single(replies);
+        var open = script.IndexOf('"', StringComparison.Ordinal);
+        var close = script.LastIndexOf('"');
+        var literal = script[open..(close + 1)];
+        var json = JsonSerializer.Deserialize<string>(literal)!;
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
 
     private sealed class RecordingShare : IShare
     {
@@ -83,5 +207,19 @@ public class NativeCapabilitiesTests
         }
 
         public ValueTask<bool> CanShareAsync(ShareData? data = null) => ValueTask.FromResult(true);
+    }
+
+    private sealed class StubClipboard(string text) : IClipboard
+    {
+        public ValueTask WriteTextAsync(string value) => default;
+
+        public ValueTask<string> ReadTextAsync() => ValueTask.FromResult(text);
+    }
+
+    private sealed class ThrowingClipboard : IClipboard
+    {
+        public ValueTask WriteTextAsync(string value) => default;
+
+        public ValueTask<string> ReadTextAsync() => throw new InvalidOperationException("the clipboard is on fire");
     }
 }

--- a/tests/Rask.Native.Tests/NativeCapabilityRegistryTests.cs
+++ b/tests/Rask.Native.Tests/NativeCapabilityRegistryTests.cs
@@ -1,0 +1,131 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Rask.Client.Browser;
+using Rask.Core.Browser;
+
+namespace Rask.Native.Tests;
+
+/// <summary>
+///     What a head advertises is <b>derived</b> from what its platform module registers.
+/// </summary>
+/// <remarks>
+///     The alternative designs both fail in ways this pins against. Asking the live container would
+///     advertise everything, because the framework registers a JS-backed default for every one of these
+///     interfaces and a module uses TryAdd — so "is it registered" cannot tell a native backend from the
+///     WebView's own JS. A hand-written list beside <c>Register</c> would answer that, and would drift the
+///     first time a sixteenth backend was added and the other half forgotten, which is exactly the failure
+///     G1 describes.
+/// </remarks>
+public class NativeCapabilityRegistryTests
+{
+    [Fact]
+    public void A_module_advertises_every_backend_it_registers()
+    {
+        var advertised = NativeCapabilityRegistry.AdvertisedFor(new ThreeBackendPlatform());
+
+        Assert.Equal(["share", "clipboard", "badge"], advertised);
+    }
+
+    /// <summary>
+    ///     The property that makes the derivation worth having: a backend added to <c>Register</c> shows up
+    ///     with nothing else to edit. This is the sixteenth-backend case from G1, in miniature.
+    /// </summary>
+    [Fact]
+    public void A_backend_added_to_the_module_advertises_itself()
+    {
+        var before = NativeCapabilityRegistry.AdvertisedFor(new ThreeBackendPlatform());
+        var after = NativeCapabilityRegistry.AdvertisedFor(new FourBackendPlatform());
+
+        Assert.DoesNotContain("vibration", before);
+        Assert.Contains("vibration", after);
+    }
+
+    [Fact]
+    public void A_module_that_registers_nothing_advertises_nothing() =>
+        Assert.Empty(NativeCapabilityRegistry.AdvertisedFor(new EmptyPlatform()));
+
+    /// <summary>
+    ///     A module may register its own plumbing; only the <c>I</c>-prefixed browser interfaces are things a
+    ///     page can invoke, so a concrete helper class must not be advertised as a capability.
+    /// </summary>
+    [Fact]
+    public void Only_interfaces_are_advertised() =>
+        Assert.Equal(["share"], NativeCapabilityRegistry.AdvertisedFor(new PlatformWithHelper()));
+
+    [Theory]
+    [InlineData(typeof(IShare), "share")]
+    [InlineData(typeof(IGeolocation), "geolocation")]
+    [InlineData(typeof(IDeviceOrientation), "deviceOrientation")]
+    [InlineData(typeof(INetworkInfo), "networkInfo")]
+    public void The_wire_name_is_the_interface_without_its_I(Type service, string expected) =>
+        Assert.Equal(expected, NativeCapabilityRegistry.CapabilityName(service));
+
+    [Fact]
+    public void A_type_that_is_not_an_interface_name_has_no_capability_name() =>
+        Assert.Null(NativeCapabilityRegistry.CapabilityName(typeof(NativeCapabilityRegistryTests)));
+
+    private sealed class ThreeBackendPlatform : INativePlatform
+    {
+        public void Register(IServiceCollection services)
+        {
+            services.TryAddSingleton<IShare>(_ => new NoShare());
+            services.TryAddSingleton<IClipboard>(_ => new NoClipboard());
+            services.TryAddSingleton<IBadge>(_ => new NoBadge());
+        }
+    }
+
+    private sealed class FourBackendPlatform : INativePlatform
+    {
+        public void Register(IServiceCollection services)
+        {
+            new ThreeBackendPlatform().Register(services);
+            services.TryAddSingleton<IVibration>(_ => new NoVibration());
+        }
+    }
+
+    private sealed class EmptyPlatform : INativePlatform
+    {
+        public void Register(IServiceCollection services)
+        {
+        }
+    }
+
+    private sealed class PlatformWithHelper : INativePlatform
+    {
+        public void Register(IServiceCollection services)
+        {
+            services.TryAddSingleton<IShare>(_ => new NoShare());
+            services.TryAddSingleton(_ => new NoShare());
+        }
+    }
+
+    private sealed class NoShare : IShare
+    {
+        public ValueTask ShareAsync(ShareData data) => default;
+
+        public ValueTask<bool> CanShareAsync(ShareData? data = null) => ValueTask.FromResult(false);
+    }
+
+    private sealed class NoClipboard : IClipboard
+    {
+        public ValueTask WriteTextAsync(string text) => default;
+
+        public ValueTask<string> ReadTextAsync() => ValueTask.FromResult(string.Empty);
+    }
+
+    private sealed class NoBadge : IBadge
+    {
+        public ValueTask<bool> IsSupportedAsync() => ValueTask.FromResult(false);
+
+        public ValueTask SetAsync(int? count = null) => default;
+
+        public ValueTask ClearAsync() => default;
+    }
+
+    private sealed class NoVibration : IVibration
+    {
+        public ValueTask<bool> VibrateAsync(params int[] pattern) => ValueTask.FromResult(false);
+
+        public ValueTask<bool> CancelAsync() => ValueTask.FromResult(false);
+    }
+}

--- a/tests/Rask.Native.Tests/NativeCapabilityStreamTests.cs
+++ b/tests/Rask.Native.Tests/NativeCapabilityStreamTests.cs
@@ -1,0 +1,182 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core.Browser;
+
+namespace Rask.Native.Tests;
+
+/// <summary>
+///     The six members that push instead of returning. A JSON envelope cannot carry a callback, so the
+///     handle stays native-side and the page refers to it by an id it chose itself.
+/// </summary>
+public class NativeCapabilityStreamTests
+{
+    [Fact]
+    public async Task Starting_a_watch_delivers_readings_to_the_page()
+    {
+        var battery = new FakeBattery();
+        var scripts = new List<string>();
+        var services = Services(s =>
+        {
+            s.AddSingleton<IBattery>(battery);
+            s.AddSingleton<NativeCapabilitySubscriptions>();
+        });
+
+        await Handle(services, scripts, """{"type":"capability","id":"1","component":"battery","op":"watch","data":"{\"sub\":\"s1\"}"}""");
+
+        await battery.EmitAsync(new BatteryStatus(0.42, true, null, null));
+
+        var evt = Event(scripts);
+        Assert.Equal("s1", evt.GetProperty("sub").GetString());
+        Assert.Contains("0.42", evt.GetProperty("payload").GetString()!, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     The id is the page's, not the host's. That is what lets a reading which beats the reply still
+    ///     find its callback — the page registered one before it ever sent the request.
+    /// </summary>
+    [Fact]
+    public async Task A_reading_that_arrives_before_the_reply_still_carries_the_pages_id()
+    {
+        var battery = new FakeBattery();
+        var scripts = new List<string>();
+        var services = Services(s =>
+        {
+            s.AddSingleton<IBattery>(battery);
+            s.AddSingleton<NativeCapabilitySubscriptions>();
+        });
+
+        // The backend pushes during the start call, before the envelope has replied.
+        battery.EmitOnWatch = new BatteryStatus(0.1, false, null, null);
+
+        await Handle(services, scripts, """{"type":"capability","id":"1","component":"battery","op":"watch","data":"{\"sub\":\"chosen\"}"}""");
+
+        var evt = Event(scripts);
+        Assert.Equal("chosen", evt.GetProperty("sub").GetString());
+    }
+
+    /// <summary>
+    ///     Releasing must actually stop the backend. A GPS watch or a wake lock that outlives the page that
+    ///     asked for it is a battery complaint with no visible cause.
+    /// </summary>
+    [Fact]
+    public async Task Releasing_a_watch_disposes_the_backends_handle()
+    {
+        var battery = new FakeBattery();
+        var scripts = new List<string>();
+        var services = Services(s =>
+        {
+            s.AddSingleton<IBattery>(battery);
+            s.AddSingleton<NativeCapabilitySubscriptions>();
+        });
+
+        await Handle(services, scripts, """{"type":"capability","id":"1","component":"battery","op":"watch","data":"{\"sub\":\"s1\"}"}""");
+        Assert.False(battery.Released);
+
+        await Handle(services, scripts, """{"type":"capability","id":"2","component":"battery","op":"unwatch","data":"\"s1\""}""");
+
+        Assert.True(battery.Released);
+    }
+
+    /// <summary>
+    ///     Disposing the app releases whatever is still running. Nothing the app started should outlive it.
+    /// </summary>
+    [Fact]
+    public async Task Disposing_the_registry_releases_every_live_subscription()
+    {
+        var battery = new FakeBattery();
+        var subscriptions = new NativeCapabilitySubscriptions();
+        var scripts = new List<string>();
+        var services = Services(s =>
+        {
+            s.AddSingleton<IBattery>(battery);
+            s.AddSingleton(subscriptions);
+        });
+
+        await Handle(services, scripts, """{"type":"capability","id":"1","component":"battery","op":"watch","data":"{\"sub\":\"s1\"}"}""");
+
+        await subscriptions.DisposeAsync();
+
+        Assert.True(battery.Released);
+    }
+
+    /// <summary>Releasing an id nobody holds is a no-op — a reloaded page will do exactly this.</summary>
+    [Fact]
+    public async Task Releasing_an_unknown_subscription_is_not_an_error()
+    {
+        var scripts = new List<string>();
+        var services = Services(s => s.AddSingleton<NativeCapabilitySubscriptions>());
+
+        await Handle(services, scripts, """{"type":"capability","id":"9","component":"battery","op":"unwatch","data":"\"ghost\""}""");
+
+        var reply = Reply(scripts);
+        Assert.True(reply.GetProperty("success").GetBoolean());
+    }
+
+    private static async Task Handle(IServiceProvider services, List<string> scripts, string message) =>
+        await NativeCapabilities.TryHandleAsync(
+            Encoding.UTF8.GetBytes(message),
+            services,
+            script =>
+            {
+                scripts.Add(script);
+                return default;
+            });
+
+    private static IServiceProvider Services(Action<IServiceCollection> configure)
+    {
+        var services = new ServiceCollection();
+        configure(services);
+        return services.BuildServiceProvider();
+    }
+
+    private static JsonElement Event(List<string> scripts) =>
+        Unwrap(scripts.Single(s => s.Contains("capabilityEvent", StringComparison.Ordinal)));
+
+    private static JsonElement Reply(List<string> scripts) =>
+        Unwrap(scripts.Single(s => s.Contains("capabilityResult", StringComparison.Ordinal)));
+
+    private static JsonElement Unwrap(string script)
+    {
+        var open = script.IndexOf('"', StringComparison.Ordinal);
+        var close = script.LastIndexOf('"');
+        var json = JsonSerializer.Deserialize<string>(script[open..(close + 1)])!;
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    private sealed class FakeBattery : IBattery
+    {
+        private Func<BatteryStatus, Task>? _onChange;
+
+        public bool Released { get; private set; }
+
+        /// <summary>A reading pushed from inside WatchAsync, before the caller has its handle.</summary>
+        public BatteryStatus? EmitOnWatch { get; set; }
+
+        public ValueTask<bool> IsSupportedAsync() => ValueTask.FromResult(true);
+
+        public ValueTask<BatteryStatus?> GetStatusAsync() => ValueTask.FromResult<BatteryStatus?>(null);
+
+        public async ValueTask<IAsyncDisposable> WatchAsync(Func<BatteryStatus, Task> onChange)
+        {
+            _onChange = onChange;
+            if (EmitOnWatch is { } early)
+            {
+                await onChange(early);
+            }
+
+            return new Handle(this);
+        }
+
+        public Task EmitAsync(BatteryStatus status) => _onChange?.Invoke(status) ?? Task.CompletedTask;
+
+        private sealed class Handle(FakeBattery owner) : IAsyncDisposable
+        {
+            public ValueTask DisposeAsync()
+            {
+                owner.Released = true;
+                return default;
+            }
+        }
+    }
+}

--- a/tests/Rask.Native.Tests/Session/NativeCapabilityBridgeTests.cs
+++ b/tests/Rask.Native.Tests/Session/NativeCapabilityBridgeTests.cs
@@ -6,7 +6,7 @@ using Rask.Native.Tests.Infrastructure;
 
 namespace Rask.Native.Tests.Session;
 
-// The native capability bridge: window.__raskNative.invoke(component, data) posts a { type:"capability" }
+// The native capability bridge: window.__raskNative.invoke(component, op, data) posts a { type:"capability" }
 // message the host routes to the registered service. This is how the declarative Shareable (and a
 // native-shell page) reaches the native backend the head registered as IShare — no user activation needed.
 [Collection("NativeSession")]
@@ -20,7 +20,7 @@ public class NativeCapabilityBridgeTests() : ResettingTestBase(LiveDiffMode.Auto
             configure: s => s.AddSingleton<IShare>(share), diffMode: DiffMode);
 
         await webView.PostAsync(
-            """{"type":"capability","component":"share","data":"{\"title\":\"Rask\",\"url\":\"https://x\"}"}""");
+            """{"type":"capability","id":"1","component":"share","op":"share","data":"{\"title\":\"Rask\",\"url\":\"https://x\"}"}""");
 
         Assert.NotNull(share.Last);
         Assert.Equal("Rask", share.Last!.Title);
@@ -34,7 +34,7 @@ public class NativeCapabilityBridgeTests() : ResettingTestBase(LiveDiffMode.Auto
         var (_, webView, _) = await NewSessionAsync(
             configure: s => s.AddSingleton<IShare>(share), diffMode: DiffMode);
 
-        await webView.PostAsync("""{"type":"capability","component":"bogus","data":"{}"}""");
+        await webView.PostAsync("""{"type":"capability","id":"2","component":"bogus","op":"go","data":"{}"}""");
 
         Assert.Null(share.Last);
     }
@@ -46,7 +46,7 @@ public class NativeCapabilityBridgeTests() : ResettingTestBase(LiveDiffMode.Auto
         var (_, webView, _) = await NewSessionAsync(
             configure: s => s.AddSingleton<IShare>(share), diffMode: DiffMode);
 
-        await webView.PostAsync("""{"type":"capability","component":"share","data":"not json"}""");
+        await webView.PostAsync("""{"type":"capability","id":"3","component":"share","op":"share","data":"not json"}""");
 
         Assert.Null(share.Last);
     }


### PR DESCRIPTION
Closes #778 (Phase 3 of the four-models epic, #774) — gap **G1**.

`NativeCapabilities` advertised a hardcoded `["share"]` and its dispatcher took a single `IShare`, so
fourteen of the fifteen backends the platform modules register were unreachable from a remote shell. A page
running as a *server* app silently got the WebView's JS instead of the device. All fifteen cross the bridge
now, in every model, with no `IsNative` branch anywhere in app code.

## The envelope had no way to answer

`invoke(component, data)` posted and returned nothing — no correlation id, no reply path. That is the whole
reason `share` was the only capability that ever worked: it returns nothing. **Twenty-two of the
thirty-five members** across the fifteen interfaces return a value, and none of them could cross.

The envelope carries an id now and the host answers on `capabilityResult`, so an invoke is a promise — the
same shape `jsResult` and `dotNetInvoke` already used in the other direction.

**Every outcome answers.** Unknown capability, backend never registered, backend threw — each sends a reply
carrying the reason. Anything but `share` used to be consumed as a forward-compatible no-op, which left the
page's `await` pending for ever.

## The six pushing members

The geolocation and battery watches, the orientation and motion streams, speech recognition, and the wake
lock's held sentinel hand back an `IAsyncDisposable` that a JSON envelope cannot carry — so the handle
stays native-side and the page refers to it by id.

**The page mints that id**, rather than receiving it in the reply. A sensor can deliver a reading before the
reply arrives, and an id the page has not seen yet is one it cannot route: the first readings would vanish,
silently, and only on a fast device. There is a test that pushes from *inside* `WatchAsync` to pin it.

One release path serves all six, and the app disposes whatever is still live — a GPS watch or a wake lock
that outlives its app is a battery complaint with no visible cause.

Readings still reach your C# through the page's own `DotNet.invokeMethodAsync` path, exactly as the web
implementation delivers them. The bridge replaces *where a reading comes from*, not how it gets home.

## The advertised set is derived, not declared

It comes from probing the platform module's own `Register`, so adding a sixteenth backend advertises it with
nothing else to edit — the drift G1 describes cannot happen.

Asking the live container would have advertised everything: the framework registers a JS-backed default for
every one of these interfaces and a module uses `TryAdd`, so "is it registered" cannot tell a native backend
from the WebView's own JS. A head with no platform module advertises nothing and the page keeps its web
APIs — which is the same property from the other side.

That design caught a real bug in review: the Native + Server sample registered `IShare` by hand and never
called `UsePlatform`, so it advertised **nothing** and would have failed this issue's own acceptance
criterion. Fixed in the second commit.

## Breaking

- **The envelope carries an `op`.** `{ component, data }` could only ever name one operation per backend.
  The old form only routed `share`, and both clients ship in this repo.
- **The remote heads take the app's services, not a lone `IShare`.** They had a private notion of what a
  capability was, which is exactly why they could only forward one. They share the in-process dispatcher and
  its reply channel now, so the two models cannot drift apart.

## Testing

- 235 native tests green, including: a result crossing the bridge, a throwing backend answering with its
  reason, an unknown capability answering instead of going quiet, a reading that beats its reply, release
  disposing the backend's handle, and app disposal releasing everything still live.
- The derivation is pinned, including "a backend added to the module advertises itself" — G1 in miniature.
- Format + `-warnaserror` + full unit gate green; pre-push browser E2E green.
- **On an iPhone 17 Pro simulator against a live `Rask.Example.Server`**, the page reported:

```
caps:      all fifteen, exactly what ApplePlatform registers
badge:     ok:true
screen:    ok:{"width":402,"height":874,"pixelRatio":3}
clipboard: ok:"from-the-bridge"     ← write then read, two chained invokes
```

That is the issue's "done when": a server-model page reaching native backends, unchanged.
