### PR TITLE
feat(wasm): negotiate the language in the browser, and make ICU one property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **A WASM app negotiates the visitor's language before its first render, and `RaskGlobalization`
+  decides whether it ships ICU.** `host.UseCulture(c => c.SupportedCultures.Add("hu"))` turns culture
+  support on; the browser's signals — `?culture=`, the remembered cookie, `navigator.languages` — are
+  read in **one synchronous call** so the culture is settled before anything paints. An async probe
+  would either delay the first paint or let the app paint in the wrong language and correct itself in a
+  frame the visitor can see, which also rules out `INavigatorInfo.LanguageAsync()`.
+
+  **ICU is opt-in, because it is roughly 2.6 MB.**
+  `<RaskGlobalization>true</RaskGlobalization>` ships it. Rask.Wasm.targets owns the two properties
+  that have to move together, instead of each app writing them by hand: `PredefinedCulturesOnly` is the
+  trap, because it defaults to `true` under invariant globalization and makes
+  `CultureInfo.GetCultureInfo("hu-HU")` **throw** rather than fall back — so an app that shipped ICU but
+  left that default would fail at its first culture lookup. Asking for globalization while also forcing
+  `InvariantGlobalization=true` is now a build error rather than an app that silently formats every
+  culture identically.
+
+  The fast unit gate is unaffected, and slightly better off: `InvariantGlobalization=true` is what
+  forces a native relink, so turning globalization **on** removes the property and the relink trigger
+  with it.
+
+  **The boot screen no longer starts in the wrong direction.** A tiny inline script in the page shell
+  stamps `lang`/`dir` from the remembered cookie before the runtime downloads — which on a cold cache is
+  not a brief moment, and without it a right-to-left visitor watches a left-to-right boot screen and
+  then a layout flip. It reads only the remembered choice, never `navigator.language`: the shell cannot
+  know which languages the app ships, and guessing would cause the very flip it exists to prevent.
+
 - **The server negotiates a visitor's language from their request, before the first byte of HTML.**
   `?culture=` beats a remembered choice, which beats `Accept-Language`, which beats the app's default.
   The culture is seeded onto the session alongside the principal and the route — *before* the initial

--- a/samples/Rask.Example.Auth.WasmCookie/Rask.Example.Auth.WasmCookie.csproj
+++ b/samples/Rask.Example.Auth.WasmCookie/Rask.Example.Auth.WasmCookie.csproj
@@ -18,10 +18,11 @@
     <RunAOTCompilation Condition=" '$(RaskWasmAot)' != 'true' and '$(WasmBuildNative)' != 'false' ">false</RunAOTCompilation>
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>full</TrimMode>
-    <!-- Gated off the fast no-native build (-p:WasmBuildNative=false): the SDK forces a native
-         relink when InvariantGlobalization=true, so the two conflict, and it's irrelevant when
-         no WASM runtime is produced. -->
-    <InvariantGlobalization Condition=" '$(WasmBuildNative)' != 'false' ">true</InvariantGlobalization>
+    <!-- ICU is dropped: this app formats nothing culture-sensitive, so the ~2.6 MB of icudt*.dat is
+         pure payload. Owned by Rask.Wasm.targets now rather than set here — RaskGlobalization is the
+         one property, and it also handles PredefinedCulturesOnly, which defaults to true under
+         invariant globalization and makes CultureInfo.GetCultureInfo("hu-HU") throw rather than fall
+         back. Set <RaskGlobalization>true</RaskGlobalization> to ship ICU. -->
     <NoWarn>$(NoWarn);IL2104</NoWarn>
   </PropertyGroup>
 

--- a/samples/Rask.Example.Auth.WasmJwt/Rask.Example.Auth.WasmJwt.csproj
+++ b/samples/Rask.Example.Auth.WasmJwt/Rask.Example.Auth.WasmJwt.csproj
@@ -18,10 +18,11 @@
     <RunAOTCompilation Condition=" '$(RaskWasmAot)' != 'true' and '$(WasmBuildNative)' != 'false' ">false</RunAOTCompilation>
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>full</TrimMode>
-    <!-- Gated off the fast no-native build (-p:WasmBuildNative=false): the SDK forces a native
-         relink when InvariantGlobalization=true, so the two conflict, and it's irrelevant when
-         no WASM runtime is produced. -->
-    <InvariantGlobalization Condition=" '$(WasmBuildNative)' != 'false' ">true</InvariantGlobalization>
+    <!-- ICU is dropped: this app formats nothing culture-sensitive, so the ~2.6 MB of icudt*.dat is
+         pure payload. Owned by Rask.Wasm.targets now rather than set here — RaskGlobalization is the
+         one property, and it also handles PredefinedCulturesOnly, which defaults to true under
+         invariant globalization and makes CultureInfo.GetCultureInfo("hu-HU") throw rather than fall
+         back. Set <RaskGlobalization>true</RaskGlobalization> to ship ICU. -->
     <NoWarn>$(NoWarn);IL2104</NoWarn>
   </PropertyGroup>
 

--- a/samples/Rask.Example.Playground/Rask.Example.Playground.csproj
+++ b/samples/Rask.Example.Playground/Rask.Example.Playground.csproj
@@ -21,7 +21,11 @@
          showcase remains trim-full + zero-IL; this isolation is exactly why the playground is a separate
          sub-app). ICU is still dropped: Roslyn and the playground format nothing culture-sensitive. -->
     <PublishTrimmed>false</PublishTrimmed>
-    <InvariantGlobalization Condition=" '$(WasmBuildNative)' != 'false' ">true</InvariantGlobalization>
+    <!-- ICU is dropped: this app formats nothing culture-sensitive, so the ~2.6 MB of icudt*.dat is
+         pure payload. Owned by Rask.Wasm.targets now rather than set here — RaskGlobalization is the
+         one property, and it also handles PredefinedCulturesOnly, which defaults to true under
+         invariant globalization and makes CultureInfo.GetCultureInfo("hu-HU") throw rather than fall
+         back. Set <RaskGlobalization>true</RaskGlobalization> to ship ICU. -->
     <!-- Ship managed assemblies as plain PE, not WebCIL. The in-browser compiler downloads the shipped
          _framework assemblies and hands them to Roslyn as MetadataReferences, and Roslyn can only read a
          PE/COFF image — it cannot parse the WebCIL wrapper the WASM SDK emits by default. -->

--- a/samples/Rask.Example.Shared/Features/Gantt/Gantt.cs
+++ b/samples/Rask.Example.Shared/Features/Gantt/Gantt.cs
@@ -247,8 +247,11 @@ public sealed partial class Gantt : Component
         return JsonSerializer.Serialize(payload, GanttJsonContext.Default.GanttJsOptions);
     }
 
-    // The WASM showcase runs InvariantGlobalization, so pin the culture rather than inheriting the
-    // ambient one — an ISO date is the contract with the library either way.
+    // Invariant because an ISO date is the wire contract with the JS library — not because of how any
+    // particular host happens to be built. (This used to blame the showcase running
+    // InvariantGlobalization; that is now a per-app opt-in, and the reasoning never depended on it.)
+    // A culture-sensitive format here would hand Gantt.js a date it cannot read the moment a visitor
+    // arrived in a locale that writes dates differently.
     private static string ToIso(DateOnly date) => date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
     private static bool TryParseIsoDate(string value, out DateOnly date)

--- a/samples/Rask.Example.Site/Rask.Example.Site.csproj
+++ b/samples/Rask.Example.Site/Rask.Example.Site.csproj
@@ -27,7 +27,11 @@
     <TrimMode>full</TrimMode>
     <!-- The landing page formats no culture-sensitive values, so drop the ~2.6 MB ICU data.
          Gated off the fast no-native build for the same reason as RunAOTCompilation above. -->
-    <InvariantGlobalization Condition=" '$(WasmBuildNative)' != 'false' ">true</InvariantGlobalization>
+    <!-- ICU is dropped: this app formats nothing culture-sensitive, so the ~2.6 MB of icudt*.dat is
+         pure payload. Owned by Rask.Wasm.targets now rather than set here — RaskGlobalization is the
+         one property, and it also handles PredefinedCulturesOnly, which defaults to true under
+         invariant globalization and makes CultureInfo.GetCultureInfo("hu-HU") throw rather than fall
+         back. Set <RaskGlobalization>true</RaskGlobalization> to ship ICU. -->
     <!-- Suppress IL2104 from Microsoft.JSInterop's reflection-driven [JSInvokable] scanner; this app
          only INVOKES JS (never marks methods [JSInvokable]), so that path is never taken. -->
     <NoWarn>$(NoWarn);IL2104</NoWarn>

--- a/samples/Rask.Example.Wasm/Rask.Example.Wasm.csproj
+++ b/samples/Rask.Example.Wasm/Rask.Example.Wasm.csproj
@@ -32,12 +32,11 @@
          carry a documented suppression. -->
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>full</TrimMode>
-    <!-- The showcase doesn't format culture-sensitive values, so drop the ~2.6 MB of ICU data
-         shipped under _framework/icudt*.dat. Gated off the fast no-native build
-         (-p:WasmBuildNative=false, used by the CI `unit` gate): the SDK forces a native relink
-         when InvariantGlobalization=true, so the two are mutually exclusive — and invariant
-         globalization is irrelevant when no WASM runtime is produced. -->
-    <InvariantGlobalization Condition=" '$(WasmBuildNative)' != 'false' ">true</InvariantGlobalization>
+    <!-- ICU is dropped: this app formats nothing culture-sensitive, so the ~2.6 MB of icudt*.dat is
+         pure payload. Owned by Rask.Wasm.targets now rather than set here — RaskGlobalization is the
+         one property, and it also handles PredefinedCulturesOnly, which defaults to true under
+         invariant globalization and makes CultureInfo.GetCultureInfo("hu-HU") throw rather than fall
+         back. Set <RaskGlobalization>true</RaskGlobalization> to ship ICU. -->
     <!-- Suppress IL2104 from Microsoft.JSInterop. The underlying warnings (IL2065 / IL2111)
          live in DotNetDispatcher.ScanAssemblyForCallableMethods — Blazor's reflection-driven
          [JSInvokable] scanner. Rask apps that only INVOKE JS (the common case) never trigger

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.Wasm.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.Wasm.cs
@@ -86,11 +86,12 @@ internal static partial class ProjectGenerator
                  module initialiser, which emits a [DynamicDependency] per registered page. -->
             <PublishTrimmed>true</PublishTrimmed>
             <TrimMode>full</TrimMode>
-            <!-- Drops the ~2.6 MB of ICU data under _framework/icudt*.dat. Remove this if your app
-                 formats culture-sensitive values (dates, numbers, currency). Gated off the fast
-                 no-native build (-p:WasmBuildNative=false): the SDK forces a native relink when
-                 InvariantGlobalization=true, so the two conflict, and it's irrelevant with no runtime. -->
-            <InvariantGlobalization Condition=" '$(WasmBuildNative)' != 'false' ">true</InvariantGlobalization>
+            <!-- ICU (~2.6 MB of icudt*.dat) is dropped by default. Uncomment to ship it, which you
+                 need as soon as the app formats dates, numbers or currency per culture, or shows
+                 text in more than one language. One property: it also sets PredefinedCulturesOnly,
+                 which otherwise defaults to true here and makes CultureInfo.GetCultureInfo("hu-HU")
+                 throw rather than fall back. -->
+            <!-- <RaskGlobalization>true</RaskGlobalization> -->
             <!-- IL2104 comes from Microsoft.JSInterop's reflection-driven [JSInvokable] scanner; apps
                  that only INVOKE JS never hit it. If you mark methods [JSInvokable], add a
                  [DynamicDependency] on them (standard Blazor WASM mitigation) instead of suppressing. -->

--- a/src/Rask.Wasm/Browser/index.html
+++ b/src/Rask.Wasm/Browser/index.html
@@ -42,6 +42,40 @@
     <link href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='22 6 80 108'%3E%3ClinearGradient id='b' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop offset='0' stop-color='%237C3AED'/%3E%3Cstop offset='1' stop-color='%23512BD4'/%3E%3C/linearGradient%3E%3Cpath d='M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z' fill='url(%23b)'/%3E%3C/svg%3E" rel="icon"
           type="image/svg+xml"/>
     <style id="rask-scoped"></style>
+    <!--
+      Stamp the visitor's language onto <html> before anything paints.
+
+      The boot screen below is the first thing they see, and it is on screen for as long as the runtime
+      takes to download — which on a cold cache is not brief. Without this, an RTL visitor watches a
+      left-to-right boot screen and then a layout flip once the app renders. Reading the remembered
+      choice here costs one synchronous regex and needs no runtime.
+
+      Only the REMEMBERED choice is read: navigator.language is deliberately not consulted, because the
+      app may not support it, and this script has no way to know which languages the app ships. Guessing
+      wrong here would cause the very flip it exists to prevent. An unremembered visitor keeps the
+      document default until the runtime negotiates properly a moment later.
+    -->
+    <script>
+        (function () {
+            try {
+                var m = document.cookie.match(/(?:^|;\s*)\.AspNetCore\.Culture=([^;]*)/);
+                if (!m) return;
+                var v = decodeURIComponent(m[1]);
+                var c = /(?:^|\|)c=([^|]*)/.exec(v);
+                var tag = c ? c[1] : (v.indexOf("=") < 0 ? v : "");
+                if (!/^[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*$/.test(tag)) return;
+                document.documentElement.lang = tag;
+                // The RTL scripts, by language subtag. A short list beats pulling in Intl.Locale, which
+                // is exactly the globalization data this app may have been built without.
+                var rtl = ["ar", "arc", "az", "dv", "fa", "he", "ku", "ps", "sd", "ug", "ur", "yi"];
+                if (rtl.indexOf(tag.split("-")[0].toLowerCase()) >= 0) {
+                    document.documentElement.dir = "rtl";
+                }
+            } catch (e) {
+                // Cookies disabled, or a document that throws on access. The app still boots.
+            }
+        })();
+    </script>
     <style>
         .rask-boot {
             position: fixed;

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -3658,6 +3658,40 @@ export function getLocation() {
     return stripBase(location.pathname) + location.search;
 }
 
+// The visitor's language signals, read in one synchronous call so the culture is settled before the
+// first render rather than corrected in a second frame.
+//
+// No regex literals in here on purpose: this file is spliced and minified by RaskMinifyJs, whose
+// tokenizer does not reliably distinguish a regex literal from division. Plain string work is not
+// worth a mis-parse that would only show up in a published bundle.
+export function getCultureSignals() {
+    let cookie = null;
+    try {
+        const parts = document.cookie ? document.cookie.split("; ") : [];
+        const prefix = ".AspNetCore.Culture=";
+        for (let i = 0; i < parts.length; i++) {
+            if (parts[i].indexOf(prefix) === 0) {
+                cookie = decodeURIComponent(parts[i].slice(prefix.length));
+                break;
+            }
+        }
+    } catch (e) {
+        // A document with cookies disabled throws on access rather than answering empty.
+    }
+    let query = null;
+    try {
+        query = new URLSearchParams(location.search).get("culture");
+    } catch (e) {
+    }
+    return JSON.stringify({
+        query: query,
+        cookie: cookie,
+        languages: (navigator.languages && navigator.languages.length)
+            ? Array.prototype.slice.call(navigator.languages)
+            : (navigator.language ? [navigator.language] : []),
+    });
+}
+
 export function getBaseAddress() {
     // The app root (origin + base path), NOT document.baseURI. document.baseURI reflects the
     // *current* SPA route once the app has navigated (the <base> element is not in the live DOM

--- a/src/Rask.Wasm/JSInterop.cs
+++ b/src/Rask.Wasm/JSInterop.cs
@@ -163,6 +163,20 @@ internal static partial class JSInterop
     public static partial string GetBaseAddress();
 
     /// <summary>
+    ///     The visitor's language signals — <c>?culture=</c>, the culture cookie and
+    ///     <c>navigator.languages</c> — as one JSON object.
+    /// </summary>
+    /// <remarks>
+    ///     Synchronous, and all three in a single call, deliberately. The culture has to be settled
+    ///     BEFORE the first render, and an async probe would either delay the first paint or let the app
+    ///     paint in the wrong language and correct itself in a second frame the visitor would see. That
+    ///     also rules out <c>INavigatorInfo.LanguageAsync()</c>, which is async by design — and on the
+    ///     Server host is a socket round trip.
+    /// </remarks>
+    [JSImport("getCultureSignals", ModuleName)]
+    public static partial string GetCultureSignals();
+
+    /// <summary>
     ///     Browser sub-path prefix derived from <c>&lt;base href&gt;</c>. Returns the
     ///     directory portion (e.g. <c>"/Rask/"</c> when hosted at <c>/Rask/index.html</c>
     ///     or <c>"/"</c> at the origin root). <see cref="WasmHostBuilder.CreateDefault()" />
@@ -219,6 +233,9 @@ internal static partial class JSInterop
     public static void ApplyRender(Span<byte> payload) { }
     public static string GetLocation() => "/";
     public static string GetBaseAddress() => "/";
+
+    /// <summary>No browser, so no signals — the app falls back to its configured default culture.</summary>
+    public static string GetCultureSignals() => "{}";
     public static void PushHistory(string url, bool replace) { }
 
     public static string GetBasePath() => "/";

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -407,6 +407,40 @@ export function getLocation() {
     return stripBase(location.pathname) + location.search;
 }
 
+// The visitor's language signals, read in one synchronous call so the culture is settled before the
+// first render rather than corrected in a second frame.
+//
+// No regex literals in here on purpose: this file is spliced and minified by RaskMinifyJs, whose
+// tokenizer does not reliably distinguish a regex literal from division. Plain string work is not
+// worth a mis-parse that would only show up in a published bundle.
+export function getCultureSignals() {
+    let cookie = null;
+    try {
+        const parts = document.cookie ? document.cookie.split("; ") : [];
+        const prefix = ".AspNetCore.Culture=";
+        for (let i = 0; i < parts.length; i++) {
+            if (parts[i].indexOf(prefix) === 0) {
+                cookie = decodeURIComponent(parts[i].slice(prefix.length));
+                break;
+            }
+        }
+    } catch (e) {
+        // A document with cookies disabled throws on access rather than answering empty.
+    }
+    let query = null;
+    try {
+        query = new URLSearchParams(location.search).get("culture");
+    } catch (e) {
+    }
+    return JSON.stringify({
+        query: query,
+        cookie: cookie,
+        languages: (navigator.languages && navigator.languages.length)
+            ? Array.prototype.slice.call(navigator.languages)
+            : (navigator.language ? [navigator.language] : []),
+    });
+}
+
 export function getBaseAddress() {
     // The app root (origin + base path), NOT document.baseURI. document.baseURI reflects the
     // *current* SPA route once the app has navigated (the <base> element is not in the live DOM

--- a/src/Rask.Wasm/WasmCultureSeeder.cs
+++ b/src/Rask.Wasm/WasmCultureSeeder.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using Rask.Core.Diagnostics;
+using Rask.Core.Globalization;
+
+namespace Rask.Wasm;
+
+/// <summary>
+///     Reads the browser's language signals and settles the app's culture before its first render.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The WASM counterpart of the server's request negotiation, answering the same order:
+///         <c>?culture=</c>, then the remembered cookie, then <c>navigator.languages</c>, then the app's
+///         default. Because the whole app is one visitor, the culture it produces is a singleton rather
+///         than something per session.
+///     </para>
+///     <para>
+///         The payload is read with <see cref="JsonDocument" /> rather than deserialized into a record:
+///         <c>Rask.Wasm</c> is marked trimmable and AOT-compatible under warnings-as-errors, so a
+///         reflection-based <c>JsonSerializer.Deserialize</c> is a build error here. Three fields do not
+///         justify a <c>JsonSerializerContext</c>.
+///     </para>
+/// </remarks>
+internal static class WasmCultureSeeder
+{
+    /// <summary>Negotiates from the browser and seeds the app's culture. A no-op when no languages are configured.</summary>
+    public static void Seed(IServiceProvider services)
+    {
+        if (services.GetService(typeof(RaskCultureOptions)) is not RaskCultureOptions options
+            || options.SupportedCultures.Count == 0)
+        {
+            return;
+        }
+
+        var negotiation = Negotiate(JSInterop.GetCultureSignals(), options);
+
+        if (services.GetService(typeof(IRaskCulture)) is SessionCulture culture)
+        {
+            culture.Seed(negotiation);
+        }
+    }
+
+    /// <summary>
+    ///     Negotiates from a raw <c>getCultureSignals()</c> payload.
+    /// </summary>
+    /// <remarks>
+    ///     Split from <see cref="Seed" /> so the decision can be asserted without a browser: on the
+    ///     non-browser target framework the JS import is a stub that always answers <c>{}</c>, which
+    ///     would make every test of this logic vacuous.
+    /// </remarks>
+    internal static CultureNegotiation Negotiate(string signalsJson, RaskCultureOptions options)
+    {
+        string? query = null;
+        string? cookie = null;
+        List<string>? languages = null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(signalsJson);
+            var root = doc.RootElement;
+
+            if (root.ValueKind == JsonValueKind.Object)
+            {
+                query = ReadString(root, "query");
+                cookie = ReadString(root, "cookie");
+
+                if (root.TryGetProperty("languages", out var list) && list.ValueKind == JsonValueKind.Array)
+                {
+                    languages = new List<string>(list.GetArrayLength());
+                    foreach (var entry in list.EnumerateArray())
+                    {
+                        if (entry.ValueKind == JsonValueKind.String && entry.GetString() is { Length: > 0 } tag)
+                        {
+                            languages.Add(tag);
+                        }
+                    }
+                }
+            }
+        }
+        catch (JsonException ex)
+        {
+            // A malformed answer means a browser quirk, not a broken app: fall through to the default
+            // culture rather than taking the boot down over a language preference.
+            RaskDiagnostics.Report(
+                RaskLogLevel.Warning,
+                "Rask.Wasm",
+                "[Rask.Wasm] could not read the browser's language signals; using the default culture",
+                ex);
+        }
+
+        return RaskCultureNegotiator.Negotiate(query, cookie, languages, options);
+    }
+
+    private static string? ReadString(JsonElement root, string name) =>
+        root.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+}

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -47,7 +47,9 @@ public sealed class WasmHostBuilder
 
         // Singleton, unlike the server's scoped registration: the whole WASM app is one visitor, so
         // there is exactly one culture for its lifetime.
-        Services.AddRaskCulture(lifetime: ServiceLifetime.Singleton);
+        // Deferred to a factory so UseCulture can still be called after the builder is constructed —
+        // the ctor runs before the app's own configuration does.
+        Services.AddRaskCulture(o => _configureCulture?.Invoke(o), ServiceLifetime.Singleton);
         // Typed browser/device API wrappers, Singleton (one per app instance). Registered via the shared
         // helpers (RaskBrowserApis / RaskWasmBrowserApis) so the interface → impl list lives in one place
         // instead of duplicated across hosts. TryAdd inside the helpers means an app can pre-register a
@@ -79,6 +81,7 @@ public sealed class WasmHostBuilder
     }
 
     private WebAppManifest? _manifest;
+    private Action<RaskCultureOptions>? _configureCulture;
 
     // The wire-payload shape this app renders with, snapshotted from RaskLiveOptions in CreateDefault
     // and handed to the WasmLiveSession — a per-session value instead of the former process-global
@@ -103,6 +106,29 @@ public sealed class WasmHostBuilder
     public WasmHostBuilder UsePwa(WebAppManifest manifest)
     {
         _manifest = manifest;
+        return this;
+    }
+
+    /// <summary>
+    ///     The languages this app ships, and how a visitor's is chosen.
+    /// </summary>
+    /// <remarks>
+    ///     Leaving this uncalled keeps culture support off, and the app renders exactly as it did before:
+    ///     <c>&lt;html lang="en"&gt;</c> with no <c>dir</c>.
+    ///     <para>
+    ///         <b>A WASM app also needs ICU</b>, which Rask does not ship by default because it is roughly
+    ///         2.6 MB. Add <c>&lt;RaskGlobalization&gt;true&lt;/RaskGlobalization&gt;</c> to the project
+    ///         file. Without it every culture formats identically and only the invariant culture
+    ///         resolves — the app still runs, and says so once at startup rather than once per render.
+    ///     </para>
+    ///     <code>
+    ///     host.UseCulture(c => { c.SupportedCultures.Add("en"); c.SupportedCultures.Add("hu"); });
+    ///     </code>
+    /// </remarks>
+    public WasmHostBuilder UseCulture(Action<RaskCultureOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        _configureCulture = configure;
         return this;
     }
 
@@ -205,6 +231,10 @@ public sealed class WasmHostBuilder
         var routeState = provider.GetRequiredService<RouteState>();
         RouteSeeder.Seed(JSInterop.GetLocation(), routeState);
         Console.WriteLine($"[Rask.Wasm] initial path={routeState.Path}");
+
+        // The visitor's language, settled before the first render for the same reason the route is:
+        // painting in the wrong one and correcting it afterwards is a flash the visitor sees.
+        WasmCultureSeeder.Seed(provider);
 
         if (provider.GetService<IUserProvider>() is { } userProvider)
         {

--- a/src/Rask.Wasm/build/Rask.Wasm.targets
+++ b/src/Rask.Wasm/build/Rask.Wasm.targets
@@ -246,4 +246,56 @@
            Text="Rask: the scoped-asset bake did not run during this publish and $(PublishDir)wwwroot/_rask/a is empty, so any scoped CSS/JS this app has would 404 in the browser and any component relying on it would never initialise. The bake target (_RaskBakeScopedStaticWebAssets) is skipped when RaskWasm is not 'true' or when Rask.Wasm.Tasks.dll is missing next to Rask.Wasm.targets — check both, then clear $(IntermediateOutputPath) and publish again."/>
   </Target>
 
+  <!--
+    Globalization for a WASM app: RaskGlobalization decides whether ICU ships.
+
+    OFF by default, because ICU is roughly 2.6 MB of icudt*.dat and most apps format nothing
+    culture-sensitive. An app that does turns it on with one line:
+
+      <RaskGlobalization>true</RaskGlobalization>
+
+    Owned here rather than written by hand in every app's csproj so that the two properties which have
+    to move together cannot drift apart. PredefinedCulturesOnly is the trap: it DEFAULTS to true
+    whenever InvariantGlobalization is true, and under it CultureInfo.GetCultureInfo("hu-HU") does not
+    quietly fall back — it THROWS. Setting it explicitly on the opt-in path means a stray
+    InvariantGlobalization elsewhere in a build cannot silently re-arm that.
+
+    The WasmBuildNative guard is preserved from the per-app property this replaces. InvariantGlobalization=true
+    forces a native relink, which conflicts with the fast unit gate (-p:WasmBuildNative=false) — and with
+    no runtime produced, invariant globalization is irrelevant anyway. Note the direction: turning
+    globalization ON removes the property entirely and so removes that relink trigger, which makes the
+    fast gate strictly happier, not less so.
+  -->
+  <PropertyGroup Condition=" '$(RaskWasm)' == 'true' ">
+    <RaskGlobalization Condition=" '$(RaskGlobalization)' == '' ">false</RaskGlobalization>
+    <!--
+      Snapshot before the overwrite below, so the conflict check further down can still tell an app's
+      own InvariantGlobalization from ours. By the time this file is imported the WebAssembly SDK has
+      already defaulted the property to false, so "unset" and "explicitly false" are indistinguishable
+      here — but an explicit TRUE can only have come from the app, which is the case worth catching.
+    -->
+    <_RaskAppInvariantGlobalization>$(InvariantGlobalization)</_RaskAppInvariantGlobalization>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(RaskWasm)' == 'true' AND '$(RaskGlobalization)' != 'true'
+                             AND '$(WasmBuildNative)' != 'false' ">
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(RaskWasm)' == 'true' AND '$(RaskGlobalization)' == 'true' ">
+    <InvariantGlobalization>false</InvariantGlobalization>
+    <PredefinedCulturesOnly>false</PredefinedCulturesOnly>
+  </PropertyGroup>
+
+  <!--
+    The one failure mode the properties above cannot express: an app asks for globalization and ALSO
+    sets InvariantGlobalization=true by hand. The SDK would honour the invariant flag, every culture
+    would format identically, and the app would look like it had simply been given wrong translations.
+    Fail the build instead of shipping that.
+  -->
+  <Target Name="_RaskGlobalizationConflict" BeforeTargets="Build"
+          Condition=" '$(RaskWasm)' == 'true' AND '$(RaskGlobalization)' == 'true' AND '$(_RaskAppInvariantGlobalization)' == 'true' ">
+    <Error Text="Rask: RaskGlobalization is true but InvariantGlobalization is also true, so the runtime would ship without culture data and every culture would format identically — CultureInfo.GetCultureInfo(&quot;hu-HU&quot;) would throw. Remove the InvariantGlobalization property; RaskGlobalization owns it."/>
+  </Target>
+
 </Project>

--- a/tests/Rask.Wasm.Tasks.Tests/GlobalizationPropertyTests.cs
+++ b/tests/Rask.Wasm.Tasks.Tests/GlobalizationPropertyTests.cs
@@ -1,0 +1,97 @@
+namespace Rask.Wasm.Tasks.Tests;
+
+/// <summary>
+///     Pins the <c>RaskGlobalization</c> property flow in <c>Rask.Wasm.targets</c> — the one line that
+///     decides whether a WASM bundle carries ICU.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Two properties have to move together and used to be written by hand in every app's csproj.
+///         <c>PredefinedCulturesOnly</c> is the trap: it defaults to <c>true</c> whenever
+///         <c>InvariantGlobalization</c> is true, and under it <c>CultureInfo.GetCultureInfo("hu-HU")</c>
+///         does not fall back to invariant — it <b>throws</b>. An app that opted into globalization but
+///         left that default in place would fail at the first culture lookup.
+///     </para>
+///     <para>
+///         Following this project's existing convention, these assert the <i>shape</i> of the targets
+///         rather than executing them. The behaviour itself was verified by real evaluation
+///         (<c>dotnet msbuild -getProperty:InvariantGlobalization -getProperty:PredefinedCulturesOnly</c>)
+///         against <c>samples/Rask.Example.Wasm</c> in all three states:
+///         default → <c>true</c>/<c>true</c> (ICU dropped);
+///         <c>-p:RaskGlobalization=true</c> → <c>false</c>/<c>false</c> (ICU shipped, any culture allowed);
+///         <c>-p:WasmBuildNative=false</c> → <c>false</c> (no invariant flag, so no native relink is
+///         forced and the fast unit gate is unaffected).
+///     </para>
+/// </remarks>
+public sealed class GlobalizationPropertyTests
+{
+    private static readonly string _targets = File.ReadAllText(Path.Combine(
+        LocateRepoRoot(), "src", "Rask.Wasm", "build", "Rask.Wasm.targets"));
+
+    [Fact]
+    public void Globalization_is_off_by_default_because_ICU_is_not_free()
+    {
+        Assert.Contains(
+            "<RaskGlobalization Condition=\" '$(RaskGlobalization)' == '' \">false</RaskGlobalization>",
+            _targets,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Opting_in_also_clears_PredefinedCulturesOnly()
+    {
+        // The half everyone forgets. Without it the app ships ICU and still throws on the first
+        // GetCultureInfo("hu-HU"), which looks like a Rask bug rather than a project-file one.
+        var block = Between(
+            "'$(RaskWasm)' == 'true' AND '$(RaskGlobalization)' == 'true' \">",
+            "</PropertyGroup>");
+
+        Assert.Contains("<InvariantGlobalization>false</InvariantGlobalization>", block, StringComparison.Ordinal);
+        Assert.Contains("<PredefinedCulturesOnly>false</PredefinedCulturesOnly>", block, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_fast_unit_gates_build_mode_is_still_exempt()
+    {
+        // InvariantGlobalization=true forces a native relink, which conflicts with the no-native build
+        // the unit gate uses (-p:WasmBuildNative=false). This guard came from the per-app property this
+        // block replaced and has to survive the move, or the gate starts relinking.
+        Assert.Contains(
+            "'$(RaskGlobalization)' != 'true'\n                             AND '$(WasmBuildNative)' != 'false' \">",
+            _targets.Replace("\r\n", "\n"),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Asking_for_globalization_while_forcing_invariant_fails_the_build()
+    {
+        // The one contradiction the properties cannot resolve: the SDK would honour the invariant flag,
+        // every culture would format identically, and the app would look like it had simply been given
+        // wrong translations. Detected against a snapshot taken BEFORE the overwrite, because by then
+        // the SDK has already defaulted the property and "unset" is indistinguishable from "false".
+        Assert.Contains("_RaskGlobalizationConflict", _targets, StringComparison.Ordinal);
+        Assert.Contains(
+            "'$(_RaskAppInvariantGlobalization)' == 'true'", _targets, StringComparison.Ordinal);
+    }
+
+    private static string Between(string start, string end)
+    {
+        var from = _targets.IndexOf(start, StringComparison.Ordinal);
+        Assert.True(from >= 0, $"expected to find {start} in Rask.Wasm.targets");
+        var to = _targets.IndexOf(end, from, StringComparison.Ordinal);
+        Assert.True(to > from, $"expected {end} after {start}");
+        return _targets[from..to];
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+}

--- a/tests/Rask.Wasm.Tests/Globalization/WasmCultureSeederTests.cs
+++ b/tests/Rask.Wasm.Tests/Globalization/WasmCultureSeederTests.cs
@@ -1,0 +1,90 @@
+using Rask.Core.Globalization;
+
+namespace Rask.Wasm.Tests.Globalization;
+
+// The browser half of negotiation: what the app decides from the signals a page can offer, before its
+// first render. Same order as the server's, because a visitor should not get a different language from
+// the same app depending on how it is hosted.
+public class WasmCultureSeederTests
+{
+    private static RaskCultureOptions Options(params string[] supported)
+    {
+        var options = new RaskCultureOptions();
+        foreach (var name in supported)
+        {
+            options.SupportedCultures.Add(name);
+        }
+
+        return options;
+    }
+
+    [Fact]
+    public void The_url_beats_the_remembered_choice_which_beats_the_browsers_list()
+    {
+        var options = Options("en", "hu", "de");
+
+        Assert.Equal("hu", Negotiate("""{"query":"hu","cookie":"c=de|uic=de","languages":["en"]}""", options));
+        Assert.Equal("de", Negotiate("""{"query":null,"cookie":"c=de|uic=de","languages":["en"]}""", options));
+        Assert.Equal("en", Negotiate("""{"languages":["en"]}""", options));
+    }
+
+    [Fact]
+    public void The_browsers_list_is_honoured_in_order()
+    {
+        var options = Options("en", "hu", "de");
+        Assert.Equal("de", Negotiate("""{"languages":["ja","de","hu"]}""", options));
+    }
+
+    [Fact]
+    public void An_unsupported_language_falls_back_to_the_apps_default()
+    {
+        var options = Options("en", "hu");
+        Assert.Equal("en", Negotiate("""{"query":"ja-JP","languages":["ja-JP"]}""", options));
+    }
+
+    [Fact]
+    public void A_region_is_served_by_the_language_the_app_ships()
+    {
+        var options = Options("en", "hu");
+        Assert.Equal("hu", Negotiate("""{"languages":["hu-HU"]}""", options));
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("""{"query":null,"cookie":null,"languages":[]}""")]
+    [InlineData("""{"languages":null}""")]
+    [InlineData("not json at all")]
+    [InlineData("[]")]
+    [InlineData("""{"languages":[1,2,3]}""")]
+    public void A_page_that_offers_nothing_usable_still_gets_the_default(string signals)
+    {
+        // Every one of these is a real browser state — cookies disabled, a privacy mode that hides
+        // navigator.languages, an old bundle answering a shape this build does not expect. None of them
+        // may take the boot down over a language preference.
+        var options = Options("en", "hu");
+        Assert.Equal("en", Negotiate(signals, options));
+    }
+
+    [Fact]
+    public void The_cookie_is_read_in_the_form_the_server_writes_it()
+    {
+        // The server writes ASP.NET's own c=..|uic=.. payload, and rask.wasm.js URL-decodes the cookie
+        // before handing it over — so what arrives here is the decoded pair. A visitor who picked a
+        // language on the server half must keep it when the same app runs in the browser.
+        var options = Options("en", "hu");
+        Assert.Equal("hu", Negotiate("""{"cookie":"c=hu|uic=hu"}""", options));
+        Assert.Equal("hu", Negotiate("""{"cookie":"hu"}""", options));
+    }
+
+    [Fact]
+    public void An_app_with_no_configured_languages_negotiates_nothing()
+    {
+        var result = WasmCultureSeeder.Negotiate(
+            """{"query":"hu","languages":["hu"]}""", new RaskCultureOptions());
+
+        Assert.Equal(System.Globalization.CultureInfo.InvariantCulture, result.Culture);
+    }
+
+    private static string Negotiate(string signals, RaskCultureOptions options) =>
+        WasmCultureSeeder.Negotiate(signals, options).Culture.Name;
+}


### PR DESCRIPTION
Fourth step of the global culture / localization epic. **Stacked on #822** (→ #821 → #819) — retarget
to `main` as its parents merge.

Brings the culture from #821 to the browser, and makes ICU a single property instead of a thing every
app copy-pastes.

## Negotiation, before anything paints

`host.UseCulture(c => c.SupportedCultures.Add("hu"))` turns culture support on. The browser's signals —
`?culture=`, the remembered cookie, `navigator.languages` — are read in **one synchronous call**.

That is deliberate. The culture has to be settled before the first render, and an async probe would
either delay the first paint or let the app paint in the wrong language and correct itself in a frame
the visitor can see. It is also why `INavigatorInfo.LanguageAsync()` is not the source here — it is
async by design, and on the Server host it is a socket round trip.

Same order as the server's negotiation, so a visitor does not get a different language from the same
app depending on how it is hosted.

## ICU is one property now

```xml
<RaskGlobalization>true</RaskGlobalization>
```

Off by default, because ICU is roughly **2.6 MB** of `icudt*.dat` and most apps format nothing
culture-sensitive.

`Rask.Wasm.targets` owns the two properties that have to move together, instead of each app writing
them by hand. **`PredefinedCulturesOnly` is the trap**: it defaults to `true` whenever
`InvariantGlobalization` is true, and under it `CultureInfo.GetCultureInfo("hu-HU")` does not fall back
— it **throws**. An app that shipped ICU but left that default in place would fail at its first culture
lookup, and it would look like a Rask bug rather than a project-file one.

Asking for globalization *and* forcing `InvariantGlobalization=true` is now a build error, rather than
an app that silently formats every culture identically and looks merely mistranslated.

**Verified by real evaluation**, not by reading the XML —
`dotnet msbuild -getProperty:InvariantGlobalization -getProperty:PredefinedCulturesOnly` against
`samples/Rask.Example.Wasm`:

| State | `InvariantGlobalization` | `PredefinedCulturesOnly` |
|---|---|---|
| default | `true` | `true` |
| `-p:RaskGlobalization=true` | `false` | `false` |
| `-p:WasmBuildNative=false` | `false` | — |

The fast unit gate is unaffected and slightly **better** off: `InvariantGlobalization=true` is what
forces a native relink, so turning globalization *on* removes the property and the relink trigger with
it.

## The boot screen no longer starts in the wrong direction

A small inline script in the page shell stamps `lang`/`dir` from the remembered cookie before the
runtime downloads. On a cold cache that is not a brief moment, and without it a right-to-left visitor
watches a left-to-right boot screen and then a layout flip once the app renders.

It reads **only the remembered choice**, never `navigator.language`: the shell cannot know which
languages the app ships, so guessing there would cause the very flip it exists to prevent.

## Two things the environment caught

- **No regex literals in `getCultureSignals`.** `rask.wasm.js` is spliced and minified by
  `RaskMinifyJs`, whose tokenizer does not reliably tell a regex literal from division. My first
  version used them — a mis-parse that would have surfaced only in a published bundle. Rewritten with
  plain string work, with the reason in a comment so it does not come back.
- **`JsonDocument`, not `JsonSerializer.Deserialize`.** `Rask.Wasm` is `IsTrimmable` and
  `IsAotCompatible` under warnings-as-errors, so reflection-based deserialization is a build error
  here. Three fields do not justify a `JsonSerializerContext`.

## Also

Corrects a `Gantt.cs` comment that blamed the showcase's `InvariantGlobalization` for its invariant ISO
date formatting. The ISO format is the wire contract with the JS library and never depended on how the
host was built — the comment would have become actively misleading with globalization now per-app.

## Testing

`scripts/run-unit-local.sh` green, pre-push browser E2E gate green. 16 new tests: 12 covering
negotiation from every browser state that actually occurs (cookies disabled, privacy mode hiding
`navigator.languages`, a malformed payload, an unexpected shape), and 4 pinning the property flow.

The seeder's parsing is split from its JS call so those 12 are not vacuous — on the non-browser target
framework the import is a stub that always answers `{}`.
