### PR TITLE
feat(server): negotiate the visitor's language before the first byte of HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **The server negotiates a visitor's language from their request, before the first byte of HTML.**
+  `?culture=` beats a remembered choice, which beats `Accept-Language`, which beats the app's default.
+  The culture is seeded onto the session alongside the principal and the route — *before* the initial
+  render — so the page is built in the visitor's language rather than rendered in the default and
+  corrected in a second frame they would see flash. `Accept-Language` is read through ASP.NET's own
+  typed header reader, so quality values are honoured and a `q=0` language is treated as refused rather
+  than merely unranked.
+
+  **A shared `?culture=hu` link sticks.** When the language arrives in the URL, the response also
+  writes the preference cookie — the one place a server-side cookie write is free, because the response
+  is already open. Without it such a link would switch exactly one page load and snap back on the next
+  navigation, which reads as the feature being broken. Only a URL-supplied culture is persisted: a
+  cookie that merely round-trips is already stored, and an `Accept-Language` match is an inference
+  rather than a choice.
+
+  **A resumed session keeps its language.** Session resume exists to hide a host restart from the
+  visitor, and rebuilding their page in the wrong language would be a conspicuous way to fail at that.
+  A resumed session is a brand-new DI scope whose culture would otherwise start at the app default, so
+  the culture is negotiated from the WebSocket upgrade request — the last place those headers exist —
+  and applied when the session is rebuilt.
+
+  **Rask does not use `RequestLocalizationMiddleware` for this, and cannot.** That middleware sets the
+  culture for the duration of an HTTP request, but only the *first* render is an HTTP request: every
+  render after it runs on the WebSocket receive loop, long after the request ended. A middleware-set
+  culture would be right once and wrong forever after. An app may still call `UseRequestLocalization()`
+  for its own non-Rask endpoints — because Rask reads and writes ASP.NET's own culture cookie, in
+  ASP.NET's own format, the two agree rather than holding conflicting preferences.
+
 - **A visitor's culture, owned by their session.** `IRaskCulture` reports the culture to format with,
   the language to render text in, the app's supported languages, and whether the script runs
   right-to-left; `SetAsync` switches it, persists the choice and repaints. Components read

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -499,6 +499,19 @@ public static partial class RaskEndpointExtensions
             var routeState = session.Services.GetRequiredService<RouteState>();
             routeState.Path = path;
             routeState.Query = AdaptQuery(httpContext.Request.Query);
+
+            // The visitor's language, seeded from the request alongside their identity and route, and
+            // BEFORE the first render below — so the page is built in their language rather than
+            // rendered in the default and corrected in a second frame they would see flash.
+            if (ServerCultureNegotiation.TryNegotiate(
+                    httpContext.Request, httpContext.RequestServices, out var culture))
+            {
+                ServerCultureNegotiation.Apply(session.Services, culture);
+                ServerCultureNegotiation.Persist(
+                    httpContext.Response,
+                    culture,
+                    httpContext.RequestServices.GetRequiredService<RaskCultureOptions>());
+            }
             // Render the GET shell and seed both baselines: the dedup baseline so a no-op
             // click after hello dedups against the HTML the browser already has (mirroring
             // WASM's InitialRenderAsync / `_lastAppliedHtml`), AND the diff-codec frame
@@ -653,8 +666,14 @@ public static partial class RaskEndpointExtensions
                 using var linked = CancellationTokenSource.CreateLinkedTokenSource(
                     ctx.RequestAborted, drain.HardStopping);
                 var resume = ctx.RequestServices.GetRequiredService<SessionResumeSupport>();
+
+                // Negotiated here, from the upgrade request, because that is the last point at which its
+                // headers and cookies exist. It is only USED if this socket ends up rebuilding a session
+                // (the resume path), which happens in a fresh DI scope much later.
+                ServerCultureNegotiation.TryNegotiate(ctx.Request, ctx.RequestServices, out var wsCulture);
+
                 await RunSocketLoop(ws, store, limits, wsUser, resume, appFactory, linked.Token,
-                    drain.HardStopping);
+                    drain.HardStopping, wsCulture);
             }));
 
         var script = LoadEmbeddedScript();
@@ -803,7 +822,7 @@ public static partial class RaskEndpointExtensions
 
     private static async Task RunSocketLoop(WebSocket ws, LiveSessionStore store, RaskServerLimits limits,
         ClaimsPrincipal wsUser, SessionResumeSupport resume, Func<IServiceProvider, Component> appFactory,
-        CancellationToken ct, CancellationToken stopping)
+        CancellationToken ct, CancellationToken stopping, CultureNegotiation resumeCulture = default)
     {
         using var abortReg = stopping.Register(() =>
         {
@@ -991,6 +1010,14 @@ public static partial class RaskEndpointExtensions
                         // which re-stamps data-rask-root — see LiveSessionBase's full-payload path.
                         session.AttachSocket(ws, ct);
                         session.Services.GetRequiredService<SessionUserProvider>().Set(wsUser);
+
+                        // A resumed session is a NEW DI scope, so its culture starts at the app default.
+                        // Without this the visitor's language would silently reset the first time the
+                        // host restarted under them — the one moment resume exists to hide.
+                        if (resumeCulture.Culture is not null)
+                        {
+                            ServerCultureNegotiation.Apply(session.Services, resumeCulture);
+                        }
                         await session.RenderAndSendAsync(null, false).ConfigureAwait(false);
                         continue;
                     }

--- a/src/Rask.Server/ServerCultureNegotiation.cs
+++ b/src/Rask.Server/ServerCultureNegotiation.cs
@@ -1,0 +1,135 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core.Globalization;
+
+namespace Rask.Server;
+
+/// <summary>
+///     Negotiates a visitor's culture from an HTTP request and seeds it onto their live session.
+/// </summary>
+/// <remarks>
+///     <para>
+///         This runs at the request layer, beside the code that seeds the principal and the route, and
+///         <b>not</b> inside <c>LiveSessionStore</c>: the headers only exist here, and the session store
+///         is also used by the resume path, which has its own request to read.
+///     </para>
+///     <para>
+///         Rask does not use <c>RequestLocalizationMiddleware</c> for this, and cannot. That middleware
+///         sets the culture for the duration of an HTTP request — but only the FIRST render is an HTTP
+///         request. Every subsequent render runs on the WebSocket receive loop, long after the request
+///         ended, so a middleware-set culture would be right once and wrong forever after. The culture
+///         has to live on the session, which is what <see cref="SessionCulture" /> is. An app may still
+///         call <c>UseRequestLocalization()</c> for its own non-Rask endpoints; because Rask reads and
+///         writes ASP.NET's own culture cookie, the two agree.
+///     </para>
+/// </remarks>
+internal static class ServerCultureNegotiation
+{
+    /// <summary>
+    ///     Negotiates a culture from <paramref name="request" />, or answers <c>false</c> when the app
+    ///     configured no languages.
+    /// </summary>
+    /// <remarks>
+    ///     Separate from <see cref="Apply" /> because the two happen at different moments on the resume
+    ///     path: the signals live on the WebSocket upgrade request, but the session they belong to is
+    ///     rebuilt later, in a fresh DI scope, once the client's resume record has been opened.
+    /// </remarks>
+    public static bool TryNegotiate(
+        HttpRequest request,
+        IServiceProvider services,
+        out CultureNegotiation negotiation)
+    {
+        negotiation = default;
+
+        var options = services.GetService<RaskCultureOptions>();
+        if (options is null || options.SupportedCultures.Count == 0)
+        {
+            return false;
+        }
+
+        negotiation = RaskCultureNegotiator.Negotiate(
+            options.UseQueryString ? request.Query[options.QueryKey].ToString() : null,
+            options.UseCookie ? request.Cookies[options.CookieName] : null,
+            options.UseClientPreference ? ClientLanguages(request) : null,
+            options);
+
+        return true;
+    }
+
+    /// <summary>Seeds a session's culture, before its first render.</summary>
+    public static void Apply(IServiceProvider sessionServices, CultureNegotiation negotiation) =>
+        sessionServices.GetRequiredService<SessionCulture>().Seed(negotiation);
+
+    /// <summary>
+    ///     Remembers a culture that arrived in the URL, and declares what the response varied on.
+    /// </summary>
+    /// <remarks>
+    ///     Writing the cookie here is the one place a server-side culture cookie is free — the response
+    ///     is already open. Without it a shared <c>?culture=hu</c> link would switch exactly one page
+    ///     load and then snap back on the next navigation, which reads as the feature being broken.
+    ///     Only a culture that came from the URL is persisted: a cookie that merely round-trips is
+    ///     already stored, and an <c>Accept-Language</c> match is an inference, not a choice.
+    /// </remarks>
+    public static void Persist(HttpResponse response, CultureNegotiation negotiation, RaskCultureOptions options)
+    {
+        // The shell is already Cache-Control: no-store (it embeds the session id), so Vary changes no
+        // caching decision today. It is still correct to declare, and it is what keeps the page honest
+        // if that policy is ever relaxed.
+        response.Headers.Vary = options.UseCookie ? "Accept-Language, Cookie" : "Accept-Language";
+
+        if (negotiation.Source != CultureSource.Query || !options.UseCookie)
+        {
+            return;
+        }
+
+        response.Cookies.Append(
+            options.CookieName,
+            RaskCultureCookie.Format(negotiation.Culture.Name, negotiation.UICulture.Name),
+            new Microsoft.AspNetCore.Http.CookieOptions
+            {
+                MaxAge = TimeSpan.FromDays(options.CookieMaxAgeDays),
+                Path = "/",
+                // Deliberately NOT HttpOnly: the WASM host reads this cookie before the runtime boots,
+                // to stamp lang/dir on the document and avoid a flash of the wrong language. It carries
+                // a language tag and never a credential.
+                HttpOnly = false,
+                IsEssential = true,
+                SameSite = SameSiteMode.Lax,
+                Secure = response.HttpContext.Request.IsHttps,
+            });
+    }
+
+    /// <summary>
+    ///     The visitor's languages, most-preferred first, from <c>Accept-Language</c>.
+    /// </summary>
+    /// <remarks>
+    ///     Parsed with ASP.NET's own typed header reader rather than by splitting on commas, so quality
+    ///     values, whitespace and malformed entries are handled the way the rest of the stack handles
+    ///     them. <c>q=0</c> means "explicitly not this one" and is dropped rather than ranked last.
+    /// </remarks>
+    private static IReadOnlyList<string>? ClientLanguages(HttpRequest request)
+    {
+        var header = request.GetTypedHeaders().AcceptLanguage;
+        if (header is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        var ranked = new List<string>(header.Count);
+        foreach (var entry in header.OrderByDescending(static h => h.Quality ?? 1d))
+        {
+            if ((entry.Quality ?? 1d) <= 0d)
+            {
+                continue;
+            }
+
+            var value = entry.Value.Value;
+            if (!string.IsNullOrWhiteSpace(value) && value != "*")
+            {
+                ranked.Add(value);
+            }
+        }
+
+        return ranked.Count > 0 ? ranked : null;
+    }
+}

--- a/tests/Rask.Server.Tests/Endpoints/CultureNegotiationEndpointTests.cs
+++ b/tests/Rask.Server.Tests/Endpoints/CultureNegotiationEndpointTests.cs
@@ -1,0 +1,166 @@
+using System.Globalization;
+using System.Net.Http.Headers;
+using Rask.Core;
+using Rask.Server.Tests.Infrastructure;
+
+#pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
+
+namespace Rask.Server.Tests.Endpoints;
+
+// The server half of culture: what the FIRST response says, before any socket exists. This is the part
+// no client-side mechanism can do — by the time JavaScript could read navigator.language, the page has
+// already been painted in some language, and if it were the wrong one the visitor would see it flash.
+public class CultureNegotiationEndpointTests
+{
+    private static RaskTestHost Host() =>
+        RaskTestHost.Create<CulturePage>(configureCulture: c =>
+        {
+            c.SupportedCultures.Add("en");
+            c.SupportedCultures.Add("hu");
+            c.SupportedCultures.Add("ar");
+        });
+
+    [Fact]
+    public async Task Accept_Language_reaches_the_very_first_rendered_html()
+    {
+        using var host = Host();
+        host.Http.DefaultRequestHeaders.AcceptLanguage.Add(new StringWithQualityHeaderValue("hu"));
+
+        var html = await host.Http.GetStringAsync("/");
+
+        // Not "the page corrects itself afterwards" — the first bytes off the server are already Hungarian.
+        Assert.Contains("lang=\"hu\"", html, StringComparison.Ordinal);
+        Assert.Contains("<p>hu</p>", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Quality_values_decide_which_language_wins()
+    {
+        using var host = Host();
+        host.Http.DefaultRequestHeaders.AcceptLanguage.Add(new StringWithQualityHeaderValue("hu", 0.3));
+        host.Http.DefaultRequestHeaders.AcceptLanguage.Add(new StringWithQualityHeaderValue("en", 0.9));
+
+        Assert.Contains("lang=\"en\"", await host.Http.GetStringAsync("/"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_language_the_visitor_refused_is_not_served_to_them()
+    {
+        // q=0 means "explicitly not this one", which is different from "did not mention it".
+        using var host = Host();
+        host.Http.DefaultRequestHeaders.AcceptLanguage.Add(new StringWithQualityHeaderValue("hu", 0));
+
+        Assert.Contains("lang=\"en\"", await host.Http.GetStringAsync("/"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task The_url_beats_the_header_and_is_remembered_so_a_shared_link_sticks()
+    {
+        using var host = Host();
+        host.Http.DefaultRequestHeaders.AcceptLanguage.Add(new StringWithQualityHeaderValue("en"));
+
+        var response = await host.Http.GetAsync("/?culture=hu");
+        var html = await response.Content.ReadAsStringAsync();
+
+        Assert.Contains("lang=\"hu\"", html, StringComparison.Ordinal);
+
+        // Without persisting here, a shared ?culture=hu link would switch exactly one page load and then
+        // snap back on the next navigation — which reads as the feature being broken.
+        var cookie = Assert.Single(
+            response.Headers.GetValues("Set-Cookie"),
+            v => v.StartsWith(".AspNetCore.Culture", StringComparison.Ordinal));
+        // URL-encoded on the wire (c%3Dhu%7Cuic%3Dhu), which is exactly what ASP.NET's own
+        // CookieRequestCultureProvider writes. Asserted in the encoded form deliberately: this is the
+        // byte sequence both halves have to agree on, and the browser writer must match it — rask-api.js
+        // encodes with encodeURIComponent and decodes on read, so a cookie set by either side is
+        // readable by the other. A mismatch here would surface as "the language resets on reload".
+        Assert.Contains("c%3Dhu%7Cuic%3Dhu", cookie, StringComparison.Ordinal);
+
+        // And it must stay readable from script: the WASM host reads it before its runtime boots.
+        Assert.DoesNotContain("httponly", cookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task The_cookie_the_server_writes_is_the_cookie_the_server_reads()
+    {
+        // Closes the round trip the assertion above only half-proves. The encoding is invisible to
+        // Request.Cookies, so this is what guarantees a persisted choice actually survives.
+        using var host = Host();
+
+        var first = await host.Http.GetAsync("/?culture=hu");
+        var setCookie = Assert.Single(
+            first.Headers.GetValues("Set-Cookie"),
+            v => v.StartsWith(".AspNetCore.Culture", StringComparison.Ordinal));
+
+        using var replay = Host();
+        replay.Http.DefaultRequestHeaders.Add("Cookie", setCookie.Split(';')[0]);
+
+        Assert.Contains("lang=\"hu\"", await replay.Http.GetStringAsync("/"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_remembered_choice_beats_the_browsers_preference()
+    {
+        using var host = Host();
+        host.Http.DefaultRequestHeaders.AcceptLanguage.Add(new StringWithQualityHeaderValue("en"));
+        host.Http.DefaultRequestHeaders.Add("Cookie", ".AspNetCore.Culture=c=hu|uic=hu");
+
+        Assert.Contains("lang=\"hu\"", await host.Http.GetStringAsync("/"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_right_to_left_language_sets_dir_and_the_others_leave_it_off()
+    {
+        using var host = Host();
+
+        host.Http.DefaultRequestHeaders.AcceptLanguage.Add(new StringWithQualityHeaderValue("ar"));
+        var arabic = await host.Http.GetStringAsync("/");
+        Assert.Contains("dir=\"rtl\"", arabic, StringComparison.Ordinal);
+
+        using var latin = Host();
+        latin.Http.DefaultRequestHeaders.AcceptLanguage.Add(new StringWithQualityHeaderValue("hu"));
+        Assert.DoesNotContain("dir=", await latin.Http.GetStringAsync("/"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task The_response_declares_what_it_varied_on()
+    {
+        using var host = Host();
+        var response = await host.Http.GetAsync("/");
+
+        var vary = string.Join(",", response.Headers.Vary);
+        Assert.Contains("Accept-Language", vary, StringComparison.Ordinal);
+        Assert.Contains("Cookie", vary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task An_app_that_configures_no_languages_renders_exactly_what_it_did_before()
+    {
+        // The guarantee that makes this feature safe to land: an app that never asked for localization
+        // must produce byte-identical HTML. lang stays the literal "en" rather than becoming the
+        // machine's "en-US", and no dir attribute appears at all.
+        using var host = RaskTestHost.Create<CulturePage>();
+        host.Http.DefaultRequestHeaders.AcceptLanguage.Add(new StringWithQualityHeaderValue("hu"));
+
+        var html = await host.Http.GetStringAsync("/");
+
+        Assert.Contains("lang=\"en\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("dir=", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task An_unsupported_language_falls_back_rather_than_being_honoured()
+    {
+        using var host = Host();
+        host.Http.DefaultRequestHeaders.AcceptLanguage.Add(new StringWithQualityHeaderValue("ja-JP"));
+
+        Assert.Contains("lang=\"en\"", await host.Http.GetStringAsync("/"), StringComparison.Ordinal);
+    }
+
+    // Renders the negotiated language into the body, so a test can see the culture the SESSION got
+    // rather than only the one the document declares.
+    private sealed class CulturePage : Component
+    {
+        protected override Component Render() => Div[P[UICulture.Name]];
+    }
+}

--- a/tests/Rask.Server.Tests/Infrastructure/RaskTestHost.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/RaskTestHost.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core;
+using Rask.Core.Globalization;
 using Rask.Core.Live;
 
 namespace Rask.Server.Tests.Infrastructure;
@@ -57,7 +58,8 @@ internal sealed class RaskTestHost : IDisposable
         string pathBase = "",
         Action<RaskServerOptions>? configureServer = null,
         LiveDiffMode diffMode = LiveDiffMode.Auto,
-        string? environment = null)
+        string? environment = null,
+        Action<RaskCultureOptions>? configureCulture = null)
         where TApp : Component
     {
         // Defaults to whatever WebApplication picks (Production under test, absent an env var).
@@ -71,7 +73,10 @@ internal sealed class RaskTestHost : IDisposable
         // carried on the LiveSessionStore) are seeded here, so each TestServer carries its own — tests
         // that assert on a specific diff/full payload pass diffMode instead of writing a process-global
         // static, which lets them run in parallel.
-        builder.Services.AddRask(configure: live => live.DiffMode = diffMode, configureServer: configureServer);
+        builder.Services.AddRask(
+            configure: live => live.DiffMode = diffMode,
+            configureServer: configureServer,
+            configureCulture: configureCulture);
         configureServices?.Invoke(builder.Services);
 
         var app = builder.Build();

--- a/tests/Rask.Server.Tests/Live/CultureResumeTests.cs
+++ b/tests/Rask.Server.Tests/Live/CultureResumeTests.cs
@@ -1,0 +1,131 @@
+using System.Globalization;
+using System.Net.WebSockets;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core;
+using Rask.Core.Live;
+using Rask.Server.Tests.Infrastructure;
+
+#pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
+
+namespace Rask.Server.Tests.Live;
+
+/// <summary>
+///     A resumed session keeps the visitor's language.
+/// </summary>
+/// <remarks>
+///     Resume exists to hide a host restart from the visitor. Rebuilding their page in the wrong language
+///     would be a conspicuous way to fail at that — and it is the easy bug to ship, because a resumed
+///     session is a <b>brand new DI scope</b>: its culture starts at the app default no matter what the
+///     old one held. The signals are still on the WebSocket upgrade request, which is where the culture
+///     is negotiated for this path.
+/// </remarks>
+public sealed class CultureResumeTests
+{
+    // Declares a value as well as the language: a resume record only rides a payload that actually
+    // changed, so the page needs something to change.
+    private sealed class LanguagePage(IPersistentState state) : Component
+    {
+        protected override Component? Render()
+        {
+            state.TryGet<int>("counter", out var count);
+            // A second P rather than Span: the HTML Span entry collides with System.Span<T> here.
+            return Div[P[UICulture.Name], P[count.ToString(CultureInfo.InvariantCulture)]];
+        }
+    }
+
+    private static RaskTestHost Host() =>
+        RaskTestHost.Create<LanguagePage>(configureCulture: c =>
+        {
+            c.SupportedCultures.Add("en");
+            c.SupportedCultures.Add("hu");
+        });
+
+    [Fact]
+    public async Task A_rebuilt_session_is_still_in_the_visitors_language()
+    {
+        using var host = Host();
+        host.Http.DefaultRequestHeaders.Add("Cookie", ".AspNetCore.Culture=c%3Dhu%7Cuic%3Dhu");
+
+        // Establish a Hungarian session and take its resume record off the wire.
+        var initial = await host.Http.GetAsync("/");
+        var html = await initial.Content.ReadAsStringAsync();
+        Assert.Contains("<p>hu</p>", html, StringComparison.Ordinal);
+
+        var sessionId = SessionIdFrom(html);
+        host.WebSockets.ConfigureRequest = r => r.Headers["Cookie"] = ".AspNetCore.Culture=c%3Dhu%7Cuic%3Dhu";
+
+        using (var first = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None))
+        {
+            await first.SendJsonAsync(new { type = "hello", session = sessionId });
+            var session = host.Store.Get(sessionId)!;
+            session.Services.GetRequiredService<IPersistentState>().Persist("counter", 41);
+            await session.View.StateHasChangedAsync();
+            var token = await ReadResumeAsync(first);
+
+            // The process that held the tree is gone — a restart, or a deploy swapping the container.
+            host.Store.Remove(sessionId);
+
+            using var second = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+            await second.SendJsonAsync(new { type = "hello", session = sessionId, resume = token });
+
+            var rebuilt = await ReadHtmlAsync(second);
+
+            // Not the app default. The rebuild read the upgrade request's cookie and seeded the new scope.
+            Assert.Contains("<p>hu</p>", rebuilt, StringComparison.Ordinal);
+            Assert.Contains("lang=\"hu\"", rebuilt, StringComparison.Ordinal);
+        }
+    }
+
+    private static string SessionIdFrom(string html)
+    {
+        const string marker = "data-rask-root=\"";
+        var start = html.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(start >= 0, "the shell did not carry a session id");
+        start += marker.Length;
+        return html[start..html.IndexOf('"', start)];
+    }
+
+    private static async Task<string> ReadResumeAsync(WebSocket ws)
+    {
+        for (var i = 0; i < 8; i++)
+        {
+            var frame = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+            if (frame is null)
+            {
+                break;
+            }
+
+            using var doc = JsonDocument.Parse(frame);
+            if (doc.RootElement.TryGetProperty("resume", out var resume)
+                && resume.ValueKind == JsonValueKind.String)
+            {
+                return resume.GetString()!;
+            }
+        }
+
+        Assert.Fail("expected a render payload carrying a resume record");
+        return string.Empty;
+    }
+
+    private static async Task<string> ReadHtmlAsync(WebSocket ws)
+    {
+        for (var i = 0; i < 8; i++)
+        {
+            var frame = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+            if (frame is null)
+            {
+                break;
+            }
+
+            using var doc = JsonDocument.Parse(frame);
+            if (doc.RootElement.TryGetProperty("html", out var html) && html.ValueKind == JsonValueKind.String)
+            {
+                return html.GetString()!;
+            }
+        }
+
+        Assert.Fail("expected a rebuild frame carrying html");
+        return string.Empty;
+    }
+}


### PR DESCRIPTION
Third step of the global culture / localization epic. **Stacked on #821** (which is stacked on #819) —
retarget to `main` as its parents merge.

Makes the culture from #821 arrive from the actual visitor.

## The guarantee this exists for

**The first bytes of HTML off the server are already in the visitor's language.**

That is the part no client-side mechanism can provide. By the time script could read
`navigator.language`, the page has already been painted — and if it were painted in the wrong language,
the visitor would watch it flash. So the culture is seeded onto the session **alongside the principal
and the route, before the initial render**, not corrected in a second frame afterwards.

`CultureNegotiationEndpointTests.Accept_Language_reaches_the_very_first_rendered_html` asserts exactly
that against a real `TestServer`.

## Order

`?culture=` → cookie → `Accept-Language` → the app's default.

`Accept-Language` is read through ASP.NET's own typed header reader rather than by splitting on commas,
so quality values are honoured and **`q=0` means "explicitly not this one"** — refused, rather than
merely ranked last. Both have tests.

## A shared link has to stick

When the language arrives in the URL, the response also writes the preference cookie. This is the one
place a server-side cookie write is free: the response is already open.

Without it, a shared `?culture=hu` link would switch **exactly one page load** and snap back on the
next navigation — which reads as the feature being broken rather than as a design decision.

Only a URL-supplied culture is persisted. A cookie that merely round-trips is already stored, and an
`Accept-Language` match is an inference about the visitor rather than a choice by them.

## The resume path would have silently reset the language

Session resume exists to hide a host restart from the visitor. Rebuilding their page **in the wrong
language** is a conspicuous way to fail at that, and it is the easy bug to ship: a resumed session is a
**brand-new DI scope**, so its culture starts at the app default no matter what the old one held.

The culture is therefore negotiated from the **WebSocket upgrade request** — the last point at which
those headers and cookies exist — and applied when the session is rebuilt.

**Verified rather than assumed:** disabling that seeding turns `CultureResumeTests` red.

## Cookie encoding, which would otherwise be a silent bug

ASP.NET writes the value URL-encoded: `c%3Dhu%7Cuic%3Dhu`. `rask-api.js` encodes and decodes with
`encodeURIComponent`/`decodeURIComponent`, so a cookie written by either half is readable by the other.

The test asserts the **encoded wire form** deliberately, plus a full round trip, because a mismatch
here would never look like an encoding problem — it would surface only as *"the language resets on
reload"*.

## Why not `RequestLocalizationMiddleware`

It cannot do this job. That middleware sets the culture for the duration of an HTTP request — but only
the **first** render is an HTTP request. Every render after it runs on the WebSocket receive loop, long
after the request ended, so a middleware-set culture would be right once and wrong forever after. The
culture has to live on the session.

An app may still call `UseRequestLocalization()` for its own non-Rask endpoints. Because Rask reads and
writes ASP.NET's own cookie in ASP.NET's own format, the two agree instead of holding conflicting
preferences.

## Testing

`scripts/run-unit-local.sh` green, pre-push browser E2E gate green. 11 new tests.

Includes the guarantee that keeps this safe to land: an app that configures **no** languages still
renders `lang="en"` with no `dir` attribute — byte-identical to before the epic.
