### PR TITLE
fix(core): format and parse everything on the wire invariantly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -238,3 +238,15 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator =
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+# CA1305 (IFormatProvider) is promoted to an error for Rask.Core only, and deliberately NOT via
+# AnalysisLevel: raising that surfaces ~33 further CA findings at once (see Directory.Build.props).
+# EnableNETAnalyzers and TreatWarningsAsErrors are already on, so this one severity line activates
+# the rule on its own.
+#
+# It matters here because Rask.Core stringifies and parses values that cross the wire — reconciliation
+# keys, DOM event payloads, field-path indices. Those are wire formats and must stay invariant even
+# when a render runs under a user's culture; an unqualified ToString/TryParse is how that regresses.
+# Display formatting is the opposite case and passes a culture explicitly.
+[src/Rask.Core/**.cs]
+dotnet_diagnostic.CA1305.severity = error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,34 @@ them until tagged releases begin.
 
 ### Fixed
 
+- **Everything Rask puts on the wire now formats and parses invariantly, whatever culture the process
+  is in.** Rask has no culture concept yet, so every one of these paths inherited the machine's locale
+  by accident. That is invisible on a developer machine in `en-US` and becomes a bug the moment the
+  process runs somewhere else — and it is a prerequisite for per-user culture, which will deliberately
+  put a *non*-invariant culture on the render thread and would have armed every one of them at once.
+
+  **A wheel delta could be read ten times too large.** `EventPayload.ReadDouble` parsed
+  string-encoded DOM numbers with no format provider. The client serialises them with JS number
+  formatting, which is invariant, so under `de-DE` a `"1.5"` scroll/pointer delta parsed as **15**.
+  `ReadInt`, `ScrollEvent` and `ModelGraphWalker`'s collection indices took the same treatment; those
+  turn out to be culture-robust for the shapes the client actually sends, and are pinned as contract
+  rather than as a caught bug.
+
+  **A reconciliation key could be re-spelled underneath the client.** `Component.KeyString`
+  stringified a non-string `Key` with a bare `ToString()`. Under `sv-SE` a negative `int` key rendered
+  with U+2212 MINUS SIGN rather than `-`, and a `decimal`/`DateTime` key re-spelled entirely. The key
+  is baked into the HTML the client already holds, so the mismatch breaks keyed reconciliation exactly
+  when the culture changes.
+
+  **A scoped-CSS scope id and an asset hash are identities, not numbers.** `CssScoper.ScopeIdFor` and
+  `HeadAssetRegistry.ContentHash` formatted without a provider; the scope id is baked into class names
+  at build time and recomputed at runtime, and the two must agree byte-for-byte on any machine. Handler
+  ids (`CreateLargeHandlerId`) and the dev-error source gutter were pinned for the same reason.
+
+  **CA1305 is now an error for `src/Rask.Core`**, via one `.editorconfig` severity line rather than an
+  `AnalysisLevel` bump — the level raise surfaces ~33 unrelated findings and stays deferred. This is
+  what stops the next unqualified `ToString`/`TryParse` from reaching the wire.
+
 - **`decimal` no longer mis-sorts — or kills the process — on a non-English locale.** SQLite has no
   decimal type, so EF Core stores one as culture-invariant `TEXT` and sorts it with a collating sequence,
   emitting `ORDER BY "Price" COLLATE EF_DECIMAL`. EF registers that sequence as

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -76,9 +76,14 @@
   <!--
     AnalysisLevel stays at the SDK default mode: the repo builds clean there, so warnings-as-errors
     locks in that clean state. Raising it (e.g. <AnalysisLevel>latest-recommended</AnalysisLevel>)
-    surfaces ~33 extra CA findings — some worth doing (CA1305/CA1865/CA1859), some that clash with
+    surfaces ~33 extra CA findings — some worth doing (CA1865/CA1859), some that clash with
     the documented hot-path design (CA1051 on RenderFrame's deliberately-public fields). Promote the
     level in a focused PR that fixes/justifies each finding with benchmark evidence — not here.
+
+    CA1305 (IFormatProvider) has since been promoted on its own, scoped to src/Rask.Core/**, in
+    .editorconfig — a single severity line rather than a level bump, so it brought none of the others
+    with it. Rask.Core is where wire formats live (reconciliation keys, DOM event payloads, field-path
+    indices), and those must stay invariant even when a render runs under a user's culture.
   -->
 
   <ItemGroup Condition=" '$(IsPackable)' != 'false' ">

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -184,10 +184,21 @@ public abstract partial class Component : RaskMarkup
     // (16 B) on EVERY node in a mounted tree — a bad trade against a rare ToString on reused nodes,
     // and this is a footprint-focused path. Non-keyed nodes (the majority) hit the null short-circuit
     // and allocate nothing.
+    //
+    // Every non-string arm formats with InvariantCulture. The key is stringified into data-rask-key and
+    // baked into the HTML the client already holds, so a culture-sensitive spelling breaks keyed
+    // reconciliation at the moment the culture changes: under sv-SE a negative int renders with U+2212
+    // MINUS SIGN rather than '-', and a decimal/DateTime key re-spells entirely. int/long/Guid lead
+    // because they are the documented common keys and stay a direct call; IFormattable catches
+    // decimal/double/DateTime/DateOnly/TimeOnly and formattable enums.
     internal string? KeyString => Key switch
     {
         null => null,
         string s => s,
+        int i => i.ToString(CultureInfo.InvariantCulture),
+        long l => l.ToString(CultureInfo.InvariantCulture),
+        Guid g => g.ToString(),
+        IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
         var k => k.ToString(),
     };
 
@@ -1811,9 +1822,9 @@ public abstract partial class Component : RaskMarkup
     {
         Span<char> buf = stackalloc char[12];
         buf[0] = 'h';
-        return n.TryFormat(buf[1..], out var written)
+        return n.TryFormat(buf[1..], out var written, provider: CultureInfo.InvariantCulture)
             ? new string(buf[..(1 + written)])
-            : "h" + n;
+            : "h" + n.ToString(CultureInfo.InvariantCulture);
     }
 
     // ---- Clean-subtree handler round-trip (see CachedSubtree.Handlers) -----------------------------

--- a/src/Rask.Core/Components/DefaultErrorPage.cs
+++ b/src/Rask.Core/Components/DefaultErrorPage.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using Rask.Core.Live;
 
@@ -270,13 +271,13 @@ public sealed class DefaultErrorPage : Component
 
             var start = Math.Max(1, line - radius);
             var end = Math.Min(lines.Length, line + radius);
-            var width = end.ToString().Length;
+            var width = end.ToString(CultureInfo.InvariantCulture).Length;
 
             var sb = new StringBuilder();
             for (var i = start; i <= end; i++)
             {
                 sb.Append(i == line ? "→ " : "  ")
-                    .Append(i.ToString().PadLeft(width))
+                    .Append(i.ToString(CultureInfo.InvariantCulture).PadLeft(width))
                     .Append(" | ")
                     .Append(lines[i - 1]);
                 if (i < end)

--- a/src/Rask.Core/Components/GestureTrigger.cs
+++ b/src/Rask.Core/Components/GestureTrigger.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.JSInterop;
@@ -174,7 +175,9 @@ public sealed class MediaCaptureTrigger : Component
     // OnResult keeps the "granted"/"denied" vocabulary it always had.
     private async Task Dispatch(string? result)
     {
-        var started = int.TryParse(result, out var streamId);
+        // Invariant: the id is minted by JS and crosses the wire as a JS-formatted integer.
+        var started = int.TryParse(
+            result, NumberStyles.Integer, CultureInfo.InvariantCulture, out var streamId);
 
         if (started && OnStream is not null)
         {

--- a/src/Rask.Core/Forms/ModelGraphWalker.cs
+++ b/src/Rask.Core/Forms/ModelGraphWalker.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Reflection;
 
 namespace Rask.Core.Forms;
@@ -225,14 +226,14 @@ public static class ModelGraphWalker
         var key = seg.Index!;
         if (value is Array arr)
         {
-            return int.TryParse(key, out var idx) && idx >= 0 && idx < arr.Length
+            return TryParseIndex(key, out var idx) && idx >= 0 && idx < arr.Length
                 ? arr.GetValue(idx)
                 : null;
         }
 
         if (value is IList list)
         {
-            return int.TryParse(key, out var idx) && idx >= 0 && idx < list.Count
+            return TryParseIndex(key, out var idx) && idx >= 0 && idx < list.Count
                 ? list[idx]
                 : null;
         }
@@ -244,11 +245,17 @@ public static class ModelGraphWalker
                 return dict[key];
             }
 
-            return int.TryParse(key, out var i) && dict.Contains(i) ? dict[i] : null;
+            return TryParseIndex(key, out var i) && dict.Contains(i) ? dict[i] : null;
         }
 
         return null;
     }
+
+    // A collection index inside a field path ("Items[10].Name") is structure, not a user-facing number:
+    // it is produced by the framework and round-trips through the wire, so it parses invariantly no
+    // matter what culture the render or dispatch is running under.
+    private static bool TryParseIndex(string key, out int index) =>
+        int.TryParse(key, NumberStyles.Integer, CultureInfo.InvariantCulture, out index);
 
     private static List<PathSegment> SplitPath(string path)
     {

--- a/src/Rask.Core/HeadAssets/HeadAssetRegistry.cs
+++ b/src/Rask.Core/HeadAssets/HeadAssetRegistry.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using Rask.Core.Components;
 using Rask.Core.Live;
@@ -374,6 +375,6 @@ internal sealed class HeadAssetRegistry
             hash *= 16777619u;
         }
 
-        return hash.ToString("x8");
+        return hash.ToString("x8", CultureInfo.InvariantCulture);
     }
 }

--- a/src/Rask.Core/Live/EventPayload.cs
+++ b/src/Rask.Core/Live/EventPayload.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 
 namespace Rask.Core.Live;
@@ -28,7 +29,10 @@ internal static class EventPayload
         {
             JsonValueKind.Number when v.TryGetInt32(out var i) => i,
             JsonValueKind.Number => (int)v.GetDouble(),
-            JsonValueKind.String when int.TryParse(v.GetString(), out var i) => i,
+            // Invariant: the client serialises DOM numbers with JS number formatting, which is
+            // invariant. Parsing them under an ambient culture would read "1.5" as 15 in de-DE.
+            JsonValueKind.String when int.TryParse(
+                v.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var i) => i,
             _ => 0
         };
     }
@@ -43,7 +47,9 @@ internal static class EventPayload
         return v.ValueKind switch
         {
             JsonValueKind.Number when v.TryGetDouble(out var d) => d,
-            JsonValueKind.String when double.TryParse(v.GetString(), out var d) => d,
+            // Invariant, for the reason given in ReadInt above — these carry wheel/pointer deltas.
+            JsonValueKind.String when double.TryParse(
+                v.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var d) => d,
             _ => 0
         };
     }

--- a/src/Rask.Core/Live/ScrollEvent.cs
+++ b/src/Rask.Core/Live/ScrollEvent.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 
 namespace Rask.Core.Live;
@@ -28,7 +29,9 @@ public sealed record ScrollEvent(int ScrollTop, int ClientHeight, int ScrollHeig
         {
             JsonValueKind.Number when v.TryGetInt32(out var i) => i,
             JsonValueKind.Number => (int)v.GetDouble(),
-            JsonValueKind.String when int.TryParse(v.GetString(), out var i) => i,
+            // Invariant: scroll offsets cross the wire as JS-formatted numbers.
+            JsonValueKind.String when int.TryParse(
+                v.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var i) => i,
             _ => 0
         };
     }

--- a/src/Rask.Core/ScopedCss/CssScoper.cs
+++ b/src/Rask.Core/ScopedCss/CssScoper.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -19,7 +20,7 @@ internal static class CssScoper
             sb.Append("r-");
             for (var i = 0; i < 4; i++)
             {
-                sb.Append(hash[i].ToString("x2"));
+                sb.Append(hash[i].ToString("x2", CultureInfo.InvariantCulture));
             }
 
             return sb.ToString();

--- a/tests/Rask.Core.Tests/Live/InvariantWireFormatTests.cs
+++ b/tests/Rask.Core.Tests/Live/InvariantWireFormatTests.cs
@@ -1,0 +1,114 @@
+using System.Globalization;
+using System.Text.Json;
+using Rask.Core.Live;
+
+#pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
+
+namespace Rask.Core.Tests.Live;
+
+// Everything Rask puts on the wire — reconciliation keys, DOM event payloads, field-path indices —
+// is culture-neutral by contract, because the two ends are Rask and the browser rather than Rask and
+// a person. These tests run those paths under a deliberately hostile ambient culture so that a change
+// dropping an IFormatProvider fails here rather than in production under a locale nobody develops in.
+//
+// sv-SE and de-DE are chosen for what they break: sv-SE formats a negative number with U+2212 MINUS
+// SIGN instead of '-', and de-DE reads '.' as a group separator, so "1.5" parses as 15.
+//
+// The culture lookups are asserted rather than skipped. A skip here would be indistinguishable from a
+// pass, and these are exactly the assertions that must not quietly stop running; the unit gate runs on
+// the server CLR, where ICU is present. A globalization-invariant runtime fails with the message below.
+public partial class InvariantWireFormatTests : global::Rask.Core.RaskMarkup
+{
+    private static CultureInfo Hostile(string name)
+    {
+        try
+        {
+            var culture = CultureInfo.GetCultureInfo(name);
+            Assert.Equal(name, culture.Name);
+            return culture;
+        }
+        catch (CultureNotFoundException e)
+        {
+            throw new InvalidOperationException(
+                $"'{name}' is unavailable, so this runtime cannot prove invariance. It is running with "
+                + "globalization turned off (InvariantGlobalization / PredefinedCulturesOnly / "
+                + "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT). Run the unit gate on a runtime with ICU.", e);
+        }
+    }
+
+    [Fact]
+    [RestoreCulture]
+    public void KeyString_NegativeIntKey_KeepsAsciiHyphen_UnderSwedish()
+    {
+        CultureInfo.CurrentCulture = Hostile("sv-SE");
+
+        // sv-SE renders -1 as "−1" (U+2212). The key is baked into the HTML the client already holds,
+        // so a culture-dependent spelling breaks keyed reconciliation the moment the culture changes.
+        Assert.Equal("<li data-rask-key=\"-1\"></li>", Li.Key(-1).ToHtml());
+    }
+
+    [Fact]
+    [RestoreCulture]
+    public void KeyString_DecimalAndDateKeys_AreInvariant_UnderGerman()
+    {
+        CultureInfo.CurrentCulture = Hostile("de-DE");
+
+        // de-DE would render 1.5 as "1,5" and the date as "02.01.2026".
+        Assert.Equal("<li data-rask-key=\"1.5\"></li>", Li.Key(1.5m).ToHtml());
+
+        // Note the spelling: IFormattable with a null format gives the INVARIANT short-date pattern
+        // (MM/dd/yyyy), not ISO. A key only has to be stable and unique, not readable, so this is
+        // deliberate — the general IFormattable arm keeps one rule for every formattable key type
+        // rather than special-casing the date types. What matters is that it does not vary by locale.
+        Assert.Equal("<li data-rask-key=\"01/02/2026\"></li>", Li.Key(new DateOnly(2026, 1, 2)).ToHtml());
+    }
+
+    [Fact]
+    [RestoreCulture]
+    public void EventPayload_StringEncodedNumbers_AreReadInvariantly_UnderGerman()
+    {
+        CultureInfo.CurrentCulture = Hostile("de-DE");
+
+        // The client serialises DOM numbers with JS formatting, which is invariant. Read under de-DE
+        // without a provider, "1.5" becomes 15 — a wheel/pointer delta off by a factor of ten.
+        using var doc = JsonDocument.Parse("""{"deltaY":"1.5","clientX":"-3"}""");
+        Assert.Equal(1.5, EventPayload.ReadDouble(doc.RootElement, "deltaY"));
+        Assert.Equal(-3, EventPayload.ReadInt(doc.RootElement, "clientX"));
+    }
+
+    // Unlike the double above, this one is a CONTRACT guard rather than a caught bug, and it is worth
+    // being precise about which: integer parsing turns out to be culture-robust for the shapes the
+    // client actually sends. NumberStyles.Integer admits no group or decimal separator in any culture,
+    // and .NET accepts the ASCII hyphen even where the culture's NegativeSign is U+2212 — so reverting
+    // the fix does not turn this test red. It stays because the invariant parse is the contract for
+    // wire data, and because the sibling double path shows what it costs when that contract lapses.
+    [Fact]
+    [RestoreCulture]
+    public void ScrollEvent_NegativeOffset_IsReadInvariantly_UnderSwedish()
+    {
+        CultureInfo.CurrentCulture = Hostile("sv-SE");
+
+        using var doc = JsonDocument.Parse(
+            """{"scrollTop":"-120","clientHeight":"600","scrollHeight":"2400"}""");
+        var scroll = ScrollEvent.FromJson(doc.RootElement);
+
+        Assert.Equal(-120, scroll.ScrollTop);
+        Assert.Equal(600, scroll.ClientHeight);
+        Assert.Equal(2400, scroll.ScrollHeight);
+    }
+
+    [Fact]
+    [RestoreCulture]
+    public void ScopeId_IsStable_UnderHostileCulture()
+    {
+        // A scope id is baked into scoped-CSS class names at build time (BakeScopedAssetsTask invokes
+        // this very method by reflection) and recomputed at runtime. The two must agree byte-for-byte
+        // on any machine, under any locale, or scoped CSS silently stops matching.
+        var before = global::Rask.Core.ScopedCss.CssScoper.ScopeIdFor(typeof(InvariantWireFormatTests));
+
+        CultureInfo.CurrentCulture = Hostile("sv-SE");
+        var after = global::Rask.Core.ScopedCss.CssScoper.ScopeIdFor(typeof(InvariantWireFormatTests));
+
+        Assert.Equal(before, after);
+    }
+}

--- a/tests/Rask.Core.Tests/RestoreCultureAttribute.cs
+++ b/tests/Rask.Core.Tests/RestoreCultureAttribute.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace Rask.Core.Tests;
+
+/// <summary>
+///     Restores <see cref="CultureInfo.CurrentCulture" /> and <see cref="CultureInfo.CurrentUICulture" />
+///     around a test that deliberately runs under a hostile culture.
+/// </summary>
+/// <remarks>
+///     Not applied assembly-wide, unlike <see cref="ResetLiveSyncContextAttribute" />: only the handful of
+///     tests that assert invariance need it, and paying two AsyncLocal writes on every test would be
+///     noise. It exists for the same underlying reason though — xUnit reuses pooled threads, and since
+///     .NET Core the current culture rides <c>ExecutionContext</c>, so a culture assigned by one test can
+///     surface in the next one on that thread and make an unrelated assertion fail somewhere else
+///     entirely. Restoring in <see cref="After" /> keeps that leak inside the test that opted in.
+/// </remarks>
+public sealed class RestoreCultureAttribute : BeforeAfterTestAttribute
+{
+    private CultureInfo? _culture;
+    private CultureInfo? _uiCulture;
+
+    public override void Before(MethodInfo methodUnderTest)
+    {
+        _culture = CultureInfo.CurrentCulture;
+        _uiCulture = CultureInfo.CurrentUICulture;
+    }
+
+    public override void After(MethodInfo methodUnderTest)
+    {
+        if (_culture is not null)
+        {
+            CultureInfo.CurrentCulture = _culture;
+        }
+
+        if (_uiCulture is not null)
+        {
+            CultureInfo.CurrentUICulture = _uiCulture;
+        }
+    }
+}


### PR DESCRIPTION
First step of the global culture / localization epic, and useful on its own: it fixes a live bug and
makes the rest of that work safe to land.

Rask has no culture concept today, so every string↔value conversion on the wire silently inherited the
machine's locale. That is invisible on a developer box in `en-US`. It is also a landmine for per-user
culture, which will deliberately put a **non**-invariant culture on the render thread — arming all of
these at once. Pinning them first means the culture PRs cannot regress the wire.

## The live bug

`EventPayload.ReadDouble` parsed string-encoded DOM numbers with no format provider. The client
serialises them with JS number formatting, which is invariant, so under `de-DE` a `"1.5"` wheel or
pointer delta parsed as **15** — a scroll/gesture delta ten times too large.

## The latent one

`Component.KeyString` stringified a non-string `Key` with a bare `ToString()`. Under `sv-SE` a negative
`int` key rendered with U+2212 MINUS SIGN rather than `-`, and a `decimal`/`DateTime` key re-spelled
entirely. The key is baked into `data-rask-key` in the HTML the client already holds, so the mismatch
breaks keyed reconciliation **exactly** when the culture changes. `int`/`long`/`Guid` get direct arms
and `IFormattable` covers the rest; the `null` short-circuit is preserved, so non-keyed nodes still
allocate nothing.

## Identities that are not numbers

Turning on CA1305 surfaced five more sites, all of which are identities rather than displayed values:

- `CssScoper.ScopeIdFor` — the scoped-CSS scope id is baked into class names at build time and
  recomputed at runtime. `BakeScopedAssetsTask` invokes this method by reflection rather than
  reimplementing it, so the two cannot desync — but the id itself must not depend on a locale.
- `HeadAssetRegistry.ContentHash` — an asset cache key.
- `Component.CreateLargeHandlerId` — handler ids the client echoes back verbatim.
- `DefaultErrorPage`'s source-excerpt gutter — line numbers are positions in a file.

`ScrollEvent`, `GestureTrigger` and `ModelGraphWalker`'s collection indices are pinned as contract
rather than as caught bugs: integer parsing turns out to be culture-robust for the shapes the client
actually sends, and the test says so out loud instead of implying a fix it did not make.

## CA1305, scoped

Promoted to an error for `src/Rask.Core/**` via a single `.editorconfig` severity line — deliberately
**not** an `AnalysisLevel` bump, which `Directory.Build.props` notes would surface ~33 unrelated
findings. `EnableNETAnalyzers` + `TreatWarningsAsErrors` are already on, so one line activates the rule
alone. This is what stops the next unqualified `ToString`/`TryParse` from reaching the wire. The
`Directory.Build.props` comment is updated to record the promotion.

## Testing

`scripts/run-unit-local.sh` green (format + `-warnaserror` Release build + tests), and the pre-push
browser E2E gate green.

New `tests/Rask.Core.Tests/Live/InvariantWireFormatTests.cs` runs the affected paths under `sv-SE` and
`de-DE`. **Three of the five were confirmed to go red with the fixes reverted** — the two that do not
are labelled in-code as contract guards, with the reason they cannot fail, so nobody later mistakes
them for proof.

The culture lookups assert rather than skip: a skip here is indistinguishable from a pass, and these
are exactly the assertions that must not quietly stop running. A globalization-invariant runtime fails
with a message naming the cause.

`RestoreCultureAttribute` restores `CurrentCulture`/`CurrentUICulture` around the opted-in tests —
xUnit reuses pooled threads and the current culture rides `ExecutionContext`, so a leak would surface
as an unrelated failure elsewhere. Same reasoning as the existing `ResetLiveSyncContextAttribute`.

## Benchmarks

`FrameDifferBenchmarks` (the keyed-diff path, which is where `KeyString` lives), parent commit vs this
change, 27 benchmarks across 100/1000/5000 rows:

**`Allocated` delta: 0 B on every benchmark.**

Mean moves ±17% in both directions on identical work — the 124 ns `RawGuidePage` case reads −0.3% at
100 rows and +17.5% at 5000, where it does the same thing — so the timing spread is box noise, not
signal. `payload-bytes.csv` is untouched: this changes neither render content nor the diff codec.
