### PR TITLE
feat(core): give every session its own culture, fetched per render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,55 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **A visitor's culture, owned by their session.** `IRaskCulture` reports the culture to format with,
+  the language to render text in, the app's supported languages, and whether the script runs
+  right-to-left; `SetAsync` switches it, persists the choice and repaints. Components read
+  `Culture` / `UICulture` / `IsRightToLeft`; code that is not a component reads `RaskCulture.Current`.
+  Configure with `AddRask(configureCulture: c => c.SupportedCultures.Add("hu"))`.
+
+  **Off until an app names a language, and byte-identical until then.** With no supported cultures
+  the render walk never resolves a culture service, `<html lang>` stays exactly `"en"`, and no `dir`
+  attribute is emitted at all — so an app that never asked for localization renders the same bytes it
+  did before. `lang` reports the negotiated language rather than the machine's locale precisely so
+  that turning the feature *off* cannot silently change `lang="en"` into `lang="en-US"`.
+
+  **The culture is fetched per render, never propagated.** `LifecycleSyncContext` deliberately calls
+  `ExecutionContext.SuppressFlow()` so a continuation cannot inherit `InHandlerScope` — and since .NET
+  Core, `CultureInfo.CurrentCulture` lives in an `AsyncLocal` riding that same `ExecutionContext`. Any
+  design where the culture had to *flow* to the render thread would lose it exactly there, ambient
+  culture and a hand-rolled `AsyncLocal` alike. So `LiveRenderContext` asks the session for the
+  culture at the top of every walk, which nothing can interrupt. A test renders inside a genuinely
+  suppressed flow, with a negative control proving the suppression is real.
+
+  **Reading the culture opts a component out of the render cache, and the reader cannot forget to.**
+  The marking lives inside the accessor, not at the call site. A language switch additionally dirties
+  the whole tree, which covers components that format through `CultureInfo.CurrentCulture` directly
+  and are therefore invisible to that marking. Rask also pins the ambient culture for the duration of
+  a render and a handler dispatch, because some culture-sensitive code has no seam to route through —
+  `BsDataGrid`'s sort reaches `Comparer<T>.Default` and a linguistic string comparison.
+
+  **Negotiation is `?culture=` → cookie → `Accept-Language` → the app's default**, and **URLs stay
+  culture-neutral**: one link is the same page for everyone, and the router, the generated
+  `Url()`/`Go()` helpers and every route value are untouched. The cookie is ASP.NET's own
+  `.AspNetCore.Culture`, in ASP.NET's own format, so an app sharing a host with MVC — or one that also
+  calls `UseRequestLocalization()` — agrees with it rather than holding a second, conflicting
+  preference.
+
+  **A runtime without ICU degrades instead of throwing.** Under `InvariantGlobalization` — still the
+  WASM default — `PredefinedCulturesOnly` is on and `new CultureInfo("hu-HU")` *throws* rather than
+  falling back. Every lookup goes through `RaskCultureResolver`, which answers `false` instead, so an
+  app that asked for languages this runtime cannot produce still renders; it reports the reason once,
+  naming `RaskGlobalization`, rather than once per render.
+
+### Changed
+- **The Bootstrap date and time pickers follow the visitor's culture instead of the server's.**
+  `BsPickerBase` read `CultureInfo.CurrentCulture` for month names, weekday names and
+  first-day-of-week — but nothing in Rask ever *set* it, so on a server every visitor got the
+  **server process** locale. It now inherits `Component.Culture`, which is the session's; the shadowing
+  member is gone, and the compiler found every call site. With culture support off the behaviour is
+  unchanged.
+
+### Removed
 
 - **Non-overlapping range constraints, declared on the model.** A booking, a lease, a price valid for a
   period — the rule is always "two rows may not cover the same point", and SQLite has no way to say it:

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -296,7 +296,7 @@ protected override Component? Render() => Router;
 ```
 
 **Fix:** return the body's content (usually `Router()`) and move the shell's pieces to the overrides
-that own them — `<head>` content to `Head`, `<html lang>` to `HtmlLang`, `<body class>` to `BodyClass`,
+that own them — `<head>` content to `Head`, `<html lang>` to `HtmlLang`, `<html dir>` to `HtmlDir`, `<body class>` to `BodyClass`,
 and a genuinely custom document to `Shell(head, body)`, which receives the framework's `<head>` and the
 rendered body as parameters. Do **not** add a runtime `<script>`; it's auto-appended to `<body>`.
 `Doctype`/`Html`/`Head`/`Body` stay ordinary tag components for documents you build by hand

--- a/src/Rask.Bootstrap/BsPickerBase.cs
+++ b/src/Rask.Bootstrap/BsPickerBase.cs
@@ -81,10 +81,13 @@ public abstract partial class BsPickerBase<T> : BsFormControl<T>
             ? Nullable.GetUnderlyingType(acc.PropertyType) ?? acc.PropertyType
             : Underlying;
 
-    // Display/parse culture. CurrentCulture drives month/weekday names and first-day-of-week; the bound
-    // value still round-trips invariant ISO because we write the typed value, never a formatted string.
-    private protected static System.Globalization.CultureInfo Culture =>
-        System.Globalization.CultureInfo.CurrentCulture;
+    // Display/parse culture: month and weekday names, and first-day-of-week. The bound value still
+    // round-trips invariant ISO, because a picker writes the typed value and never a formatted string.
+    //
+    // Inherited from Component now rather than declared here. That is the whole point of the change:
+    // this used to read CultureInfo.CurrentCulture, which on a server is the process locale — so every
+    // visitor of a multi-user app got the SERVER's month names. Component.Culture is the session's, and
+    // reading it also marks the picker as culture-dependent so a language switch repaints it.
 
     // The native-input fallback for Native:true — the SAME core <input> BsInput renders (a
     // type=date|time|datetime-local bound to a string round-tripped by FormatValue/StringChangeHandler),

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -525,12 +525,32 @@ public abstract partial class Component : RaskMarkup
     internal Component? CachedHeadInternal => _live?.CachedHead;
     internal void MarkReadsAmbientStateInternal() => SetFlag(FlagReadsAmbientState, true);
 
+    // Test seam: whether this component read something the render cache cannot see (context,
+    // edit context, culture). Paired with the setter above so a test can assert the marking
+    // happened without reaching into the flag bits.
+    internal bool ReadsAmbientStateInternal => _readsAmbientState;
+
     /// <summary>
     ///     The <c>lang</c> attribute for the document's <c>&lt;html&gt;</c> element. Read off the root
     ///     component only — Rask builds the shell around whatever the root renders. Return <c>null</c> to
     ///     emit no <c>lang</c> at all.
     /// </summary>
-    protected virtual string? HtmlLang => "en";
+    /// <remarks>
+    ///     Follows the session's language once the app configures cultures, and is otherwise exactly
+    ///     <c>"en"</c> as before. The fallback is literal rather than "whatever the machine's locale
+    ///     says" on purpose: reporting the ambient culture would turn <c>lang="en"</c> into
+    ///     <c>lang="en-US"</c> on any US-locale machine and change the HTML of every app that never
+    ///     asked for localization.
+    /// </remarks>
+    protected virtual string? HtmlLang => Globalization.RaskCulture.HtmlLang ?? "en";
+
+    /// <summary>
+    ///     The <c>dir</c> attribute for the document's <c>&lt;html&gt;</c> element. Defaults to
+    ///     <c>"rtl"</c> for a right-to-left session culture and <c>null</c> otherwise, which emits no
+    ///     attribute at all — left-to-right is HTML's own default, so writing it would only add bytes
+    ///     to every page.
+    /// </summary>
+    protected virtual string? HtmlDir => Globalization.RaskCulture.HtmlDir;
 
     /// <summary>
     ///     The <c>class</c> attribute for the document's <c>&lt;body&gt;</c> element (theming hooks,
@@ -563,7 +583,7 @@ public abstract partial class Component : RaskMarkup
     ///     </para>
     /// </summary>
     protected virtual Component Shell(Component head, Component body) =>
-        Html.Lang(HtmlLang)[head, Body.Class(BodyClass)[body]];
+        Html.Lang(HtmlLang).Dir(HtmlDir)[head, Body.Class(BodyClass)[body]];
 
     // The host's entry into the escape hatch above: RootErrorBoundary composes the document around the
     // App, so it needs to reach the App's override. Kept internal because Shell is a user-facing
@@ -576,6 +596,24 @@ public abstract partial class Component : RaskMarkup
     ///     <see cref="IsServer" /> / <see cref="IsWasm" />.
     /// </summary>
     protected RenderEngine HostEngine => LiveRenderContext.CurrentSync?.Engine ?? RenderEngine.Server;
+
+    /// <summary>
+    ///     The culture to format dates, numbers and currency with for the visitor rendering this
+    ///     component.
+    /// </summary>
+    /// <remarks>
+    ///     Unlike <see cref="HostEngine" />, which is fixed for the session, culture can change while the
+    ///     app is running — so reading it marks this component as depending on ambient state, which opts
+    ///     its subtree out of the clean-subtree render cache. Without that, switching language would
+    ///     leave cached subtrees on screen still rendered in the old one.
+    /// </remarks>
+    protected System.Globalization.CultureInfo Culture => Globalization.RaskCulture.Current;
+
+    /// <summary>The language to render this component's text in. Marks ambient state, as <see cref="Culture" /> does.</summary>
+    protected System.Globalization.CultureInfo UICulture => Globalization.RaskCulture.CurrentUI;
+
+    /// <summary>Whether the visitor's language is written right-to-left. Marks ambient state.</summary>
+    protected bool IsRightToLeft => Globalization.RaskCulture.IsRightToLeft;
 
     /// <summary><c>true</c> when rendered server-side over a live connection (<see cref="RenderEngine.Server" />).</summary>
     protected bool IsServer => HostEngine == RenderEngine.Server;
@@ -1922,6 +1960,11 @@ public abstract partial class Component : RaskMarkup
 
         using var __dispatchScope = DispatchServicesScope.Push(services);
 
+        // A handler runs outside any render walk, so there is no LiveRenderContext to read the culture
+        // from — push it here, from the same service provider, so code the handler calls formats and
+        // parses in the visitor's culture rather than the machine's.
+        using var __cultureScope = Globalization.RaskCultureScope.PushFrom(services);
+
         // When the host supplied a cancellable dispatch token (a handler timeout is configured), make
         // owner.CancellationToken observe it during this handler by publishing a token linked with the
         // owner's lifetime token. With no timeout we push nothing — CancellationToken then resolves to
@@ -2404,7 +2447,7 @@ public abstract partial class Component : RaskMarkup
     // render re-executes each Render() — including cached subtrees — against the freshly-applied IL. A
     // component with no LiveState has never rendered (no cache to bust), so it's skipped. Called from
     // LiveSessionBase.RerenderAllForHotReload under `dotnet watch`; best-effort (the caller swallows).
-    internal static void MarkSubtreeDirtyForHotReload(Component root)
+    internal static void MarkSubtreeDirtyInternal(Component root)
     {
         var seen = new HashSet<Component>();
         Visit(root, seen);

--- a/src/Rask.Core/Globalization/CookieCulturePersistence.cs
+++ b/src/Rask.Core/Globalization/CookieCulturePersistence.cs
@@ -1,0 +1,48 @@
+using Rask.Core.Browser;
+
+namespace Rask.Core.Globalization;
+
+/// <summary>
+///     Remembers the chosen culture in a cookie, written through the browser.
+/// </summary>
+/// <remarks>
+///     Uses <see cref="ICookies" />, so it works identically on the server (the write rides the live
+///     socket with the next render payload) and in WASM (it happens in-process). One consequence worth
+///     knowing: because this goes through <c>document.cookie</c>, the new value reaches the
+///     <em>server</em> only on the next HTTP request. That is not a gap — the session switched the
+///     moment <see cref="IRaskCulture.SetAsync(string)" /> returned, and the cookie exists to survive a
+///     reload, not to carry the current render.
+/// </remarks>
+public sealed class CookieCulturePersistence(ICookies cookies, RaskCultureOptions options)
+    : IRaskCulturePersistence
+{
+    /// <inheritdoc />
+    public Task SaveAsync(string culture, string uiCulture, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var value = RaskCultureCookie.Format(culture, uiCulture);
+        return cookies.SetAsync(
+            options.CookieName,
+            value,
+            new CookieOptions
+            {
+                MaxAgeSeconds = options.CookieMaxAgeDays * 24 * 60 * 60,
+                Path = "/",
+                // Lax, not Strict: a visitor following a link into the app from anywhere else should
+                // still arrive in their own language. The value is a language tag, never a credential.
+                SameSite = SameSiteMode.Lax,
+            }).AsTask();
+    }
+}
+
+/// <summary>
+///     Remembers nothing. The default where there is nowhere to write, and what an app gets when it
+///     turns <see cref="RaskCultureOptions.UseCookie" /> off.
+/// </summary>
+public sealed class NullCulturePersistence : IRaskCulturePersistence
+{
+    /// <inheritdoc />
+    public Task SaveAsync(string culture, string uiCulture, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+}

--- a/src/Rask.Core/Globalization/IRaskCulture.cs
+++ b/src/Rask.Core/Globalization/IRaskCulture.cs
@@ -1,0 +1,57 @@
+using System.Globalization;
+
+namespace Rask.Core.Globalization;
+
+/// <summary>
+///     The visitor's culture for this session: what to format with, what language to render text in, and
+///     how to change it.
+/// </summary>
+/// <remarks>
+///     Registered by every host, whether or not the app configured any languages — an app that never
+///     asked gets an instance reporting no supported cultures, so a component can take this in its
+///     constructor without knowing which it is. Inject it to <em>change</em> the culture; to
+///     <em>read</em> one while rendering, prefer <c>Component.Culture</c>, which also tells the render
+///     cache that the component depends on it.
+/// </remarks>
+public interface IRaskCulture
+{
+    /// <summary>The culture dates, numbers and currency are formatted with.</summary>
+    CultureInfo Culture { get; }
+
+    /// <summary>The language UI text is rendered in. Usually the same as <see cref="Culture" />.</summary>
+    CultureInfo UICulture { get; }
+
+    /// <summary>The languages this app ships. Empty when culture support is off.</summary>
+    IReadOnlyList<CultureInfo> Supported { get; }
+
+    /// <summary>Whether the current culture is written right-to-left.</summary>
+    bool IsRightToLeft { get; }
+
+    /// <summary>Raised after the culture changes, so the session can re-render.</summary>
+    event Action? Changed;
+
+    /// <summary>
+    ///     Switches to <paramref name="culture" /> if the app supports it, persists the choice, and
+    ///     triggers a re-render. A culture that is not supported — or a runtime with no culture data —
+    ///     leaves the session unchanged rather than throwing.
+    /// </summary>
+    /// <returns>Whether the culture changed.</returns>
+    Task<bool> SetAsync(CultureInfo culture);
+
+    /// <summary>
+    ///     Switches to the named culture. Convenience for the common call site — a switcher bound to a
+    ///     tag from markup or a query string — forwarding to <see cref="SetAsync(CultureInfo)" />.
+    /// </summary>
+    /// <returns>Whether the culture changed.</returns>
+    Task<bool> SetAsync(string name);
+}
+
+/// <summary>
+///     Where an explicit culture choice is stored between visits. Implemented per host: a cookie on the
+///     web, nothing at all where there is nowhere to write.
+/// </summary>
+public interface IRaskCulturePersistence
+{
+    /// <summary>Stores the chosen culture.</summary>
+    Task SaveAsync(string culture, string uiCulture, CancellationToken cancellationToken = default);
+}

--- a/src/Rask.Core/Globalization/RaskCulture.cs
+++ b/src/Rask.Core/Globalization/RaskCulture.cs
@@ -1,0 +1,151 @@
+using System.Globalization;
+using Rask.Core.Live;
+
+namespace Rask.Core.Globalization;
+
+/// <summary>
+///     The culture in effect right now, for code that is not a component — a helper, a formatter, a
+///     library type like <c>Rask.Bootstrap</c>'s pickers.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Reading <see cref="Current" /> marks the component being rendered as depending on the
+///         culture</b>, which permanently opts it out of the clean-subtree render cache. That is the
+///         point of routing every read through here rather than letting callers touch
+///         <c>CultureInfo.CurrentCulture</c>: the marking cannot be forgotten, because it happens inside
+///         the only accessor. Without it, switching language would leave cached subtrees on screen still
+///         rendered in the old one. Same contract as <c>Context.Get</c> and <c>EditContext</c>.
+///     </para>
+///     <para>
+///         <b>Outside a render walk or a handler dispatch, the current culture is undefined for Rask
+///         purposes</b> and this falls back to the thread's. That is not an oversight: the session, not
+///         the thread, owns the culture, and there is no session to ask from a background timer.
+///     </para>
+/// </remarks>
+public static class RaskCulture
+{
+    /// <summary>
+    ///     Whether any host has configured languages. A pure fast path — when false, the render walk
+    ///     never resolves a culture service and every accessor here is a thread-culture read.
+    /// </summary>
+    /// <remarks>
+    ///     Process-wide rather than per-host, which the repo normally avoids. It is safe precisely
+    ///     because it is not a source of truth: it only decides whether to <em>look</em> for one. Two
+    ///     hosts in one process take the union — both then pay a lookup, and neither can read the
+    ///     other's culture, because the value itself always comes from the session.
+    /// </remarks>
+    public static bool IsEnabled { get; internal set; }
+
+    /// <summary>
+    ///     The culture to format with, and a declaration that the calling component depends on it.
+    /// </summary>
+    public static CultureInfo Current
+    {
+        get
+        {
+            if (!IsEnabled)
+            {
+                return CultureInfo.CurrentCulture;
+            }
+
+            var ctx = LiveRenderContext.CurrentSync;
+            if (ctx is not null)
+            {
+                ctx.MarkCurrentReadsAmbientState();
+                return ctx.Culture;
+            }
+
+            if (RaskCultureScope.Current is { } scope)
+            {
+                return scope.Culture;
+            }
+
+            // An async continuation inside a render: the ThreadStatic mirror is gone but the
+            // AsyncLocal context is not. No marking here — the walk that could act on it has ended.
+            return LiveRenderContext.Current?.Culture ?? CultureInfo.CurrentCulture;
+        }
+    }
+
+    /// <summary>The language to render text in, and a declaration that the caller depends on it.</summary>
+    public static CultureInfo CurrentUI
+    {
+        get
+        {
+            if (!IsEnabled)
+            {
+                return CultureInfo.CurrentUICulture;
+            }
+
+            var ctx = LiveRenderContext.CurrentSync;
+            if (ctx is not null)
+            {
+                ctx.MarkCurrentReadsAmbientState();
+                return ctx.UICulture;
+            }
+
+            if (RaskCultureScope.Current is { } scope)
+            {
+                return scope.UICulture;
+            }
+
+            return LiveRenderContext.Current?.UICulture ?? CultureInfo.CurrentUICulture;
+        }
+    }
+
+    /// <summary>Whether the current culture is written right-to-left.</summary>
+    public static bool IsRightToLeft => Current.TextInfo.IsRightToLeft;
+
+    /// <summary>
+    ///     The value for <c>&lt;html lang&gt;</c>, or <c>null</c> when culture support is off so the
+    ///     document keeps its existing default.
+    /// </summary>
+    /// <remarks>
+    ///     Returning <c>null</c> rather than the negotiated name when nothing is configured is what keeps
+    ///     every existing app's HTML byte-for-byte identical: otherwise <c>lang="en"</c> would silently
+    ///     become <c>lang="en-US"</c> on any US-locale machine and churn every golden file and E2E
+    ///     assertion in the repo.
+    /// </remarks>
+    public static string? HtmlLang
+    {
+        get
+        {
+            if (!IsEnabled)
+            {
+                return null;
+            }
+
+            var name = CurrentUI.Name;
+            return name.Length == 0 ? null : name;
+        }
+    }
+
+    /// <summary>
+    ///     <c>"rtl"</c> for a right-to-left culture, otherwise <c>null</c> so no <c>dir</c> attribute is
+    ///     emitted at all — left-to-right is the HTML default, and emitting it would change every
+    ///     existing page.
+    /// </summary>
+    public static string? HtmlDir => IsEnabled && IsRightToLeft ? "rtl" : null;
+
+    /// <summary>
+    ///     The current culture <em>without</em> marking the caller as culture-dependent, for framework
+    ///     internals that must not latch the render cache.
+    /// </summary>
+    internal static CultureInfo CurrentUnmarked
+    {
+        get
+        {
+            if (!IsEnabled)
+            {
+                return CultureInfo.CurrentCulture;
+            }
+
+            return LiveRenderContext.CurrentSync?.Culture
+                   ?? RaskCultureScope.Current?.Culture
+                   ?? LiveRenderContext.Current?.Culture
+                   ?? CultureInfo.CurrentCulture;
+        }
+    }
+
+    /// <summary>Test-only: returns the process to the "no app configured a culture" state.</summary>
+    internal static void ResetForTests() => IsEnabled = false;
+}

--- a/src/Rask.Core/Globalization/RaskCultureCookie.cs
+++ b/src/Rask.Core/Globalization/RaskCultureCookie.cs
@@ -1,0 +1,71 @@
+using System.Globalization;
+
+namespace Rask.Core.Globalization;
+
+/// <summary>
+///     Reads and writes ASP.NET's culture-cookie payload, <c>c=hu-HU|uic=hu-HU</c>.
+/// </summary>
+/// <remarks>
+///     Hand-written rather than taken from <c>Microsoft.AspNetCore.Localization</c>: this lives in
+///     <c>Rask.Core</c>, which has no ASP.NET dependency and also runs in the browser. The format is
+///     reproduced exactly so that a Rask app sitting beside MVC — or one that also calls
+///     <c>UseRequestLocalization()</c> — reads and writes the same preference rather than a second,
+///     disagreeing one. See <see cref="RaskCultureOptions.CookieName" />.
+/// </remarks>
+public static class RaskCultureCookie
+{
+    private const string CulturePrefix = "c=";
+    private const string UICulturePrefix = "uic=";
+
+    /// <summary>Formats a cookie value for the given cultures.</summary>
+    public static string Format(string culture, string? uiCulture = null) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"{CulturePrefix}{culture}|{UICulturePrefix}{uiCulture ?? culture}");
+
+    /// <summary>
+    ///     Parses a cookie value. Tolerates a bare tag (<c>"hu-HU"</c>) as well as the paired form, and
+    ///     answers <c>false</c> for anything it cannot read rather than throwing — a malformed cookie is
+    ///     a visitor with a stale or hand-edited browser, not a server error.
+    /// </summary>
+    public static bool TryParse(string? value, out string culture, out string uiCulture)
+    {
+        culture = string.Empty;
+        uiCulture = string.Empty;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        foreach (var range in value.AsSpan().Split('|'))
+        {
+            var part = value.AsSpan()[range].Trim();
+            if (part.StartsWith(CulturePrefix, StringComparison.Ordinal))
+            {
+                culture = part[CulturePrefix.Length..].ToString();
+            }
+            else if (part.StartsWith(UICulturePrefix, StringComparison.Ordinal))
+            {
+                uiCulture = part[UICulturePrefix.Length..].ToString();
+            }
+            else if (culture.Length == 0 && !part.IsEmpty && !part.Contains('='))
+            {
+                // A bare tag, which is what a hand-set cookie usually contains. Whether it names a real
+                // culture is RaskCultureResolver's question, not this parser's.
+                culture = part.ToString();
+            }
+        }
+
+        if (culture.Length == 0)
+        {
+            culture = uiCulture;
+        }
+
+        if (uiCulture.Length == 0)
+        {
+            uiCulture = culture;
+        }
+
+        return culture.Length > 0;
+    }
+}

--- a/src/Rask.Core/Globalization/RaskCultureNegotiator.cs
+++ b/src/Rask.Core/Globalization/RaskCultureNegotiator.cs
@@ -1,0 +1,194 @@
+using System.Globalization;
+
+namespace Rask.Core.Globalization;
+
+/// <summary>Where a negotiated culture came from.</summary>
+public enum CultureSource
+{
+    /// <summary>Nothing matched; the configured default was used.</summary>
+    Default,
+
+    /// <summary>The visitor's own preference (<c>Accept-Language</c> / <c>navigator.languages</c>).</summary>
+    Client,
+
+    /// <summary>A remembered explicit choice.</summary>
+    Cookie,
+
+    /// <summary>An explicit override in the URL.</summary>
+    Query,
+}
+
+/// <summary>The outcome of negotiation: which cultures to use, and what decided it.</summary>
+public readonly record struct CultureNegotiation(
+    CultureInfo Culture,
+    CultureInfo UICulture,
+    CultureSource Source);
+
+/// <summary>
+///     Chooses a visitor's culture from the signals a host can offer. Pure, and free of host types, so
+///     the decision is unit-testable without a server or a browser.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Order: <b>URL → cookie → client preference → default</b>. An explicit act beats a remembered
+///         one, which beats an inferred one. Nothing here inspects the route: <b>Rask keeps culture out
+///         of the URL path</b>, so one link is the same page for everyone and the router, the generated
+///         <c>Url()</c>/<c>Go()</c> helpers, and every route value stay culture-neutral.
+///     </para>
+///     <para>
+///         Matching walks <see cref="CultureInfo.Parent" /> (<c>hu-HU</c> → <c>hu</c>) and will also
+///         accept a sibling region — <c>hu</c> matches a supported <c>hu-HU</c> — because a visitor
+///         asking for a language the app has in another region wants that language, not English.
+///     </para>
+/// </remarks>
+public static class RaskCultureNegotiator
+{
+    /// <summary>Runs the negotiation described on this type.</summary>
+    /// <param name="queryValue">The <c>?culture=</c> value, or <c>null</c>.</param>
+    /// <param name="cookieValue">The raw culture cookie, or <c>null</c>.</param>
+    /// <param name="clientPreferences">The visitor's languages, most-preferred first.</param>
+    /// <param name="options">The app's configured languages.</param>
+    public static CultureNegotiation Negotiate(
+        string? queryValue,
+        string? cookieValue,
+        IReadOnlyList<string>? clientPreferences,
+        RaskCultureOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        // No configured languages means culture support is off; the caller should not have asked, but
+        // answering with the invariant culture is the only honest result.
+        if (options.SupportedCultures.Count == 0)
+        {
+            return new CultureNegotiation(
+                CultureInfo.InvariantCulture, CultureInfo.InvariantCulture, CultureSource.Default);
+        }
+
+        if (options.UseQueryString && TrySelect(queryValue, options, out var fromQuery))
+        {
+            return fromQuery with { Source = CultureSource.Query };
+        }
+
+        if (options.UseCookie
+            && RaskCultureCookie.TryParse(cookieValue, out var cookieCulture, out var cookieUI)
+            && TrySelect(cookieCulture, options, out var fromCookie))
+        {
+            return fromCookie with
+            {
+                UICulture = Match(cookieUI, options.SupportedUICultures) ?? fromCookie.UICulture,
+                Source = CultureSource.Cookie,
+            };
+        }
+
+        if (options.UseClientPreference && clientPreferences is { Count: > 0 })
+        {
+            foreach (var candidate in clientPreferences)
+            {
+                if (TrySelect(candidate, options, out var fromClient))
+                {
+                    return fromClient with { Source = CultureSource.Client };
+                }
+            }
+        }
+
+        var defaultName = options.DefaultCulture ?? options.SupportedCultures[0];
+        var culture = RaskCultureResolver.TryResolve(defaultName, out var resolved)
+            ? resolved
+            : CultureInfo.InvariantCulture;
+
+        return new CultureNegotiation(
+            culture,
+            Match(defaultName, options.SupportedUICultures) ?? culture,
+            CultureSource.Default);
+    }
+
+    /// <summary>
+    ///     Matches one requested tag against the app's languages, ignoring where it came from.
+    /// </summary>
+    /// <remarks>
+    ///     Separate from <see cref="Negotiate" /> because an explicit switch is not a negotiation: when a
+    ///     visitor picks a language from a menu, <see cref="RaskCultureOptions.UseQueryString" /> and the
+    ///     cookie settings decide how the choice is <em>carried</em>, never whether it is honoured.
+    ///     Routing a switch through the query branch would have made <c>UseQueryString = false</c>
+    ///     silently disable the culture switcher.
+    /// </remarks>
+    public static bool TrySelect(string? requested, RaskCultureOptions options, out CultureNegotiation selection)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        selection = default;
+        if (Match(requested, options.SupportedCultures) is not { } culture)
+        {
+            return false;
+        }
+
+        selection = new CultureNegotiation(
+            culture,
+            Match(requested, options.SupportedUICultures) ?? culture,
+            CultureSource.Query);
+        return true;
+    }
+
+    /// <summary>
+    ///     The supported culture that best serves <paramref name="requested" />, or <c>null</c>.
+    /// </summary>
+    /// <remarks>
+    ///     Two passes. The first walks the request's own parent chain, so <c>hu-HU</c> is served by a
+    ///     supported <c>hu-HU</c> and then by a supported <c>hu</c>. The second compares the neutral
+    ///     language of each side, so a request for <c>hu</c> is served by a supported <c>hu-HU</c> —
+    ///     the app has the language, just in a region the visitor did not name.
+    /// </remarks>
+    private static CultureInfo? Match(string? requested, IList<string>? supported)
+    {
+        if (supported is null || supported.Count == 0 || !RaskCultureResolver.TryResolve(requested, out var wanted))
+        {
+            return null;
+        }
+
+        for (var candidate = wanted; !candidate.Equals(CultureInfo.InvariantCulture); candidate = candidate.Parent)
+        {
+            foreach (var name in supported)
+            {
+                if (string.Equals(name, candidate.Name, StringComparison.OrdinalIgnoreCase)
+                    && RaskCultureResolver.TryResolve(name, out var exact))
+                {
+                    return exact;
+                }
+            }
+
+            // Parent of a neutral culture is the invariant culture, which ends the walk.
+            if (candidate.Parent.Equals(candidate))
+            {
+                break;
+            }
+        }
+
+        var wantedNeutral = Neutral(wanted);
+        foreach (var name in supported)
+        {
+            if (RaskCultureResolver.TryResolve(name, out var supportedCulture)
+                && string.Equals(
+                    Neutral(supportedCulture).Name, wantedNeutral.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                return supportedCulture;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>The neutral (language-only) culture behind a specific one: <c>hu-HU</c> → <c>hu</c>.</summary>
+    private static CultureInfo Neutral(CultureInfo culture)
+    {
+        var current = culture;
+        while (!current.IsNeutralCulture
+               && !current.Equals(CultureInfo.InvariantCulture)
+               && !current.Parent.Equals(current)
+               && !current.Parent.Equals(CultureInfo.InvariantCulture))
+        {
+            current = current.Parent;
+        }
+
+        return current;
+    }
+}

--- a/src/Rask.Core/Globalization/RaskCultureOptions.cs
+++ b/src/Rask.Core/Globalization/RaskCultureOptions.cs
@@ -1,0 +1,85 @@
+namespace Rask.Core.Globalization;
+
+/// <summary>
+///     The app's languages, and how a visitor's is chosen. Configured through <c>AddRaskCulture</c> on
+///     the server or <c>UseCulture</c> on WASM.
+/// </summary>
+/// <remarks>
+///     Culture support is <b>off until <see cref="SupportedCultures" /> has an entry</b>. That is what
+///     keeps this whole subsystem free for the apps that never asked for it: with no supported cultures
+///     the render path never resolves a culture service, <c>&lt;html lang&gt;</c> stays exactly
+///     <c>"en"</c>, and no <c>dir</c> attribute is emitted — so existing apps render byte-identical HTML.
+/// </remarks>
+public sealed class RaskCultureOptions
+{
+    /// <summary>
+    ///     The languages this app ships, as BCP&#160;47 tags. <b>The first is the default</b> that
+    ///     negotiation falls back to. Empty (the default) turns culture support off.
+    /// </summary>
+    public IList<string> SupportedCultures { get; } = [];
+
+    /// <summary>
+    ///     The languages the <em>UI text</em> is available in, when that differs from the set of
+    ///     languages whose date and number formats you support. <c>null</c> (the default) means the same
+    ///     list as <see cref="SupportedCultures" />, which is what most apps want.
+    /// </summary>
+    public IList<string>? SupportedUICultures { get; set; }
+
+    /// <summary>
+    ///     The culture used when negotiation finds nothing. <c>null</c> (the default) means the first
+    ///     entry of <see cref="SupportedCultures" />.
+    /// </summary>
+    public string? DefaultCulture { get; set; }
+
+    /// <summary>Whether <c>?culture=</c> in the URL may override the stored preference. Default <c>true</c>.</summary>
+    /// <remarks>
+    ///     On so that a link can carry a language — which is what makes a culture switcher shareable and
+    ///     a support request reproducible. It is an override for one request, not a stored preference,
+    ///     unless the host chooses to persist it.
+    /// </remarks>
+    public bool UseQueryString { get; set; } = true;
+
+    /// <summary>The query-string key read when <see cref="UseQueryString" /> is on. Default <c>"culture"</c>.</summary>
+    public string QueryKey { get; set; } = "culture";
+
+    /// <summary>Whether an explicit choice is remembered in a cookie. Default <c>true</c>.</summary>
+    public bool UseCookie { get; set; } = true;
+
+    /// <summary>
+    ///     The cookie that carries the choice. Defaults to ASP.NET's own
+    ///     <c>.AspNetCore.Culture</c>, in ASP.NET's own <c>c=..|uic=..</c> format.
+    /// </summary>
+    /// <remarks>
+    ///     Matching the framework cookie rather than inventing <c>.Rask.Culture</c> is deliberate. A Rask
+    ///     app that shares a host with MVC or Razor Pages, or that also calls
+    ///     <c>app.UseRequestLocalization()</c>, then agrees with them for free instead of holding two
+    ///     disagreeing preferences. The cookie is intentionally readable from JavaScript — the WASM host
+    ///     reads it before the runtime boots, to stamp <c>lang</c> on the document — so it must never
+    ///     carry anything but a language tag.
+    /// </remarks>
+    public string CookieName { get; set; } = ".AspNetCore.Culture";
+
+    /// <summary>How long the preference cookie lives. Default one year.</summary>
+    public int CookieMaxAgeDays { get; set; } = 365;
+
+    /// <summary>
+    ///     Whether the visitor's own preference (<c>Accept-Language</c> on the server,
+    ///     <c>navigator.languages</c> in the browser) is consulted. Default <c>true</c>.
+    /// </summary>
+    public bool UseClientPreference { get; set; } = true;
+
+    /// <summary>
+    ///     Whether Rask pins <see cref="System.Globalization.CultureInfo.CurrentCulture" /> to the
+    ///     session's culture for the duration of a render walk and a handler dispatch. Default <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    ///     On by default because a great deal of correct-looking code formats through the ambient culture
+    ///     — including code Rask does not own. The concrete case inside the framework is
+    ///     <c>BsDataGrid</c>'s sort: comparing two strings reaches <c>Comparer&lt;T&gt;.Default</c> and
+    ///     therefore a <em>linguistic</em> comparison under the current culture, which is what makes a
+    ///     Hungarian grid sort in Hungarian order. There is no seam to route that through, so the pin is
+    ///     what makes it right. Turn this off only if you are hosting Rask inside something that manages
+    ///     the ambient culture itself.
+    /// </remarks>
+    public bool ApplyToCurrentCulture { get; set; } = true;
+}

--- a/src/Rask.Core/Globalization/RaskCultureResolver.cs
+++ b/src/Rask.Core/Globalization/RaskCultureResolver.cs
@@ -1,0 +1,98 @@
+using System.Globalization;
+
+namespace Rask.Core.Globalization;
+
+/// <summary>
+///     Turns a culture name into a <see cref="CultureInfo" /> without ever throwing, and reports whether
+///     this runtime has real culture data at all.
+/// </summary>
+/// <remarks>
+///     Every culture lookup in Rask goes through here, because the obvious call is a trap on the host we
+///     care most about. A WASM app published with <c>InvariantGlobalization=true</c> — still the Rask
+///     default, since ICU is ~2.6 MB — also gets <c>PredefinedCulturesOnly=true</c>, and there
+///     <c>new CultureInfo("hu-HU")</c> does not fall back to invariant: it <b>throws</b>
+///     <see cref="CultureNotFoundException" />. A framework that let that escape would turn "this app
+///     supports Hungarian" into a blank page rather than into English text.
+///     <para>
+///         So the contract is: an unavailable culture is a <c>false</c>, never an exception, and the
+///         caller carries on with what it already had. An app that asked for cultures it cannot have is
+///         told once, at startup, by <see cref="SessionCulture" /> — not once per render.
+///     </para>
+/// </remarks>
+public static class RaskCultureResolver
+{
+    private static readonly Lazy<bool> _supported = new(Probe, LazyThreadSafetyMode.PublicationOnly);
+
+    /// <summary>
+    ///     Whether this runtime carries culture data. <c>false</c> under invariant globalization, where
+    ///     every culture formats identically and only the invariant culture can be constructed.
+    /// </summary>
+    /// <remarks>
+    ///     Probed by asking for a culture that certainly exists wherever ICU does, rather than read off an
+    ///     <c>AppContext</c> switch: the switch is only one of the ways a runtime ends up invariant (the
+    ///     MSBuild property, <c>DOTNET_SYSTEM_GLOBALIZATION_INVARIANT</c>, and a runtimeconfig entry all
+    ///     reach the same place), and what actually matters is whether a lookup works.
+    /// </remarks>
+    public static bool IsGlobalizationSupported => _supported.Value;
+
+    /// <summary>
+    ///     Resolves <paramref name="name" /> to a culture, returning <c>false</c> instead of throwing
+    ///     when it is null, blank, malformed, or unknown to this runtime.
+    /// </summary>
+    /// <remarks>
+    ///     A <c>true</c> here does not mean "this is a real language". .NET does not reject an
+    ///     unknown-but-well-formed tag — ICU manufactures a culture for it — so <c>zz-ZZ-not-real</c>
+    ///     resolves. That is why nothing in Rask treats a resolved name as trusted: negotiation matches
+    ///     only against the list the app itself configured, so an invented tag arriving in a query
+    ///     string or a cookie can never select anything.
+    /// </remarks>
+    public static bool TryResolve(string? name, out CultureInfo culture)
+    {
+        culture = CultureInfo.InvariantCulture;
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return false;
+        }
+
+        try
+        {
+            // GetCultureInfo rather than the constructor, so repeated lookups hit the BCL's own cache.
+            var resolved = CultureInfo.GetCultureInfo(name.Trim());
+
+            // Under a runtime with no culture data a lookup can still succeed and hand back something
+            // invariant wearing the requested name, which would let "hu-HU" pose as real support.
+            if (!IsGlobalizationSupported && !resolved.Equals(CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+
+            culture = resolved;
+            return true;
+        }
+        catch (CultureNotFoundException)
+        {
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            // Malformed rather than merely unknown (embedded separators, over-long subtags).
+            return false;
+        }
+    }
+
+    private static bool Probe()
+    {
+        try
+        {
+            // en-US exists wherever ICU does. Under invariant globalization PredefinedCulturesOnly is
+            // on, so this throws — the catch is the whole test. The equality check covers a runtime
+            // that allows arbitrary culture names but still has no data behind them, where the lookup
+            // succeeds and hands back the invariant culture.
+            return !CultureInfo.GetCultureInfo("en-US").Equals(CultureInfo.InvariantCulture);
+        }
+        catch (CultureNotFoundException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Rask.Core/Globalization/RaskCultureScope.cs
+++ b/src/Rask.Core/Globalization/RaskCultureScope.cs
@@ -1,0 +1,106 @@
+using System.Globalization;
+
+namespace Rask.Core.Globalization;
+
+/// <summary>
+///     Carries the session's culture across a handler dispatch, where there is no render context to read
+///     it from.
+/// </summary>
+/// <remarks>
+///     Same shape as <c>DispatchServicesScope</c>, and pushed beside it. <see cref="AsyncLocal{T}" />
+///     rather than <c>[ThreadStatic]</c> because a handler may await and resume on another thread.
+///     <para>
+///         This is the <em>second</em> of the two seams, not the primary one. The render walk does not
+///         rely on it: <c>LiveRenderContext</c> re-reads the culture from the session on every walk,
+///         which is what makes culture survive <c>LifecycleSyncContext</c>'s deliberate
+///         <c>ExecutionContext.SuppressFlow()</c> — an <c>AsyncLocal</c> cannot cross that, and neither
+///         can <c>CultureInfo.CurrentCulture</c>, which is itself an <c>AsyncLocal</c>.
+///     </para>
+/// </remarks>
+internal static class RaskCultureScope
+{
+    private static readonly AsyncLocal<Entry?> _current = new();
+
+    public static Entry? Current => _current.Value;
+
+    public static IDisposable Push(CultureInfo culture, CultureInfo uiCulture)
+    {
+        var previous = _current.Value;
+        _current.Value = new Entry(culture, uiCulture);
+        return new Popper(previous);
+    }
+
+    /// <summary>
+    ///     Pushes the culture belonging to <paramref name="services" />, or nothing at all when the app
+    ///     configured no cultures.
+    /// </summary>
+    /// <remarks>
+    ///     The <see cref="RaskCulture.IsEnabled" /> check is what keeps this free for apps that never
+    ///     asked for localization: no service resolution, no allocation, no ambient write on the
+    ///     dispatch path. Also pins the thread's culture for the handler's duration, for the same reason
+    ///     the render walk does — code the handler calls may format through the ambient culture.
+    /// </remarks>
+    public static IDisposable PushFrom(IServiceProvider? services)
+    {
+        if (!RaskCulture.IsEnabled || services?.GetService(typeof(IRaskCulture)) is not IRaskCulture culture)
+        {
+            return NullScope.Instance;
+        }
+
+        return new PinnedScope(Push(culture.Culture, culture.UICulture), culture.Culture, culture.UICulture);
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+
+    // Pops the AsyncLocal entry and unpins the thread culture, in that order.
+    private sealed class PinnedScope : IDisposable
+    {
+        private readonly IDisposable _inner;
+        private readonly CultureInfo _culture;
+        private readonly CultureInfo _previousCulture;
+        private readonly CultureInfo _previousUICulture;
+        private readonly CultureInfo _uiCulture;
+
+        public PinnedScope(IDisposable inner, CultureInfo culture, CultureInfo uiCulture)
+        {
+            _inner = inner;
+            _culture = culture;
+            _uiCulture = uiCulture;
+            _previousCulture = CultureInfo.CurrentCulture;
+            _previousUICulture = CultureInfo.CurrentUICulture;
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = uiCulture;
+        }
+
+        public void Dispose()
+        {
+            // Only unpin what is still ours: an awaited handler can resume on a different thread, and
+            // restoring there would stamp a foreign value onto a thread this scope never touched.
+            if (ReferenceEquals(CultureInfo.CurrentCulture, _culture))
+            {
+                CultureInfo.CurrentCulture = _previousCulture;
+            }
+
+            if (ReferenceEquals(CultureInfo.CurrentUICulture, _uiCulture))
+            {
+                CultureInfo.CurrentUICulture = _previousUICulture;
+            }
+
+            _inner.Dispose();
+        }
+    }
+
+    internal sealed record Entry(CultureInfo Culture, CultureInfo UICulture);
+
+    private sealed class Popper(Entry? previous) : IDisposable
+    {
+        public void Dispose() => _current.Value = previous;
+    }
+}

--- a/src/Rask.Core/Globalization/RaskCultureServiceCollectionExtensions.cs
+++ b/src/Rask.Core/Globalization/RaskCultureServiceCollectionExtensions.cs
@@ -1,0 +1,73 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Rask.Core.Browser;
+
+namespace Rask.Core.Globalization;
+
+/// <summary>Registers the culture services both hosts need.</summary>
+public static class RaskCultureServiceCollectionExtensions
+{
+    /// <summary>
+    ///     Registers the visitor's culture, and configures the app's languages.
+    /// </summary>
+    /// <param name="services">The app's services.</param>
+    /// <param name="configure">
+    ///     Adds the languages this app ships. Leaving <see cref="RaskCultureOptions.SupportedCultures" />
+    ///     empty — which is what happens when a host calls this on an app that never asked for
+    ///     localization — keeps culture support switched off.
+    /// </param>
+    /// <param name="lifetime">
+    ///     <see cref="ServiceLifetime.Scoped" /> on the server, where a scope is a live session and so a
+    ///     visitor; <see cref="ServiceLifetime.Singleton" /> on WASM, where the whole app is one visitor.
+    /// </param>
+    /// <remarks>
+    ///     Called unconditionally by every host, so that <c>IRaskCulture</c> can be a host contract and a
+    ///     component may take it in its constructor without first asking whether localization is on.
+    ///     Only <c>configure</c> adding a supported culture actually turns the subsystem on.
+    /// </remarks>
+    public static IServiceCollection AddRaskCulture(
+        this IServiceCollection services,
+        Action<RaskCultureOptions>? configure = null,
+        ServiceLifetime lifetime = ServiceLifetime.Scoped)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var options = new RaskCultureOptions();
+        configure?.Invoke(options);
+
+        // The options describe the APP, so they are a singleton whichever lifetime the culture takes.
+        services.TryAddSingleton(options);
+
+        // The process-wide switch that lets every read on the render and dispatch paths cost nothing
+        // until an app actually configures a language. It only ever decides whether to LOOK for a
+        // culture; the value itself always comes from the session, so two hosts in one process taking
+        // the union of this flag cannot make either read the other's culture.
+        if (options.SupportedCultures.Count > 0)
+        {
+            RaskCulture.IsEnabled = true;
+        }
+
+        services.Add(new ServiceDescriptor(typeof(SessionCulture), typeof(SessionCulture), lifetime));
+        services.Add(new ServiceDescriptor(
+            typeof(IRaskCulture), static sp => sp.GetRequiredService<SessionCulture>(), lifetime));
+
+        services.TryAdd(new ServiceDescriptor(
+            typeof(IRaskCulturePersistence),
+            static sp =>
+            {
+                var opts = sp.GetRequiredService<RaskCultureOptions>();
+
+                // A cookie is only reachable where there is a browser to write it through, and only
+                // wanted when the app asked for the choice to be remembered.
+                if (!opts.UseCookie || sp.GetService<ICookies>() is not { } cookies)
+                {
+                    return new NullCulturePersistence();
+                }
+
+                return new CookieCulturePersistence(cookies, opts);
+            },
+            lifetime));
+
+        return services;
+    }
+}

--- a/src/Rask.Core/Globalization/SessionCulture.cs
+++ b/src/Rask.Core/Globalization/SessionCulture.cs
@@ -1,0 +1,125 @@
+using System.Globalization;
+using Rask.Core.Diagnostics;
+
+namespace Rask.Core.Globalization;
+
+/// <summary>
+///     The default <see cref="IRaskCulture" />: one visitor's culture, held for the life of their
+///     session.
+/// </summary>
+/// <remarks>
+///     Scoped per session on the server (one live session, one instance) and a singleton on WASM, where
+///     the whole app <em>is</em> one session. The session reads this at the top of every render walk
+///     rather than relying on the value propagating — see <see cref="RaskCultureScope" /> for why
+///     propagation cannot be trusted.
+/// </remarks>
+public sealed class SessionCulture : IRaskCulture
+{
+    private readonly RaskCultureOptions _options;
+    private readonly IRaskCulturePersistence? _persistence;
+    private readonly IReadOnlyList<CultureInfo> _supported;
+
+    /// <summary>Creates a session culture from the app's configured languages.</summary>
+    public SessionCulture(RaskCultureOptions options, IRaskCulturePersistence? persistence = null)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _options = options;
+        _persistence = persistence;
+
+        var supported = new List<CultureInfo>(options.SupportedCultures.Count);
+        foreach (var name in options.SupportedCultures)
+        {
+            if (RaskCultureResolver.TryResolve(name, out var culture))
+            {
+                supported.Add(culture);
+            }
+        }
+
+        _supported = supported;
+
+        // One report, once per process, rather than one per failed lookup: an app that asked for
+        // languages this runtime cannot produce has a build-configuration problem, and the actionable
+        // part is the MSBuild property, not the individual culture.
+        if (supported.Count < options.SupportedCultures.Count && !RaskCultureResolver.IsGlobalizationSupported)
+        {
+            RaskDiagnostics.ReportOnce(
+                "rask.globalization:no-culture-data",
+                RaskLogLevel.Warning,
+                "Rask.Globalization",
+                static () =>
+                    "This app configures cultures, but the runtime was built without culture data, so "
+                    + "every culture formats identically and only the invariant culture resolves. Set "
+                    + "<RaskGlobalization>true</RaskGlobalization> in the app's project file to ship ICU "
+                    + "(roughly 2.6 MB in a WASM bundle), or configure a single culture.");
+        }
+
+        var initial = RaskCultureNegotiator.Negotiate(null, null, null, options);
+        Culture = initial.Culture;
+        UICulture = initial.UICulture;
+    }
+
+    /// <inheritdoc />
+    public CultureInfo Culture { get; private set; }
+
+    /// <inheritdoc />
+    public CultureInfo UICulture { get; private set; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<CultureInfo> Supported => _supported;
+
+    /// <inheritdoc />
+    public bool IsRightToLeft => Culture.TextInfo.IsRightToLeft;
+
+    /// <inheritdoc />
+    public event Action? Changed;
+
+    /// <inheritdoc />
+    public Task<bool> SetAsync(CultureInfo culture)
+    {
+        ArgumentNullException.ThrowIfNull(culture);
+        return SetCoreAsync(culture.Name);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> SetAsync(string name) => SetCoreAsync(name);
+
+    /// <summary>
+    ///     Seeds the culture from a host's negotiation, before the first render. Does not persist and
+    ///     does not raise <see cref="Changed" /> — nothing has rendered yet, so there is nothing to
+    ///     invalidate, and the visitor has not chosen anything worth remembering.
+    /// </summary>
+    internal void Seed(CultureNegotiation negotiation)
+    {
+        Culture = negotiation.Culture;
+        UICulture = negotiation.UICulture;
+    }
+
+    private async Task<bool> SetCoreAsync(string? name)
+    {
+        // TrySelect, not Negotiate: a switch honours the same matching rules ("hu" may select a
+        // supported "hu-HU") but must not be gated on UseQueryString, which governs how a choice
+        // travels rather than whether it counts.
+        if (!RaskCultureNegotiator.TrySelect(name, _options, out var selected))
+        {
+            return false;
+        }
+
+        if (selected.Culture.Equals(Culture) && selected.UICulture.Equals(UICulture))
+        {
+            return false;
+        }
+
+        Culture = selected.Culture;
+        UICulture = selected.UICulture;
+
+        if (_options.UseCookie && _persistence is not null)
+        {
+            await _persistence.SaveAsync(Culture.Name, UICulture.Name).ConfigureAwait(false);
+        }
+
+        // The session subscribes to this and re-renders. Raised after persistence so a reload during
+        // the render cannot observe the old preference.
+        Changed?.Invoke();
+        return true;
+    }
+}

--- a/src/Rask.Core/Live/IRenderHandle.cs
+++ b/src/Rask.Core/Live/IRenderHandle.cs
@@ -39,4 +39,16 @@ public interface IRenderHandle
     // The render engine, surfaced to components during render (via LiveRenderContext → Component.HostEngine).
     // Defaulted here so the interface stays non-breaking; concrete sessions override with their own fact.
     internal RenderEngine Engine => RenderEngine.Server;
+
+    // The session's culture, read fresh by LiveRenderContext at the top of every render walk.
+    //
+    // Pulled rather than pushed, and that is the whole point: LifecycleSyncContext deliberately calls
+    // ExecutionContext.SuppressFlow() so a continuation cannot inherit InHandlerScope, and since .NET
+    // Core CultureInfo.CurrentCulture lives in an AsyncLocal riding that same ExecutionContext. Anything
+    // that had to FLOW to the render thread — the ambient culture, or an AsyncLocal of our own — would
+    // be lost exactly there. Asking the session per walk is immune, because nothing has to survive.
+    internal System.Globalization.CultureInfo Culture => System.Globalization.CultureInfo.CurrentCulture;
+
+    // As above, for the language UI text renders in.
+    internal System.Globalization.CultureInfo UICulture => System.Globalization.CultureInfo.CurrentUICulture;
 }

--- a/src/Rask.Core/Live/LiveRenderContext.cs
+++ b/src/Rask.Core/Live/LiveRenderContext.cs
@@ -21,6 +21,8 @@ public sealed class LiveRenderContext : IDisposable
     [ThreadStatic] private static LiveRenderContext? _syncCurrent;
 
     private readonly LiveRenderContext? _previousSync;
+    private readonly System.Globalization.CultureInfo? _pinnedCulture;
+    private readonly System.Globalization.CultureInfo? _pinnedUICulture;
     private readonly Stack<ErrorBoundary> _boundaryStack = new();
     private readonly Dictionary<ObjectKey, EditContext> _currentEditContexts;
     private readonly IRenderHandle? _handle;
@@ -63,6 +65,20 @@ public sealed class LiveRenderContext : IDisposable
         _previousSync = _syncCurrent;
         _current.Value = this;
         _syncCurrent = this;
+
+        Culture = _handle?.Culture ?? System.Globalization.CultureInfo.CurrentCulture;
+        UICulture = _handle?.UICulture ?? System.Globalization.CultureInfo.CurrentUICulture;
+
+        // Pin the ambient culture for the walk, so code that formats through CultureInfo.CurrentCulture
+        // — including code Rask does not own, and BsDataGrid's linguistic string sort, which reaches
+        // Comparer<T>.Default and has no seam to route through — agrees with the session.
+        if (Globalization.RaskCulture.IsEnabled)
+        {
+            _pinnedCulture = System.Globalization.CultureInfo.CurrentCulture;
+            _pinnedUICulture = System.Globalization.CultureInfo.CurrentUICulture;
+            System.Globalization.CultureInfo.CurrentCulture = Culture;
+            System.Globalization.CultureInfo.CurrentUICulture = UICulture;
+        }
     }
 
     internal bool IsActive { get; private set; } = true;
@@ -93,6 +109,13 @@ public sealed class LiveRenderContext : IDisposable
     // Component.HostEngine. Constant for the session → safe to read from Render() without the render-cache
     // ambient-state opt-out.
     internal RenderEngine Engine => _handle?.Engine ?? RenderEngine.Server;
+
+    // The culture for this walk, snapshotted in the constructor from the session. A field, not a
+    // forward to the handle: one walk must render in ONE culture even if a handler switches it
+    // mid-flight, or a page could come out half-translated.
+    internal System.Globalization.CultureInfo Culture { get; }
+
+    internal System.Globalization.CultureInfo UICulture { get; }
 
     public IServiceProvider? Services { get; }
 
@@ -153,6 +176,21 @@ public sealed class LiveRenderContext : IDisposable
         IsActive = false;
         _current.Value = _previous;
         _syncCurrent = _previousSync;
+
+        // Restore the pin only if this walk's culture is still the one in effect. An async render can
+        // release its thread at an await and resume elsewhere, so Dispose may run on a thread this
+        // context never pinned — writing there would stamp a foreign value onto an unrelated thread.
+        if (_pinnedCulture is not null
+            && ReferenceEquals(System.Globalization.CultureInfo.CurrentCulture, Culture))
+        {
+            System.Globalization.CultureInfo.CurrentCulture = _pinnedCulture;
+        }
+
+        if (_pinnedUICulture is not null
+            && ReferenceEquals(System.Globalization.CultureInfo.CurrentUICulture, UICulture))
+        {
+            System.Globalization.CultureInfo.CurrentUICulture = _pinnedUICulture;
+        }
     }
 
     internal ContextScope PushScope(Component instance)

--- a/src/Rask.Core/Live/LiveSessionBase.cs
+++ b/src/Rask.Core/Live/LiveSessionBase.cs
@@ -58,8 +58,44 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
 
     protected virtual RenderEngine EngineCore => RenderEngine.Server;
 
+    // The session's culture, read by LiveRenderContext at the top of every render walk. Resolved once in
+    // the constructor rather than per walk: the service is scoped to this session, so the instance never
+    // changes — only the culture inside it does.
+    System.Globalization.CultureInfo IRenderHandle.Culture =>
+        _culture?.Culture ?? System.Globalization.CultureInfo.CurrentCulture;
+
+    System.Globalization.CultureInfo IRenderHandle.UICulture =>
+        _culture?.UICulture ?? System.Globalization.CultureInfo.CurrentUICulture;
+
     // Called at the very start of each render walk (before the tree is serialized). Base is a no-op.
     protected virtual void OnBeforeRenderWalk() { }
+
+    // A language switch has to repaint everything, so the whole tree is marked dirty before re-rendering.
+    //
+    // Belt AND braces, deliberately. Reading Component.Culture already marks that component as depending
+    // on ambient state, which alone would invalidate its cache entry — but only for components that read
+    // culture THROUGH Rask. A component formatting with CultureInfo.CurrentCulture directly is invisible
+    // to that marking and would otherwise keep serving a cached subtree in the previous language.
+    private void OnCultureChanged()
+    {
+        Component.MarkSubtreeDirtyInternal(View);
+        _ = RequestRenderAsync();
+    }
+
+    // Unhooks the culture subscription. Called by each host's Dispose: the service outlives a
+    // per-session tree on WASM (where it is a singleton), so leaving the handler attached would keep a
+    // disposed session's tree reachable and re-render it.
+    protected void DetachCulture()
+    {
+        if (_culture is not null)
+        {
+            _culture.Changed -= OnCultureChanged;
+        }
+    }
+
+    // The session's culture service, or null when the app configured no cultures. Held so the session
+    // can unsubscribe on dispose, and so the render walk never pays a service resolution.
+    private readonly Globalization.IRaskCulture? _culture;
 
     protected LiveSessionBase(Component view, IServiceProvider services, LiveDiffMode diffMode)
     {
@@ -67,6 +103,15 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
         Services = services;
         DiffMode = diffMode;
         view.RenderHandle = this;
+
+        // Only when an app actually configured cultures — otherwise this costs nothing and the whole
+        // subsystem stays inert (see RaskCulture.IsEnabled).
+        if (Globalization.RaskCulture.IsEnabled
+            && services.GetService(typeof(Globalization.IRaskCulture)) is Globalization.IRaskCulture culture)
+        {
+            _culture = culture;
+            _culture.Changed += OnCultureChanged;
+        }
         // RootErrorBoundary wraps the user's App; forward the handle to the inner so its
         // StateHasChanged() reaches the session even before the first GetOrCreate would attach it.
         if (view is RootErrorBoundary root)
@@ -147,7 +192,7 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
         {
             try
             {
-                Component.MarkSubtreeDirtyForHotReload(session.View);
+                Component.MarkSubtreeDirtyInternal(session.View);
                 await session.RequestRenderAsync().ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/src/Rask.Core/RaskHostContracts.cs
+++ b/src/Rask.Core/RaskHostContracts.cs
@@ -55,6 +55,10 @@ public static class RaskHostContracts
         typeof(IDownloadSink),
         // The interop runtime every Core browser wrapper is built on.
         typeof(IJSRuntime),
+        // The visitor's language. Registered by every host even when the app configured no cultures,
+        // so a component can take it in its constructor without first asking whether localization is
+        // switched on — an unconfigured one simply reports no supported cultures.
+        typeof(Globalization.IRaskCulture),
     ];
 
     /// <summary>

--- a/src/Rask.Generators/Analyzers/RootShellAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/RootShellAnalyzer.cs
@@ -46,7 +46,7 @@ public sealed class RootShellAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor Rask021 = new(
         "RASK021",
         "Root component must not render the page shell",
-        "The Rask root component '{0}' renders the page shell itself ({1}). Rask builds the document around the root — return the body's content and move <head> contributions to the Head override, <html lang> to HtmlLang, <body class> to BodyClass, or the whole document to a Shell override.",
+        "The Rask root component '{0}' renders the page shell itself ({1}). Rask builds the document around the root — return the body's content and move <head> contributions to the Head override, <html lang> to HtmlLang, <html dir> to HtmlDir, <body class> to BodyClass, or the whole document to a Shell override.",
         DiagnosticHelp.Category,
         DiagnosticSeverity.Warning,
         true,
@@ -54,7 +54,8 @@ public sealed class RootShellAnalyzer : DiagnosticAnalyzer
                      + "whatever it returns. Building them again nests a second document inside the body, which the "
                      + "parser unwraps — the page keeps rendering and quietly loses the nested tags' attributes. Return "
                      + "the body content (typically Router()); put head contributions in the Head override, the "
-                     + "document language in HtmlLang, the body class in BodyClass, and anything else in a "
+                     + "document language in HtmlLang, its writing direction in HtmlDir, the body class in "
+                     + "BodyClass, and anything else in a "
                      + "Shell(head, body) override. Do not add the runtime <script> — it is appended to <body> "
                      + "automatically.",
         helpLinkUri: DiagnosticHelp.Link("RASK021"));

--- a/src/Rask.Server/LiveSessionStore.cs
+++ b/src/Rask.Server/LiveSessionStore.cs
@@ -443,7 +443,7 @@ public sealed class LiveSessionStore : IAsyncDisposable
             {
                 try
                 {
-                    Component.MarkSubtreeDirtyForHotReload(session.View);
+                    Component.MarkSubtreeDirtyInternal(session.View);
                     await session.View.StateHasChangedAsync().ConfigureAwait(false);
                 }
                 catch

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -30,6 +30,7 @@ using Rask.Core.Browser;
 using Rask.Core.Components;
 using Rask.Core.Diagnostics;
 using Rask.Core.Forms;
+using Rask.Core.Globalization;
 using Rask.Core.HotReload;
 using Rask.Core.Live;
 using Rask.Core.Messaging;
@@ -105,10 +106,23 @@ public static partial class RaskEndpointExtensions
     ///     the framework's prior hardcoded defaults apply. Bind from configuration with
     ///     <c>AddRask(configureServer: o =&gt; config.GetSection("Rask").Bind(o))</c>.
     /// </param>
+    /// <param name="configureCulture">
+    ///     The languages this app ships, and how a visitor's is chosen. Leaving it unset — the default —
+    ///     keeps culture support off, and the rendered document is byte-for-byte what it was before:
+    ///     <c>&lt;html lang="en"&gt;</c> with no <c>dir</c>.
+    ///     <code>
+    ///     services.AddRask(configureCulture: c =&gt;
+    ///     {
+    ///         c.SupportedCultures.Add("en");   // the first entry is the default
+    ///         c.SupportedCultures.Add("hu");
+    ///     });
+    ///     </code>
+    /// </param>
     /// <returns>The same <paramref name="services" /> instance, for chaining.</returns>
     public static IServiceCollection AddRask(this IServiceCollection services,
         Action<RaskLiveOptions>? configure = null,
-        Action<RaskServerOptions>? configureServer = null)
+        Action<RaskServerOptions>? configureServer = null,
+        Action<RaskCultureOptions>? configureCulture = null)
     {
         // Per-app live runtime options. The framework default for DiffMode is LiveDiffMode.Auto, so a
         // fresh `AddRask()` ships the diff codec out of the box. Override:
@@ -212,6 +226,11 @@ public static partial class RaskEndpointExtensions
         // Transient user messages / toasts (a flash-message pattern). Scoped = one queue per session, so a
         // message queued before a client-side NavigateTo survives the navigation and shows once on arrival.
         services.AddScoped<IToaster, Toaster>();
+
+        // Scoped: a DI scope on the server IS a live session, and so a visitor. Registered even when
+        // the app configured nothing, because IRaskCulture is a host contract; without a configured
+        // culture this is inert. Negotiating one from the request arrives in a later change.
+        services.AddRaskCulture(configureCulture, ServiceLifetime.Scoped);
         // Typed browser/device API wrappers — the transport-agnostic Core set, Scoped (one per WebSocket
         // session). Registered via the shared helper (RaskBrowserApis) so the interface → impl list lives in
         // one place instead of being duplicated across the Server and WASM hosts. TryAdd inside the helper
@@ -301,7 +320,7 @@ public static partial class RaskEndpointExtensions
     }
 
     /// <summary>
-    ///     <see cref="AddRask(IServiceCollection, Action{RaskLiveOptions}, Action{RaskServerOptions})" />
+    ///     <see cref="AddRask(IServiceCollection, Action{RaskLiveOptions}, Action{RaskServerOptions}, Action{RaskCultureOptions})" />
     ///     under a name only this package defines — for an app that references <b>both</b> hosts.
     ///     <para>
     ///         <c>Rask.Wasm.Hosting</c> declares an <c>AddRask(this IServiceCollection)</c> as well, and

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -8,6 +8,7 @@ using Rask.Core.Authentication;
 using Rask.Core.Browser;
 using Rask.Core.Diagnostics;
 using Rask.Core.Forms;
+using Rask.Core.Globalization;
 using Rask.Core.Live;
 using Rask.Core.Messaging;
 using Rask.Core.Routing;
@@ -43,6 +44,10 @@ public sealed class WasmHostBuilder
         // Transient user messages / toasts (a flash-message pattern). Singleton = one queue for the app instance
         // (the whole WASM app is a single session), so a message queued before a NavigateTo survives it.
         Services.AddSingleton<IToaster, Toaster>();
+
+        // Singleton, unlike the server's scoped registration: the whole WASM app is one visitor, so
+        // there is exactly one culture for its lifetime.
+        Services.AddRaskCulture(lifetime: ServiceLifetime.Singleton);
         // Typed browser/device API wrappers, Singleton (one per app instance). Registered via the shared
         // helpers (RaskBrowserApis / RaskWasmBrowserApis) so the interface → impl list lives in one place
         // instead of duplicated across hosts. TryAdd inside the helpers means an app can pre-register a

--- a/tests/Rask.Core.Tests/Globalization/CultureFlowTests.cs
+++ b/tests/Rask.Core.Tests/Globalization/CultureFlowTests.cs
@@ -1,0 +1,218 @@
+using System.Globalization;
+using Rask.Core.Globalization;
+using Rask.Core.Live;
+
+#pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
+
+namespace Rask.Core.Tests.Globalization;
+
+// The culture reaches a render because the walk ASKS the session for it, never because it flowed there.
+// These tests pin that down, including the case that rules out every propagation-based design.
+public partial class CultureFlowTests : global::Rask.Core.RaskMarkup, IDisposable
+{
+    private static readonly CultureInfo Hungarian = CultureInfo.GetCultureInfo("hu-HU");
+    private static readonly CultureInfo German = CultureInfo.GetCultureInfo("de-DE");
+
+    public CultureFlowTests() => RaskCulture.IsEnabled = true;
+
+    public void Dispose()
+    {
+        RaskCulture.ResetForTests();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    [RestoreCulture]
+    public void Render_ReadsTheSessionsCulture_NotTheThreads()
+    {
+        // The thread says German; the session says Hungarian. The session wins, because the walk reads
+        // the handle rather than the ambient value.
+        CultureInfo.CurrentCulture = German;
+
+        var probe = new CultureProbe();
+        probe.RenderHandle = new FixedCultureHandle(Hungarian);
+
+        using var ctx = LiveRenderContext.Begin(probe);
+        probe.ToHtml();
+
+        Assert.Equal(Hungarian, probe.Seen);
+    }
+
+    [Fact]
+    [RestoreCulture]
+    public void Render_PinsTheAmbientCulture_ForCodeThatCannotBeRoutedThroughRask()
+    {
+        // BsDataGrid's sort is the real case: comparing two strings reaches Comparer<T>.Default and so a
+        // linguistic comparison under the CURRENT culture, with no seam to intercept. The pin is what
+        // makes that follow the session.
+        CultureInfo.CurrentCulture = German;
+
+        var probe = new AmbientProbe();
+        probe.RenderHandle = new FixedCultureHandle(Hungarian);
+
+        using (var ctx = LiveRenderContext.Begin(probe))
+        {
+            probe.ToHtml();
+        }
+
+        Assert.Equal(Hungarian, probe.SeenAmbient);
+
+        // And the walk gives the thread back what it borrowed.
+        Assert.Equal(German, CultureInfo.CurrentCulture);
+    }
+
+    [Fact]
+    [RestoreCulture]
+    public void Culture_SurvivesSuppressedExecutionContextFlow()
+    {
+        // THE test for this design. LifecycleSyncContext deliberately calls ExecutionContext.SuppressFlow()
+        // so a continuation cannot inherit InHandlerScope. Since .NET Core, CultureInfo.CurrentCulture
+        // lives in an AsyncLocal riding that same ExecutionContext — so a culture that had to FLOW to the
+        // continuation's render would be lost exactly there, and so would an AsyncLocal of our own.
+        //
+        // Reproduce that hostile environment literally, then render inside it.
+        CultureInfo.CurrentCulture = German;
+
+        var probe = new CultureProbe();
+        probe.RenderHandle = new FixedCultureHandle(Hungarian);
+
+        CultureInfo? seenInsideSuppressedFlow = null;
+        CultureInfo? ambientInsideSuppressedFlow = null;
+        var done = new ManualResetEventSlim();
+
+        using (ExecutionContext.SuppressFlow())
+        {
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    // Negative control, sampled BEFORE the render pins anything. If this came back as
+                    // German the suppression would not be doing what the test claims, and the assertion
+                    // below would be passing for the wrong reason — a culture that flowed rather than
+                    // one that was fetched.
+                    ambientInsideSuppressedFlow = CultureInfo.CurrentCulture;
+
+                    using var ctx = LiveRenderContext.Begin(probe);
+                    probe.ToHtml();
+                    seenInsideSuppressedFlow = probe.Seen;
+                }
+                finally
+                {
+                    done.Set();
+                }
+            });
+        }
+
+        Assert.True(done.Wait(TimeSpan.FromSeconds(30)), "the suppressed-flow render never completed");
+
+        Assert.False(
+            German.Equals(ambientInsideSuppressedFlow),
+            "ExecutionContext flow was not actually suppressed, so this test proves nothing");
+
+        // Fetched from the session, across a boundary nothing can flow over.
+        Assert.Equal(Hungarian, seenInsideSuppressedFlow);
+    }
+
+    [Fact]
+    [RestoreCulture]
+    public void ReadingCulture_MarksTheComponentAsDependingOnAmbientState()
+    {
+        // Without this mark the clean-subtree render cache would keep serving a subtree rendered in the
+        // previous language after a switch. It lives inside RaskCulture.Current precisely so a component
+        // author cannot forget it.
+        var reader = new CultureProbe();
+        reader.RenderHandle = new FixedCultureHandle(Hungarian);
+        using (var ctx = LiveRenderContext.Begin(reader))
+        {
+            reader.ToHtml();
+        }
+
+        Assert.True(reader.ReadsAmbientStateInternal);
+
+        var ignorer = new PlainProbe();
+        ignorer.RenderHandle = new FixedCultureHandle(Hungarian);
+        using (var ctx = LiveRenderContext.Begin(ignorer))
+        {
+            ignorer.ToHtml();
+        }
+
+        Assert.False(ignorer.ReadsAmbientStateInternal);
+    }
+
+    [Fact]
+    [RestoreCulture]
+    public void OneWalkRendersInOneCulture_EvenIfTheSessionChangesMidFlight()
+    {
+        // The context snapshots the culture in its constructor. A handler switching language while a
+        // walk is in progress must not produce a half-translated page.
+        var handle = new MutableCultureHandle(Hungarian);
+        var probe = new TwiceReadingProbe(() => handle.Culture = German);
+        probe.RenderHandle = handle;
+
+        using var ctx = LiveRenderContext.Begin(probe);
+        probe.ToHtml();
+
+        Assert.Equal(Hungarian, probe.First);
+        Assert.Equal(Hungarian, probe.Second);
+    }
+
+    private sealed class FixedCultureHandle(CultureInfo culture) : IRenderHandle
+    {
+        public Task RequestRenderAsync() => Task.CompletedTask;
+
+        CultureInfo IRenderHandle.Culture => culture;
+        CultureInfo IRenderHandle.UICulture => culture;
+    }
+
+    private sealed class MutableCultureHandle(CultureInfo culture) : IRenderHandle
+    {
+        public CultureInfo Culture { get; set; } = culture;
+
+        public Task RequestRenderAsync() => Task.CompletedTask;
+
+        CultureInfo IRenderHandle.Culture => Culture;
+        CultureInfo IRenderHandle.UICulture => Culture;
+    }
+
+    private sealed class CultureProbe : Component
+    {
+        public CultureInfo? Seen { get; private set; }
+
+        protected override Component Render()
+        {
+            Seen = Culture;
+            return Div["x"];
+        }
+    }
+
+    private sealed class AmbientProbe : Component
+    {
+        public CultureInfo? SeenAmbient { get; private set; }
+
+        protected override Component Render()
+        {
+            // Deliberately NOT through Rask — this is the code the pin exists for.
+            SeenAmbient = CultureInfo.CurrentCulture;
+            return Div["x"];
+        }
+    }
+
+    private sealed class PlainProbe : Component
+    {
+        protected override Component Render() => Div["x"];
+    }
+
+    private sealed class TwiceReadingProbe(Action between) : Component
+    {
+        public CultureInfo? First { get; private set; }
+        public CultureInfo? Second { get; private set; }
+
+        protected override Component Render()
+        {
+            First = Culture;
+            between();
+            Second = Culture;
+            return Div["x"];
+        }
+    }
+}

--- a/tests/Rask.Core.Tests/Globalization/CultureNegotiationTests.cs
+++ b/tests/Rask.Core.Tests/Globalization/CultureNegotiationTests.cs
@@ -1,0 +1,189 @@
+using System.Globalization;
+using Rask.Core.Globalization;
+
+namespace Rask.Core.Tests.Globalization;
+
+// Negotiation is pure and host-free, so it can be asserted without a server, a browser or a socket.
+public class CultureNegotiationTests
+{
+    private static RaskCultureOptions Options(params string[] supported)
+    {
+        var options = new RaskCultureOptions();
+        foreach (var name in supported)
+        {
+            options.SupportedCultures.Add(name);
+        }
+
+        return options;
+    }
+
+    [Fact]
+    public void Query_beats_cookie_beats_client_beats_default()
+    {
+        var options = Options("en", "hu", "de");
+
+        Assert.Equal("hu", Negotiate("hu", "c=de|uic=de", ["en"]).Culture.Name);
+        Assert.Equal("de", Negotiate(null, "c=de|uic=de", ["en"]).Culture.Name);
+        Assert.Equal("en", Negotiate(null, null, ["en"]).Culture.Name);
+        Assert.Equal("en", Negotiate(null, null, null).Culture.Name);
+
+        CultureNegotiation Negotiate(string? q, string? c, string[]? client) =>
+            RaskCultureNegotiator.Negotiate(q, c, client, options);
+    }
+
+    [Fact]
+    public void The_source_is_reported_so_a_host_knows_whether_to_remember_the_choice()
+    {
+        var options = Options("en", "hu");
+
+        Assert.Equal(CultureSource.Query, RaskCultureNegotiator.Negotiate("hu", null, null, options).Source);
+        Assert.Equal(CultureSource.Cookie, RaskCultureNegotiator.Negotiate(null, "c=hu|uic=hu", null, options).Source);
+        Assert.Equal(CultureSource.Client, RaskCultureNegotiator.Negotiate(null, null, ["hu"], options).Source);
+        Assert.Equal(CultureSource.Default, RaskCultureNegotiator.Negotiate(null, null, ["ja"], options).Source);
+    }
+
+    [Fact]
+    public void A_region_falls_back_to_the_language_the_app_does_ship()
+    {
+        // hu-HU is not configured, hu is: the visitor gets Hungarian rather than the default.
+        var options = Options("en", "hu");
+        Assert.Equal("hu", RaskCultureNegotiator.Negotiate("hu-HU", null, null, options).Culture.Name);
+    }
+
+    [Fact]
+    public void A_language_is_served_by_a_region_the_app_does_ship()
+    {
+        // The mirror case: the visitor asks for "hu", the app only lists "hu-HU". Serving it beats
+        // falling through to English — they asked for a language the app has.
+        var options = Options("en-US", "hu-HU");
+        Assert.Equal("hu-HU", RaskCultureNegotiator.Negotiate("hu", null, null, options).Culture.Name);
+    }
+
+    [Fact]
+    public void An_unsupported_language_is_ignored_rather_than_honoured()
+    {
+        var options = Options("en", "hu");
+        var result = RaskCultureNegotiator.Negotiate("ja-JP", null, ["ja-JP"], options);
+
+        Assert.Equal("en", result.Culture.Name);
+        Assert.Equal(CultureSource.Default, result.Source);
+    }
+
+    [Fact]
+    public void The_client_list_is_honoured_in_order_of_preference()
+    {
+        var options = Options("en", "hu", "de");
+        Assert.Equal("de", RaskCultureNegotiator.Negotiate(null, null, ["ja", "de", "hu"], options).Culture.Name);
+    }
+
+    [Fact]
+    public void The_first_supported_culture_is_the_default_unless_one_is_named()
+    {
+        Assert.Equal("hu", RaskCultureNegotiator.Negotiate(null, null, null, Options("hu", "en")).Culture.Name);
+
+        var explicitDefault = Options("hu", "en");
+        explicitDefault.DefaultCulture = "en";
+        Assert.Equal("en", RaskCultureNegotiator.Negotiate(null, null, null, explicitDefault).Culture.Name);
+    }
+
+    [Fact]
+    public void No_configured_cultures_means_culture_support_is_off()
+    {
+        var result = RaskCultureNegotiator.Negotiate("hu", "c=hu|uic=hu", ["hu"], new RaskCultureOptions());
+
+        Assert.Equal(CultureInfo.InvariantCulture, result.Culture);
+        Assert.Equal(CultureSource.Default, result.Source);
+    }
+
+    [Fact]
+    public void Each_signal_can_be_turned_off_independently()
+    {
+        var noQuery = Options("en", "hu");
+        noQuery.UseQueryString = false;
+        Assert.Equal("en", RaskCultureNegotiator.Negotiate("hu", null, null, noQuery).Culture.Name);
+
+        var noCookie = Options("en", "hu");
+        noCookie.UseCookie = false;
+        Assert.Equal("en", RaskCultureNegotiator.Negotiate(null, "c=hu|uic=hu", null, noCookie).Culture.Name);
+
+        var noClient = Options("en", "hu");
+        noClient.UseClientPreference = false;
+        Assert.Equal("en", RaskCultureNegotiator.Negotiate(null, null, ["hu"], noClient).Culture.Name);
+    }
+
+    [Fact]
+    public void An_explicit_selection_is_honoured_even_when_the_query_signal_is_off()
+    {
+        // UseQueryString governs how a choice TRAVELS, not whether it counts. Routing a switcher through
+        // the query branch of Negotiate would have made this flag silently disable the culture switcher.
+        var options = Options("en", "hu");
+        options.UseQueryString = false;
+
+        Assert.True(RaskCultureNegotiator.TrySelect("hu", options, out var selected));
+        Assert.Equal("hu", selected.Culture.Name);
+    }
+
+    [Fact]
+    public void A_UI_language_list_can_differ_from_the_formatting_list()
+    {
+        // Formats for Austrian German, but the app's text only exists in German.
+        var options = Options("en", "de-AT");
+        options.SupportedUICultures = ["en", "de"];
+
+        var result = RaskCultureNegotiator.Negotiate("de-AT", null, null, options);
+        Assert.Equal("de-AT", result.Culture.Name);
+        Assert.Equal("de", result.UICulture.Name);
+    }
+
+    [Theory]
+    [InlineData("c=hu-HU|uic=hu-HU", "hu-HU", "hu-HU")]
+    [InlineData("c=hu|uic=en", "hu", "en")]
+    [InlineData("hu-HU", "hu-HU", "hu-HU")]
+    [InlineData("uic=hu", "hu", "hu")]
+    public void The_cookie_format_round_trips_including_the_bare_tag_a_person_would_type(
+        string value, string culture, string uiCulture)
+    {
+        Assert.True(RaskCultureCookie.TryParse(value, out var parsedCulture, out var parsedUI));
+        Assert.Equal(culture, parsedCulture);
+        Assert.Equal(uiCulture, parsedUI);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("c=|uic=")]
+    public void A_malformed_cookie_is_a_miss_rather_than_a_throw(string? value) =>
+        Assert.False(RaskCultureCookie.TryParse(value, out _, out _));
+
+    [Fact]
+    public void Format_writes_what_ASP_NET_reads()
+    {
+        Assert.Equal("c=hu-HU|uic=hu-HU", RaskCultureCookie.Format("hu-HU"));
+        Assert.Equal("c=hu-HU|uic=en-US", RaskCultureCookie.Format("hu-HU", "en-US"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not a culture")]
+    public void An_unusable_culture_name_answers_false_rather_than_throwing(string? name) =>
+        Assert.False(RaskCultureResolver.TryResolve(name, out _));
+
+    [Fact]
+    public void A_wellformed_but_invented_tag_resolves_and_that_is_fine()
+    {
+        // Worth pinning because it surprises people: .NET does NOT reject an unknown-but-well-formed
+        // tag. ICU manufactures a culture for it, so TryResolve says yes to "zz-ZZ-not-real".
+        //
+        // It is not a hole. Nothing in Rask trusts a name from outside — negotiation only ever matches
+        // against the list the APP configured, so an invented tag from a query string or a cookie can
+        // never select anything unless the app itself configured that tag.
+        Assert.True(RaskCultureResolver.TryResolve("zz-ZZ-not-real", out _));
+
+        var options = Options("en", "hu");
+        Assert.Equal("en", RaskCultureNegotiator.Negotiate("zz-ZZ-not-real", null, null, options).Culture.Name);
+        Assert.False(RaskCultureNegotiator.TrySelect("zz-ZZ-not-real", options, out _));
+    }
+}

--- a/tests/Rask.Core.Tests/Live/ComponentHotReloadTests.cs
+++ b/tests/Rask.Core.Tests/Live/ComponentHotReloadTests.cs
@@ -7,7 +7,7 @@ namespace Rask.Core.Tests.Live;
 
 // The C# Hot Reload → live re-render seam: a component-code edit under `dotnet watch` must re-execute
 // every component's Render() (busting cached subtrees) and re-render every tracked session. These pin the
-// two halves — MarkSubtreeDirtyForHotReload forces a cached child to re-run, and
+// two halves — MarkSubtreeDirtyInternal forces a cached child to re-run, and
 // RerenderAllForHotReloadAsync / the MetadataUpdateHandler drive registered sessions (resiliently, and
 // only when registered).
 //
@@ -18,7 +18,7 @@ namespace Rask.Core.Tests.Live;
 public class ComponentHotReloadTests
 {
     [Fact]
-    public void MarkSubtreeDirtyForHotReload_ForcesCachedChildToReExecute()
+    public void MarkSubtreeDirtyInternal_ForcesCachedChildToReExecute()
     {
         var sp = RenderHarness.EmptyServices();
         var child = new Counter();
@@ -28,7 +28,7 @@ public class ComponentHotReloadTests
         host.RenderAsLiveRoot(sp);
         Assert.Equal(1, child.RenderCount); // cached: the child's Render didn't re-run on the 2nd pass
 
-        Component.MarkSubtreeDirtyForHotReload(host);
+        Component.MarkSubtreeDirtyInternal(host);
         host.RenderAsLiveRoot(sp);
 
         Assert.Equal(2, child.RenderCount); // marked dirty → re-executes against the (would-be) new IL


### PR DESCRIPTION
Second step of the global culture / localization epic. **Stacked on #819** — review that first; this PR
targets its branch, and should be retargeted to `main` before #819 merges.

Gives every session its own culture, and fixes the bug that motivated the epic.

## The bug this fixes

`BsPickerBase` read `CultureInfo.CurrentCulture` for month names, weekday names and first-day-of-week —
but **nothing in Rask ever set it**. On a server that is the *process* locale, so every visitor of a
multi-user app got the server's Hungarian, or the server's English, regardless of their own. A consumer
with no producer.

Adding `Component.Culture` turned that into a **CS0108 compile error** under warnings-as-errors, which
is exactly what should happen — the compiler found every call site, and the shadowing member is gone.

## The design decision everything follows from

**The culture is fetched at the top of every render walk, never propagated to it.**

`LifecycleSyncContext` deliberately calls `ExecutionContext.SuppressFlow()` so a continuation cannot
inherit `InHandlerScope`. Since .NET Core, `CultureInfo.CurrentCulture` lives in an `AsyncLocal` riding
that same `ExecutionContext` — so **any** design where the culture had to flow to the render thread
loses it precisely there. That rules out the ambient culture *and* a hand-rolled `AsyncLocal`, which is
the obvious implementation and would have been quietly broken in lifecycle continuations only.

`LiveRenderContext` therefore asks the session for the culture in its constructor, on whatever thread
the walk lands on. Nothing has to survive, so nothing can be lost.

`CultureFlowTests.Culture_SurvivesSuppressedExecutionContextFlow` renders inside a genuinely suppressed
flow. It carries a **negative control** asserting the ambient culture did *not* leak into the task —
without that, the test would pass trivially if suppression ever stopped working, proving nothing.

## Render-cache correctness

A switchable culture is not constant for a session, unlike the host axes, so a component that reads it
must be excluded from the clean-subtree cache or a language switch leaves stale subtrees on screen.

Belt **and** braces, deliberately:

- The marking lives **inside** `RaskCulture.Current`, not at the call site, so a component author
  cannot forget it.
- A switch **also** dirties the whole tree, which covers components formatting through
  `CultureInfo.CurrentCulture` directly — those are invisible to the marking.

Rask also pins the ambient culture for a render and a dispatch, because some culture-sensitive code has
no seam to route through: `BsDataGrid`'s sort reaches `Comparer<T>.Default` and therefore a *linguistic*
string comparison. That is the concrete reason `ApplyToCurrentCulture` defaults on. Both pins restore
only if the value is still theirs (`ReferenceEquals`), since an awaited render can resume on another
thread and must not stamp a foreign value onto it.

## Off by default, and byte-identical when off

With no supported cultures the walk never resolves a culture service, `<html lang>` stays exactly
`"en"`, and no `dir` attribute is emitted at all. `HtmlLang` falls back to the literal `"en"` rather
than reporting the ambient culture on purpose: the latter would turn `lang="en"` into `lang="en-US"` on
any US-locale machine and change the HTML of every app that never asked for localization.

## Negotiation

`?culture=` → cookie → `Accept-Language` → the app's default. **URLs stay culture-neutral** — one link
is the same page for everyone, and the router, the generated `Url()`/`Go()` helpers and every route
value are untouched. Wiring negotiation into the hosts comes in the next PRs; this one lands the
decision function, which is pure and host-free, and tested as such.

The cookie is ASP.NET's own `.AspNetCore.Culture` in ASP.NET's own `c=..|uic=..` format, hand-written
because `Rask.Core` has no ASP.NET dependency and also runs in the browser. An app sharing a host with
MVC, or one that also calls `UseRequestLocalization()`, then agrees with it instead of holding a second,
conflicting preference.

## Degrading without ICU

Under `InvariantGlobalization` — still the WASM default — `PredefinedCulturesOnly` is on and
`new CultureInfo("hu-HU")` **throws** rather than falling back. Every lookup goes through
`RaskCultureResolver`, which answers `false` instead, so an app that asked for languages this runtime
cannot produce still renders. The reason is reported **once**, naming `RaskGlobalization`, rather than
once per render.

Worth knowing, and documented rather than papered over: **.NET does not reject an unknown-but-well-formed
tag** — ICU manufactures a culture, so `TryResolve("zz-ZZ-not-real")` is `true`. It is not a hole,
because matching is only ever against the list the app itself configured; there is a test for exactly
that.

## Host contract

`IRaskCulture` joins `HostServices`, so a host that forgets to register it fails the build. **Verified
by removing the WASM registration and watching the parity test fail naming `IRaskCulture`** — not
assumed. Registration lives in one shared `AddRaskCulture` rather than duplicated per host: scoped on
the server (a DI scope *is* a session), singleton on WASM (the app *is* one visitor).

`AddRask` gains an optional third `configureCulture` parameter, so it is non-breaking.

## Testing

`scripts/run-unit-local.sh` green, pre-push browser E2E gate green. 30 new tests across
`CultureFlowTests` and `CultureNegotiationTests`.

No benchmark is quoted: the render path adds two field reads on a walk that already resolves the host
engine the same way, and every new accessor short-circuits on a process-wide `IsEnabled` flag that is
false until an app configures a language. The paths that would move are exercised in #819's benchmark,
which measured 0 B.
