### PR TITLE
feat(generators): compile translated text from JSON, so a missing key cannot ship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **Translated text is generated from JSON, and a missing key is a compile error.**
+  `Resources/Strings.en.json` beside `Resources/Strings.hu.json` becomes
+  `Strings.Greeting(user.Name)` — a real member, with real parameters.
+
+  **The point is what happens when you get it wrong.** A typo'd key is **CS0117**, and the wrong number
+  of arguments is **CS1501**: ordinary C# errors, at the call site, before anything runs. A
+  stringly-typed lookup would instead render the key itself to a user, which is the classic way a
+  localized app fails in production.
+
+  **Placeholders are named** — `{name}`, optionally `{count:int}`, optionally `{price:decimal:C}`.
+  Named because other languages reorder arguments, so the correctness rule is that the *set* of names
+  matches the neutral catalog, not the order. A translation that disagrees is **RASK051**, an error,
+  because `string.Format` would throw `FormatException` the first time that string rendered — in that
+  one language only.
+
+  **A missing translation is a warning, not an error** (**RASK052**), because a partly translated app
+  is the normal state of every real project: the neutral text is used until it is filled in. Promote it
+  to an error in `.editorconfig` to gate a release on complete translations.
+
+  **Nothing reflects, and nothing ships in a satellite assembly.** Lookup is a generated `switch` over a
+  BCP 47 **string**, never a `CultureInfo` — which is what lets an app ship in three languages under
+  `InvariantGlobalization`, where constructing a culture throws. Only placeholder *formatting* falls
+  back to invariant there. A key with no placeholders compiles to a property returning an interned
+  literal, so reading one allocates nothing.
+
+  Fallback walks `hu-HU` → `hu` → the neutral catalog, and "the key itself" is a state that cannot
+  occur: a key absent from the neutral catalog generates no member, so it cannot be referenced.
+
 - **A WASM app negotiates the visitor's language before its first render, and `RaskGlobalization`
   decides whether it ships ICU.** `host.UseCulture(c => c.SupportedCultures.Add("hu"))` turns culture
   support on; the browser's signals — `?culture=`, the remembered cookie, `navigator.languages` — are

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -85,6 +85,8 @@ dotnet_analyzer_diagnostic.category-Rask.severity = warning
 | RASK048 | — | *Retired* — HTML cannot sit inside a native screen |
 | RASK049 | — | *Retired* — a `NativeWebView` set a `Url` and took children |
 | RASK050 | — | *Retired* — a native head was named on a web-only host |
+| [RASK051](#rask051) | Error | Translation catalog is malformed |
+| [RASK052](#rask052) | Warning | Translation catalog disagrees with the neutral catalog |
 | [RASK053](#rask053) | Error | Remote message has no wire encoding |
 
 ---
@@ -998,6 +1000,75 @@ inside a native screen (RASK048), a `NativeWebView` that set a `Url` *and* took 
 native head named on a web-only host (RASK050). Rask is a web framework — `Rask.Native` and every type
 those rules mentioned are gone, so none of the mistakes they caught can be written any more. The ids are
 retired, not reused.
+
+## RASK051
+
+**Translation catalog is malformed** · Error
+
+A translation catalog is a JSON object whose values are text or further objects, named
+`Resources/{Family}.{culture}.json`. This fires when one cannot be read, or when it describes strings
+that would fail at runtime.
+
+```jsonc
+// Resources/Strings.en.json
+{
+  "Greeting": "Hello, {name}!",
+  "Home": { "Title": "Dashboard" }
+}
+```
+
+The reported cause names the file and the problem:
+
+| Cause | Why it is an error |
+|---|---|
+| a JSON syntax error, a duplicate key, a value that is not text or an object | nothing can be generated |
+| a key that is not a usable C# identifier | the member it would generate cannot be written |
+| an unclosed `{`, a stray `}`, a mix of `{0}` and `{name}` | the message cannot be turned into a format string |
+| a translation whose **placeholder set** differs from the neutral catalog's | `string.Format` throws `FormatException` the first time that string renders — in that one language only |
+| no catalog for the neutral language | nothing defines which keys exist |
+
+The placeholder rule is about the *set*, not the order: other languages reorder arguments, and naming
+placeholders is what makes that safe.
+
+```jsonc
+// Resources/Strings.hu.json — fine, the same names in a different order
+{ "M": "{b} majd {a}" }
+
+// ✗ RASK051 — {nev} is not {name}, so this would throw when a Hungarian visitor sees it
+{ "Greeting": "Szia, {nev}!" }
+```
+
+**Fix:** correct the file the message names. A JSON file in `Resources/` that is *not* a catalog needs
+no action — one without a culture tag in its name is ignored.
+
+## RASK052
+
+**Translation catalog disagrees with the neutral catalog** · Warning
+
+The neutral catalog defines which keys exist; a translation supplies their text. This fires when a
+translation is missing a key, or carries one the neutral catalog does not define.
+
+```jsonc
+// Resources/Strings.en.json
+{ "Save": "Save", "Cancel": "Cancel" }
+
+// Resources/Strings.hu.json
+{ "Save": "Mentés" }        // ⚠ RASK052 — no translation for 'Cancel'
+```
+
+A missing translation is a **warning**, not an error, because a partly translated app is the normal
+state of every real project: the neutral text is used until it is filled in, so the page works. The
+opposite case — a key only a translation has — is also a warning: it generates nothing and is almost
+always a rename that was applied to one file.
+
+**Fix:** add the key, or delete it. To gate a release on complete translations, promote it:
+
+```ini
+# .editorconfig
+dotnet_diagnostic.RASK052.severity = error
+```
+
+Or silence it while translation is in progress with `= none`.
 
 ## RASK053
 

--- a/src/Rask.Core/build/Rask.Core.targets
+++ b/src/Rask.Core/build/Rask.Core.targets
@@ -39,6 +39,11 @@
   <ItemGroup>
     <CompilerVisibleProperty Include="RaskScopedJsAutoInclude"/>
     <CompilerVisibleProperty Include="RaskBuilderEntryInjection"/>
+    <!-- The language a catalog's keys are DEFINED in, and whose text is used when a translation is
+         missing. Falls back to $(NeutralLanguage) and then to "en". -->
+    <CompilerVisibleProperty Include="RaskNeutralLanguage"/>
+    <!-- The generated catalog class lands in the app's own namespace. -->
+    <CompilerVisibleProperty Include="RootNamespace"/>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(RaskScopedCssAutoInclude)' != 'false' ">
@@ -55,6 +60,28 @@
     rask.wasm.js, main.js, rask-morph.js, rask-scoped.js) don't get vacuumed up by
     consumers' builds. Opt out entirely with <RaskScopedJsAutoInclude>false</…>.
   -->
+  <!--
+    Translation catalogs: Resources/{Family}.{culture}.json, handed to TranslationCatalogGenerator as
+    <AdditionalFiles> so it can emit compile-checked members for their keys.
+
+    Scoped to Resources/ rather than the whole project, because a JSON file anywhere else is an app's
+    own data and has nothing to do with translation. Every catalog carries a culture tag in its name —
+    including the neutral language's — which is what keeps a sibling Resources/seed-data.json out of
+    the generator without needing a diagnostic to explain why it was ignored.
+
+    Opt out with <RaskTranslationsAutoInclude>false</RaskTranslationsAutoInclude> and add the files by
+    hand, exactly as the scoped-CSS/JS globs allow.
+  -->
+  <PropertyGroup>
+    <RaskNeutralLanguage Condition=" '$(RaskNeutralLanguage)' == '' ">$(NeutralLanguage)</RaskNeutralLanguage>
+    <RaskNeutralLanguage Condition=" '$(RaskNeutralLanguage)' == '' ">en</RaskNeutralLanguage>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(RaskTranslationsAutoInclude)' != 'false' ">
+    <AdditionalFiles Include="Resources\**\*.json"
+                     Exclude="@(AdditionalFiles);bin\**;obj\**;node_modules\**;wwwroot\**"/>
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(RaskScopedJsAutoInclude)' != 'false' ">
     <AdditionalFiles Include="**\*.js"
                      Exclude="@(AdditionalFiles);bin\**;obj\**;node_modules\**;wwwroot\**;Resources\**;Browser\**"/>

--- a/src/Rask.Generators/Translations/CatalogModel.cs
+++ b/src/Rask.Generators/Translations/CatalogModel.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+
+namespace Rask.Generators.Translations;
+
+// One key in a catalog: the dotted path a caller writes (Home.Title), the text, and where it came
+// from so a diagnostic can point at the line rather than at the file.
+internal sealed class CatalogEntry(string path, string value, int line, int column)
+{
+    public string Path { get; } = path;
+    public string Value { get; } = value;
+    public int Line { get; } = line;
+    public int Column { get; } = column;
+}
+
+// One file: Resources/{Family}.{tag}.json.
+internal sealed class Catalog(string filePath, string family, string cultureTag)
+{
+    public string FilePath { get; } = filePath;
+    public string Family { get; } = family;
+
+    // The BCP 47 tag from the file name. Every catalog carries one, including the neutral language's,
+    // which is what makes "is this JSON a catalog?" a purely syntactic question — an app's own
+    // Resources/seed-data.json is ignored without needing an orphan diagnostic to explain itself.
+    public string CultureTag { get; } = cultureTag;
+
+    public Dictionary<string, CatalogEntry> Entries { get; } = new(StringComparer.Ordinal);
+
+    // Keys in the order they were read, so generated output is stable across builds.
+    public List<string> Order { get; } = [];
+
+    public List<CatalogDefect> Defects { get; } = [];
+
+    public void Add(CatalogEntry entry)
+    {
+        if (Entries.ContainsKey(entry.Path))
+        {
+            Defects.Add(new CatalogDefect(
+                $"duplicate key '{entry.Path}' — remove one of them", entry.Line, entry.Column));
+            return;
+        }
+
+        Entries[entry.Path] = entry;
+        Order.Add(entry.Path);
+    }
+}
+
+// A hard problem with a catalog: it cannot generate code, or the code it generated would throw.
+internal sealed class CatalogDefect(string reason, int line, int column)
+{
+    public string Reason { get; } = reason;
+    public int Line { get; } = line;
+    public int Column { get; } = column;
+}

--- a/src/Rask.Generators/Translations/JsonCatalogReader.cs
+++ b/src/Rask.Generators/Translations/JsonCatalogReader.cs
@@ -1,0 +1,282 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace Rask.Generators.Translations;
+
+/// <summary>
+///     Reads a translation catalog: a JSON object whose values are strings or further objects.
+/// </summary>
+/// <remarks>
+///     Hand-written rather than <c>System.Text.Json</c> because this assembly is a Roslyn analyzer —
+///     netstandard2.0, loaded into csc and into every IDE, and carrying exactly one package reference.
+///     Shipping a serializer alongside it is how an analyzer starts failing to load against whatever
+///     version the IDE already has. The grammar needed here is tiny, and doing it by hand also keeps
+///     precise line/column offsets, so a defect points at the key rather than at the file.
+/// </remarks>
+internal static class JsonCatalogReader
+{
+    public static void Read(string text, Catalog catalog)
+    {
+        var reader = new Reader(text, catalog);
+        reader.ReadDocument();
+    }
+
+    private sealed class Reader(string text, Catalog catalog)
+    {
+        private int _pos;
+        private int _line = 1;
+        private int _lineStart;
+
+        private int Column => _pos - _lineStart + 1;
+
+        public void ReadDocument()
+        {
+            SkipWhitespace();
+            if (!TryExpect('{', "a catalog must be a JSON object mapping keys to text"))
+            {
+                return;
+            }
+
+            ReadObject(prefix: null);
+
+            // Only look for trailing content when the document was otherwise clean. A reader that has
+            // already bailed out mid-document is sitting somewhere arbitrary, so this check would fire
+            // every time and bury the real cause under a second, confusing error.
+            if (catalog.Defects.Count > 0)
+            {
+                return;
+            }
+
+            SkipWhitespace();
+            if (_pos < text.Length)
+            {
+                Defect("trailing content after the closing brace");
+            }
+        }
+
+        private void ReadObject(string? prefix)
+        {
+            SkipWhitespace();
+            if (Peek() == '}')
+            {
+                _pos++;
+                return;
+            }
+
+            while (true)
+            {
+                SkipWhitespace();
+                var keyLine = _line;
+                var keyColumn = Column;
+
+                if (Peek() != '"')
+                {
+                    Defect("expected a quoted key");
+                    return;
+                }
+
+                if (!TryReadString(out var key))
+                {
+                    return;
+                }
+
+                SkipWhitespace();
+                if (!TryExpect(':', $"expected ':' after the key '{key}'"))
+                {
+                    return;
+                }
+
+                var path = prefix is null ? key : prefix + "." + key;
+
+                SkipWhitespace();
+                var c = Peek();
+                if (c == '"')
+                {
+                    if (!TryReadString(out var value))
+                    {
+                        return;
+                    }
+
+                    catalog.Add(new CatalogEntry(path, value, keyLine, keyColumn));
+                }
+                else if (c == '{')
+                {
+                    _pos++;
+                    ReadObject(path);
+                }
+                else
+                {
+                    // A number, bool or null in a catalog is almost always a mistake rather than an
+                    // intent — say which key, because the file may have hundreds.
+                    Defect($"the value for '{path}' is not text or a nested object");
+                    return;
+                }
+
+                SkipWhitespace();
+                if (Peek() == ',')
+                {
+                    _pos++;
+                    continue;
+                }
+
+                if (Peek() == '}')
+                {
+                    _pos++;
+                    return;
+                }
+
+                Defect($"expected ',' or '}}' after the value for '{path}'");
+                return;
+            }
+        }
+
+        private bool TryReadString(out string value)
+        {
+            value = string.Empty;
+            _pos++; // opening quote
+            var sb = new StringBuilder();
+
+            while (_pos < text.Length)
+            {
+                var c = text[_pos];
+                if (c == '"')
+                {
+                    _pos++;
+                    value = sb.ToString();
+                    return true;
+                }
+
+                if (c == '\\')
+                {
+                    _pos++;
+                    if (_pos >= text.Length)
+                    {
+                        break;
+                    }
+
+                    var esc = text[_pos];
+                    switch (esc)
+                    {
+                        case '"': sb.Append('"'); break;
+                        case '\\': sb.Append('\\'); break;
+                        case '/': sb.Append('/'); break;
+                        case 'b': sb.Append('\b'); break;
+                        case 'f': sb.Append('\f'); break;
+                        case 'n': sb.Append('\n'); break;
+                        case 'r': sb.Append('\r'); break;
+                        case 't': sb.Append('\t'); break;
+                        case 'u':
+                            if (_pos + 4 < text.Length
+                                && TryParseHex(text.Substring(_pos + 1, 4), out var code))
+                            {
+                                sb.Append((char)code);
+                                _pos += 4;
+                            }
+                            else
+                            {
+                                Defect("malformed \\u escape");
+                                return false;
+                            }
+
+                            break;
+                        default:
+                            Defect($"unknown escape '\\{esc}'");
+                            return false;
+                    }
+
+                    _pos++;
+                    continue;
+                }
+
+                if (c == '\n')
+                {
+                    Defect("a newline inside a quoted value — use \\n");
+                    return false;
+                }
+
+                sb.Append(c);
+                _pos++;
+            }
+
+            Defect("unterminated text value");
+            return false;
+        }
+
+        private static bool TryParseHex(string s, out int value)
+        {
+            value = 0;
+            foreach (var c in s)
+            {
+                var digit = c switch
+                {
+                    >= '0' and <= '9' => c - '0',
+                    >= 'a' and <= 'f' => c - 'a' + 10,
+                    >= 'A' and <= 'F' => c - 'A' + 10,
+                    _ => -1,
+                };
+
+                if (digit < 0)
+                {
+                    return false;
+                }
+
+                value = (value * 16) + digit;
+            }
+
+            return true;
+        }
+
+        private char Peek() => _pos < text.Length ? text[_pos] : '\0';
+
+        private bool TryExpect(char expected, string reason)
+        {
+            if (Peek() == expected)
+            {
+                _pos++;
+                return true;
+            }
+
+            Defect(reason);
+            return false;
+        }
+
+        private void SkipWhitespace()
+        {
+            while (_pos < text.Length)
+            {
+                var c = text[_pos];
+                if (c == '\n')
+                {
+                    _line++;
+                    _pos++;
+                    _lineStart = _pos;
+                    continue;
+                }
+
+                if (c is ' ' or '\t' or '\r')
+                {
+                    _pos++;
+                    continue;
+                }
+
+                // Line comments are not JSON, but every catalog file eventually grows a note about
+                // where a string appears. Accepting them costs four lines and avoids a defect that
+                // teaches nothing.
+                if (c == '/' && _pos + 1 < text.Length && text[_pos + 1] == '/')
+                {
+                    while (_pos < text.Length && text[_pos] != '\n')
+                    {
+                        _pos++;
+                    }
+
+                    continue;
+                }
+
+                return;
+            }
+        }
+
+        private void Defect(string reason) =>
+            catalog.Defects.Add(new CatalogDefect(reason, _line, Column));
+    }
+}

--- a/src/Rask.Generators/Translations/MessageParser.cs
+++ b/src/Rask.Generators/Translations/MessageParser.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Rask.Generators.Translations;
+
+// One placeholder in a message: the name a caller sees, the CLR type its parameter takes, and any
+// .NET format specifier to apply.
+internal sealed class Placeholder(string name, string clrType, string? format)
+{
+    public string Name { get; } = name;
+    public string ClrType { get; } = clrType;
+    public string? Format { get; } = format;
+}
+
+// A message with its placeholders lifted out: "Hello, {name}!" becomes "Hello, {0}!" plus one
+// placeholder called name.
+internal sealed class ParsedMessage(string format, List<Placeholder> placeholders, string? error)
+{
+    public string Format { get; } = format;
+    public List<Placeholder> Placeholders { get; } = placeholders;
+    public string? Error { get; } = error;
+}
+
+/// <summary>
+///     Turns a catalog value into a <c>string.Format</c> template plus a typed parameter list.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Placeholders are named — <c>{name}</c>, optionally <c>{count:int}</c>, optionally
+///         <c>{price:decimal:C}</c>. Named rather than positional because that is what makes reordering
+///         across languages <em>checkable</em>: Hungarian will move the arguments, so the correctness
+///         rule is that the SET of names matches the neutral catalog, not that the order does.
+///     </para>
+///     <para>
+///         Positional <c>{0}</c> is accepted as sugar so the obvious first thing anyone writes compiles,
+///         but a message may not mix the two — the resulting parameter list would be ambiguous to read
+///         and trivial to get wrong at the call site.
+///     </para>
+/// </remarks>
+internal static class MessageParser
+{
+    private static readonly Dictionary<string, string> _types = new(StringComparer.Ordinal)
+    {
+        ["string"] = "string",
+        ["int"] = "int",
+        ["long"] = "long",
+        ["double"] = "double",
+        ["decimal"] = "decimal",
+        ["float"] = "float",
+        ["bool"] = "bool",
+        ["DateTime"] = "global::System.DateTime",
+        ["DateOnly"] = "global::System.DateOnly",
+        ["TimeOnly"] = "global::System.TimeOnly",
+        ["TimeSpan"] = "global::System.TimeSpan",
+        ["Guid"] = "global::System.Guid",
+    };
+
+    public static ParsedMessage Parse(string value)
+    {
+        var format = new StringBuilder();
+        var placeholders = new List<Placeholder>();
+        var byName = new Dictionary<string, int>(StringComparer.Ordinal);
+        var sawNamed = false;
+        var sawPositional = false;
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+
+            if (c == '{')
+            {
+                if (i + 1 < value.Length && value[i + 1] == '{')
+                {
+                    format.Append("{{");
+                    i++;
+                    continue;
+                }
+
+                var close = value.IndexOf('}', i + 1);
+                if (close < 0)
+                {
+                    return Fail("an unclosed '{' — write '{{' for a literal brace");
+                }
+
+                var body = value.Substring(i + 1, close - i - 1);
+                i = close;
+
+                if (body.Length == 0)
+                {
+                    return Fail("an empty placeholder '{}'");
+                }
+
+                var parts = body.Split(':');
+                var name = parts[0].Trim();
+                if (name.Length == 0)
+                {
+                    return Fail("a placeholder with no name");
+                }
+
+                var positional = IsAllDigits(name);
+                if (positional)
+                {
+                    sawPositional = true;
+                    name = "arg" + name;
+                }
+                else
+                {
+                    sawNamed = true;
+                    if (!IsIdentifier(name))
+                    {
+                        return Fail($"'{name}' is not usable as a parameter name");
+                    }
+                }
+
+                if (sawNamed && sawPositional)
+                {
+                    return Fail("a mix of positional {0} and named {name} placeholders — use one or the other");
+                }
+
+                var clrType = "object?";
+                string? fmt = null;
+                if (parts.Length > 1)
+                {
+                    var typeToken = parts[1].Trim();
+                    if (typeToken.Length > 0 && _types.TryGetValue(typeToken, out var mapped))
+                    {
+                        clrType = mapped;
+                        if (parts.Length > 2)
+                        {
+                            fmt = string.Join(":", parts, 2, parts.Length - 2).Trim();
+                        }
+                    }
+                    else
+                    {
+                        // Not a type keyword, so the rest is a .NET format specifier: {when::d} and
+                        // {when:d} mean the same thing.
+                        fmt = string.Join(":", parts, 1, parts.Length - 1).Trim();
+                    }
+
+                    if (fmt is { Length: 0 })
+                    {
+                        fmt = null;
+                    }
+                }
+
+                if (!byName.TryGetValue(name, out var index))
+                {
+                    index = placeholders.Count;
+                    byName[name] = index;
+                    placeholders.Add(new Placeholder(name, clrType, fmt));
+                }
+
+                format.Append('{').Append(index);
+                if (fmt is not null)
+                {
+                    format.Append(':').Append(fmt);
+                }
+
+                format.Append('}');
+                continue;
+            }
+
+            if (c == '}')
+            {
+                if (i + 1 < value.Length && value[i + 1] == '}')
+                {
+                    format.Append("}}");
+                    i++;
+                    continue;
+                }
+
+                return Fail("a stray '}' — write '}}' for a literal brace");
+            }
+
+            format.Append(c);
+        }
+
+        return new ParsedMessage(format.ToString(), placeholders, null);
+
+        static ParsedMessage Fail(string reason) => new(string.Empty, [], reason);
+    }
+
+    private static bool IsAllDigits(string s)
+    {
+        foreach (var c in s)
+        {
+            if (c is < '0' or > '9')
+            {
+                return false;
+            }
+        }
+
+        return s.Length > 0;
+    }
+
+    private static bool IsIdentifier(string s)
+    {
+        if (s.Length == 0 || (!char.IsLetter(s[0]) && s[0] != '_'))
+        {
+            return false;
+        }
+
+        foreach (var c in s)
+        {
+            if (!char.IsLetterOrDigit(c) && c != '_')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Rask.Generators/Translations/TranslationCatalogGenerator.cs
+++ b/src/Rask.Generators/Translations/TranslationCatalogGenerator.cs
@@ -1,0 +1,505 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Rask.Generators.Translations;
+
+/// <summary>
+///     Turns <c>Resources/{Family}.{culture}.json</c> into compile-checked members:
+///     <c>Strings.Greeting(user.Name)</c>.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The point is that a missing key or a wrong argument count is a <b>C# compile error</b> —
+///         CS0117 and CS1501 — rather than a blank on a page or a bare key shown to a user, which is
+///         what a stringly-typed lookup gives you. Nothing here reflects, and nothing ships in a
+///         satellite assembly, so a fully trimmed WASM publish keeps every string.
+///     </para>
+///     <para>
+///         Lookup is keyed on a plain BCP 47 <b>string</b>, never a <c>CultureInfo</c>. That is what lets
+///         translated text work under <c>InvariantGlobalization</c>, where constructing a culture throws:
+///         an app can ship in three languages with no ICU at all, and only placeholder <em>formatting</em>
+///         falls back to invariant.
+///     </para>
+/// </remarks>
+[Generator]
+public sealed class TranslationCatalogGenerator : IIncrementalGenerator
+{
+    private const string DefaultNeutral = "en";
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var files = context.AdditionalTextsProvider
+            .Where(static f => f.Path.EndsWith(".json", System.StringComparison.OrdinalIgnoreCase))
+            .Select(static (f, ct) => (Path: f.Path, Text: f.GetText(ct)?.ToString() ?? string.Empty))
+            .Collect();
+
+        var options = context.AnalyzerConfigOptionsProvider.Select(static (p, _) =>
+        {
+            p.GlobalOptions.TryGetValue("build_property.RaskNeutralLanguage", out var neutral);
+            p.GlobalOptions.TryGetValue("build_property.RootNamespace", out var ns);
+            return (Neutral: string.IsNullOrWhiteSpace(neutral) ? DefaultNeutral : neutral!.Trim(),
+                Namespace: string.IsNullOrWhiteSpace(ns) ? "Rask.Generated" : ns!.Trim());
+        });
+
+        context.RegisterSourceOutput(files.Combine(options), static (spc, pair) =>
+            Emit(spc, pair.Left, pair.Right.Neutral, pair.Right.Namespace));
+    }
+
+    private static void Emit(
+        SourceProductionContext spc,
+        ImmutableArray<(string Path, string Text)> files,
+        string neutral,
+        string rootNamespace)
+    {
+        var families = new Dictionary<string, List<Catalog>>(System.StringComparer.Ordinal);
+
+        foreach (var (path, text) in files)
+        {
+            if (!TryDescribe(path, out var family, out var tag))
+            {
+                // Not named like a catalog, so it is just an app's own JSON sitting in the same folder.
+                // Silence is correct here: an "orphan file" diagnostic on every data file would be noise.
+                continue;
+            }
+
+            var catalog = new Catalog(path, family, tag);
+            JsonCatalogReader.Read(text, catalog);
+
+            foreach (var defect in catalog.Defects)
+            {
+                Report(spc, TranslationDiagnostics.Malformed, path, defect.Line, defect.Column,
+                    System.IO.Path.GetFileName(path), defect.Reason);
+            }
+
+            if (catalog.Defects.Count > 0)
+            {
+                continue;
+            }
+
+            if (!families.TryGetValue(family, out var list))
+            {
+                list = [];
+                families[family] = list;
+            }
+
+            list.Add(catalog);
+        }
+
+        foreach (var family in families.Keys.OrderBy(static k => k, System.StringComparer.Ordinal))
+        {
+            EmitFamily(spc, family, families[family], neutral, rootNamespace);
+        }
+    }
+
+    private static void EmitFamily(
+        SourceProductionContext spc,
+        string family,
+        List<Catalog> catalogs,
+        string neutral,
+        string rootNamespace)
+    {
+        var neutralCatalog = catalogs.FirstOrDefault(c =>
+            string.Equals(c.CultureTag, neutral, System.StringComparison.OrdinalIgnoreCase));
+
+        if (neutralCatalog is null)
+        {
+            // Without a neutral catalog there is no answer to "which keys exist", so nothing can be
+            // generated and every call site would fail to compile with no useful explanation.
+            Report(spc, TranslationDiagnostics.Malformed, catalogs[0].FilePath, 1, 1,
+                family,
+                $"there is no catalog for the neutral language '{neutral}' — add Resources/{family}.{neutral}.json, "
+                + "or set <RaskNeutralLanguage> to a language this app does ship");
+            return;
+        }
+
+        // Sorted so the generated switch, and therefore the compiled output, is stable across builds.
+        var ordered = catalogs
+            .OrderBy(c => c.CultureTag, System.StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var parsed = new Dictionary<string, ParsedMessage>(System.StringComparer.Ordinal);
+        foreach (var key in neutralCatalog.Order)
+        {
+            var message = MessageParser.Parse(neutralCatalog.Entries[key].Value);
+            if (message.Error is not null)
+            {
+                Report(spc, TranslationDiagnostics.Malformed, neutralCatalog.FilePath,
+                    neutralCatalog.Entries[key].Line, neutralCatalog.Entries[key].Column,
+                    System.IO.Path.GetFileName(neutralCatalog.FilePath),
+                    $"the text for '{key}' has {message.Error}");
+                return;
+            }
+
+            parsed[key] = message;
+        }
+
+        // Cross-check every translation against the neutral catalog before emitting anything.
+        foreach (var catalog in ordered)
+        {
+            if (ReferenceEquals(catalog, neutralCatalog))
+            {
+                continue;
+            }
+
+            var neutralName = System.IO.Path.GetFileName(neutralCatalog.FilePath);
+            var name = System.IO.Path.GetFileName(catalog.FilePath);
+
+            foreach (var key in neutralCatalog.Order)
+            {
+                if (!catalog.Entries.ContainsKey(key))
+                {
+                    Report(spc, TranslationDiagnostics.Disagrees, catalog.FilePath, 1, 1,
+                        name, neutralName,
+                        $"no translation for '{key}' — the '{neutral}' text is used at runtime");
+                }
+            }
+
+            foreach (var key in catalog.Order)
+            {
+                if (!neutralCatalog.Entries.ContainsKey(key))
+                {
+                    Report(spc, TranslationDiagnostics.Disagrees, catalog.FilePath,
+                        catalog.Entries[key].Line, catalog.Entries[key].Column, name, neutralName,
+                        $"'{key}' is not in the neutral catalog, so it generates nothing — add it to "
+                        + $"'{neutralName}', or delete it here");
+                    continue;
+                }
+
+                var message = MessageParser.Parse(catalog.Entries[key].Value);
+                if (message.Error is not null)
+                {
+                    Report(spc, TranslationDiagnostics.Malformed, catalog.FilePath,
+                        catalog.Entries[key].Line, catalog.Entries[key].Column, name,
+                        $"the text for '{key}' has {message.Error}");
+                    return;
+                }
+
+                // A placeholder set that disagrees is not a style problem: string.Format throws
+                // FormatException the first time that string is rendered, in that language only.
+                var expected = parsed[key].Placeholders.Select(static p => p.Name).OrderBy(static n => n,
+                    System.StringComparer.Ordinal);
+                var actual = message.Placeholders.Select(static p => p.Name).OrderBy(static n => n,
+                    System.StringComparer.Ordinal);
+                if (!expected.SequenceEqual(actual, System.StringComparer.Ordinal))
+                {
+                    Report(spc, TranslationDiagnostics.Malformed, catalog.FilePath,
+                        catalog.Entries[key].Line, catalog.Entries[key].Column, name,
+                        $"'{key}' uses placeholders {{{string.Join(", ", message.Placeholders.Select(static p => p.Name))}}} "
+                        + $"but the neutral catalog uses {{{string.Join(", ", parsed[key].Placeholders.Select(static p => p.Name))}}} "
+                        + "— a mismatched set throws FormatException at runtime");
+                    return;
+                }
+            }
+        }
+
+        spc.AddSource($"{family}.g.cs", SourceText.From(
+            Render(family, ordered, neutralCatalog, parsed, rootNamespace), Encoding.UTF8));
+    }
+
+    private static string Render(
+        string family,
+        List<Catalog> catalogs,
+        Catalog neutralCatalog,
+        Dictionary<string, ParsedMessage> parsed,
+        string rootNamespace)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated />");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+        sb.AppendLine($"namespace {rootNamespace};");
+        sb.AppendLine();
+        sb.AppendLine("/// <summary>");
+        sb.AppendLine($"///     Translated text from Resources/{family}.*.json. Generated — edit the JSON, not this file.");
+        sb.AppendLine("/// </summary>");
+        sb.AppendLine($"public static partial class {family}");
+        sb.AppendLine("{");
+
+        var tree = BuildTree(neutralCatalog.Order);
+        RenderNode(sb, tree, catalogs, neutralCatalog, parsed, indent: 1);
+
+        RenderCatalogPlumbing(sb, catalogs, neutralCatalog);
+
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private sealed class Node
+    {
+        public Dictionary<string, Node> Children { get; } = new(System.StringComparer.Ordinal);
+        public List<string> Order { get; } = [];
+        public string? Key { get; set; }
+    }
+
+    private static Node BuildTree(List<string> keys)
+    {
+        var root = new Node();
+        foreach (var key in keys)
+        {
+            var node = root;
+            var parts = key.Split('.');
+            for (var i = 0; i < parts.Length; i++)
+            {
+                if (!node.Children.TryGetValue(parts[i], out var child))
+                {
+                    child = new Node();
+                    node.Children[parts[i]] = child;
+                    node.Order.Add(parts[i]);
+                }
+
+                node = child;
+                if (i == parts.Length - 1)
+                {
+                    node.Key = key;
+                }
+            }
+        }
+
+        return root;
+    }
+
+    private static void RenderNode(
+        StringBuilder sb,
+        Node node,
+        List<Catalog> catalogs,
+        Catalog neutralCatalog,
+        Dictionary<string, ParsedMessage> parsed,
+        int indent)
+    {
+        var pad = new string(' ', indent * 4);
+
+        foreach (var name in node.Order)
+        {
+            var child = node.Children[name];
+
+            if (child.Key is { } key)
+            {
+                RenderMember(sb, pad, name, key, catalogs, neutralCatalog, parsed);
+                continue;
+            }
+
+            sb.AppendLine($"{pad}/// <summary>Translated text under \"{name}\".</summary>");
+            sb.AppendLine($"{pad}public static class {name}");
+            sb.AppendLine($"{pad}{{");
+            RenderNode(sb, child, catalogs, neutralCatalog, parsed, indent + 1);
+            sb.AppendLine($"{pad}}}");
+        }
+    }
+
+    private static void RenderMember(
+        StringBuilder sb,
+        string pad,
+        string name,
+        string key,
+        List<Catalog> catalogs,
+        Catalog neutralCatalog,
+        Dictionary<string, ParsedMessage> parsed)
+    {
+        var message = parsed[key];
+        var member = Escape(name);
+
+        sb.AppendLine($"{pad}/// <summary><c>{neutralCatalog.CultureTag}</c>: {Xml(neutralCatalog.Entries[key].Value)}</summary>");
+
+        if (message.Placeholders.Count == 0)
+        {
+            // A constant string per culture: the switch returns an interned literal, so reading one of
+            // these allocates nothing at all.
+            sb.AppendLine($"{pad}public static string {member} => __Index switch");
+            sb.AppendLine($"{pad}{{");
+            AppendArms(sb, pad + "    ", catalogs, neutralCatalog, key, static (m) => Literal(m.Format));
+            sb.AppendLine($"{pad}}};");
+            sb.AppendLine();
+            return;
+        }
+
+        var parameters = string.Join(", ", message.Placeholders.Select(p => $"{p.ClrType} {Escape(p.Name)}"));
+        var arguments = string.Join(", ", message.Placeholders.Select(p => Escape(p.Name)));
+
+        sb.AppendLine($"{pad}public static string {member}({parameters})");
+        sb.AppendLine($"{pad}{{");
+        sb.AppendLine($"{pad}    var __format = __Index switch");
+        sb.AppendLine($"{pad}    {{");
+        AppendArms(sb, pad + "        ", catalogs, neutralCatalog, key, static (m) => Literal(m.Format));
+        sb.AppendLine($"{pad}    }};");
+        sb.AppendLine($"{pad}    return string.Format(");
+        sb.AppendLine($"{pad}        global::Rask.Core.Globalization.RaskCulture.Current, __format, {arguments});");
+        sb.AppendLine($"{pad}}}");
+        sb.AppendLine();
+    }
+
+    private static void AppendArms(
+        StringBuilder sb,
+        string pad,
+        List<Catalog> catalogs,
+        Catalog neutralCatalog,
+        string key,
+        System.Func<ParsedMessage, string> render)
+    {
+        for (var i = 0; i < catalogs.Count; i++)
+        {
+            var catalog = catalogs[i];
+            if (ReferenceEquals(catalog, neutralCatalog) || !catalog.Entries.TryGetValue(key, out var entry))
+            {
+                continue;
+            }
+
+            var message = MessageParser.Parse(entry.Value);
+            sb.AppendLine($"{pad}{i} => {render(message)},");
+        }
+
+        // The neutral text is the default arm, so an untranslated key falls back to it without any
+        // runtime lookup — and "the key itself" is a state that cannot occur.
+        sb.AppendLine($"{pad}_ => {render(MessageParser.Parse(neutralCatalog.Entries[key].Value))},");
+    }
+
+    private static void RenderCatalogPlumbing(StringBuilder sb, List<Catalog> catalogs, Catalog neutralCatalog)
+    {
+        var neutralIndex = catalogs.IndexOf(neutralCatalog);
+
+        sb.AppendLine("    // Which catalog the active UI language resolves to. A switch over a plain BCP 47");
+        sb.AppendLine("    // string, never a CultureInfo: constructing one throws under InvariantGlobalization,");
+        sb.AppendLine("    // so keying on the string is what lets translated text work with no ICU at all.");
+        sb.AppendLine("    private static int __Index");
+        sb.AppendLine("    {");
+        sb.AppendLine("        get");
+        sb.AppendLine("        {");
+        sb.AppendLine("            var __tag = global::Rask.Core.Globalization.RaskCulture.CurrentUI.Name;");
+        sb.AppendLine("            while (__tag.Length > 0)");
+        sb.AppendLine("            {");
+        sb.AppendLine("                switch (__tag)");
+        sb.AppendLine("                {");
+
+        for (var i = 0; i < catalogs.Count; i++)
+        {
+            sb.AppendLine($"                    case \"{catalogs[i].CultureTag}\": return {i};");
+        }
+
+        sb.AppendLine("                }");
+        sb.AppendLine();
+        sb.AppendLine("                // hu-HU -> hu -> the neutral catalog. Sliced rather than Substring'd:");
+        sb.AppendLine("                // this runs on the render path, and an allocation per lookup would show up.");
+        sb.AppendLine("                var __cut = __tag.LastIndexOf('-');");
+        sb.AppendLine("                if (__cut <= 0) break;");
+        sb.AppendLine("                __tag = __tag.Substring(0, __cut);");
+        sb.AppendLine("            }");
+        sb.AppendLine();
+        sb.AppendLine($"            return {neutralIndex};");
+        sb.AppendLine("        }");
+        sb.AppendLine("    }");
+    }
+
+    // Resources/Strings.hu-HU.json -> family "Strings", tag "hu-HU".
+    private static bool TryDescribe(string path, out string family, out string tag)
+    {
+        family = string.Empty;
+        tag = string.Empty;
+
+        var dir = System.IO.Path.GetDirectoryName(path) ?? string.Empty;
+        if (dir.IndexOf("Resources", System.StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            return false;
+        }
+
+        var name = System.IO.Path.GetFileNameWithoutExtension(path);
+        var dot = name.LastIndexOf('.');
+        if (dot <= 0 || dot == name.Length - 1)
+        {
+            return false;
+        }
+
+        family = name.Substring(0, dot);
+        tag = name.Substring(dot + 1);
+        return IsIdentifier(family) && IsCultureTag(tag);
+    }
+
+    private static bool IsCultureTag(string tag)
+    {
+        if (tag.Length is < 2 or > 32)
+        {
+            return false;
+        }
+
+        var subtag = 0;
+        foreach (var part in tag.Split('-'))
+        {
+            if (part.Length is 0 or > 8)
+            {
+                return false;
+            }
+
+            foreach (var c in part)
+            {
+                if (!char.IsLetterOrDigit(c))
+                {
+                    return false;
+                }
+            }
+
+            if (subtag == 0)
+            {
+                if (part.Length < 2)
+                {
+                    return false;
+                }
+
+                foreach (var c in part)
+                {
+                    if (!char.IsLetter(c))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            subtag++;
+        }
+
+        return subtag > 0;
+    }
+
+    private static bool IsIdentifier(string s)
+    {
+        if (s.Length == 0 || (!char.IsLetter(s[0]) && s[0] != '_'))
+        {
+            return false;
+        }
+
+        foreach (var c in s)
+        {
+            if (!char.IsLetterOrDigit(c) && c != '_')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string Escape(string name) => IsKeyword(name) ? "@" + name : name;
+
+    private static bool IsKeyword(string name) => Microsoft.CodeAnalysis.CSharp.SyntaxFacts.GetKeywordKind(name)
+        != Microsoft.CodeAnalysis.CSharp.SyntaxKind.None;
+
+    private static string Literal(string value) =>
+        Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Literal(value).ToFullString();
+
+    private static string Xml(string value) =>
+        value.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
+
+    private static void Report(
+        SourceProductionContext spc,
+        DiagnosticDescriptor descriptor,
+        string path,
+        int line,
+        int column,
+        params object[] args)
+    {
+        var position = new LinePosition(System.Math.Max(0, line - 1), System.Math.Max(0, column - 1));
+        var location = Location.Create(path, new TextSpan(0, 0), new LinePositionSpan(position, position));
+        spc.ReportDiagnostic(Diagnostic.Create(descriptor, location, args));
+    }
+}

--- a/src/Rask.Generators/Translations/TranslationDiagnostics.cs
+++ b/src/Rask.Generators/Translations/TranslationDiagnostics.cs
@@ -1,0 +1,41 @@
+using Microsoft.CodeAnalysis;
+
+namespace Rask.Generators.Translations;
+
+// Two ids for the whole subsystem, with the specific cause carried in the message.
+//
+// That is the RASK003 pattern ("Route template '{0}' on '{1}' is malformed: {2}") and it is a
+// deliberate economy: RASK051 and RASK052 are the last free ids below the retired block, and a
+// caller reading "catalog X is malformed: duplicate key 'Y'" learns exactly as much as they would
+// from a dedicated id, while an .editorconfig rule still has something coherent to target.
+internal static class TranslationDiagnostics
+{
+    public static readonly DiagnosticDescriptor Malformed = new(
+        "RASK051",
+        "Translation catalog is malformed",
+        "Translation catalog '{0}' is malformed: {1}",
+        DiagnosticHelp.Category,
+        DiagnosticSeverity.Error,
+        true,
+        description: "A translation catalog is a JSON object whose values are text or further objects, named "
+                     + "Resources/{Family}.{culture}.json. This one either cannot be read, or describes strings "
+                     + "that would fail at runtime — a placeholder set that disagrees with the neutral catalog "
+                     + "throws FormatException the first time the string is used, so it is refused at build time "
+                     + "instead. Fix the reported cause in the file named by the message.",
+        helpLinkUri: DiagnosticHelp.Link("RASK051"));
+
+    public static readonly DiagnosticDescriptor Disagrees = new(
+        "RASK052",
+        "Translation catalog disagrees with the neutral catalog",
+        "Translation catalog '{0}' disagrees with '{1}': {2}",
+        DiagnosticHelp.Category,
+        DiagnosticSeverity.Warning,
+        true,
+        description: "The neutral catalog defines which keys exist; a translation supplies the text for them. "
+                     + "This one is missing a key, or carries one the neutral catalog does not define. A missing "
+                     + "translation is a warning rather than an error because a partly translated app is the "
+                     + "normal state of every real project — the neutral text is used until it is filled in. Set "
+                     + "dotnet_diagnostic.RASK052.severity = error to gate releases on complete translations, or "
+                     + "= none while translating.",
+        helpLinkUri: DiagnosticHelp.Link("RASK052"));
+}

--- a/tests/Rask.Generators.Tests/GeneratorDriverFixture.cs
+++ b/tests/Rask.Generators.Tests/GeneratorDriverFixture.cs
@@ -22,6 +22,22 @@ internal static class GeneratorDriverFixture
     public static GeneratorRun Run(
         (string Path, string Source)[] sources,
         IIncrementalGenerator generator,
+        (string Path, string Contents)[]? additionalTexts = null) =>
+        Run(sources, [generator], additionalTexts);
+
+    /// <summary>
+    ///     Runs SEVERAL generators over one compilation, so their outputs are compiled together.
+    /// </summary>
+    /// <remarks>
+    ///     Needed whenever the question is whether generated code BINDS rather than whether it was
+    ///     emitted. Asserting on the generated text alone is a false negative in this repo: inside a
+    ///     markup host the factory generator injects builder entries as members of the host type, and
+    ///     ordinary member lookup beats the namespace-level names another generator produced. Only a
+    ///     combined compilation can show which one a call site actually resolves to.
+    /// </remarks>
+    public static GeneratorRun Run(
+        (string Path, string Source)[] sources,
+        IIncrementalGenerator[] generators,
         (string Path, string Contents)[]? additionalTexts = null)
     {
         var trees = sources
@@ -39,7 +55,7 @@ internal static class GeneratorDriverFixture
                 nullableContextOptions: NullableContextOptions.Enable));
 
         var driver = CSharpGeneratorDriver
-            .Create(generator)
+            .Create(generators)
             .WithUpdatedParseOptions(new CSharpParseOptions(LanguageVersion.Latest));
 
         if (additionalTexts is { Length: > 0 })

--- a/tests/Rask.Generators.Tests/TranslationCatalogGeneratorTests.cs
+++ b/tests/Rask.Generators.Tests/TranslationCatalogGeneratorTests.cs
@@ -1,0 +1,198 @@
+using Microsoft.CodeAnalysis;
+using Rask.Generators.Translations;
+
+namespace Rask.Generators.Tests;
+
+// The catalog generator's contract: a key that exists becomes a member, a key that does not becomes a
+// C# compile error at the call site, and a translation that disagrees with the neutral catalog is
+// reported before it can throw at runtime.
+public class TranslationCatalogGeneratorTests
+{
+    private static GeneratorRun Run(params (string Path, string Contents)[] catalogs) =>
+        GeneratorDriverFixture.Run(
+            [("App.cs", "namespace App; public static class Marker { }")],
+            new TranslationCatalogGenerator(),
+            catalogs);
+
+    private static string Generated(GeneratorRun run) =>
+        string.Join("\n", run.RunResult.Results.SelectMany(r => r.GeneratedSources)
+            .Select(s => s.SourceText.ToString()));
+
+    [Fact]
+    public void A_key_becomes_a_member_and_the_generated_code_compiles()
+    {
+        var run = Run(
+            ("/p/Resources/Strings.en.json", """{ "Greeting": "Hello!" }"""),
+            ("/p/Resources/Strings.hu.json", """{ "Greeting": "Szia!" }"""));
+
+        Assert.Empty(run.RunResult.Diagnostics);
+
+        // The strongest assertion available: the emitted switch, the escaped literals and every
+        // identifier actually bind.
+        Assert.Empty(run.GeneratedCompileErrors());
+
+        var code = Generated(run);
+        Assert.Contains("public static partial class Strings", code, StringComparison.Ordinal);
+        Assert.Contains("\"Szia!\"", code, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_placeholder_becomes_a_typed_parameter()
+    {
+        var run = Run(("/p/Resources/Strings.en.json",
+            """{ "Greeting": "Hello, {name}!", "Cart": "{count:int} items", "Due": "{when:DateOnly:d}" }"""));
+
+        var code = Generated(run);
+        Assert.Empty(run.GeneratedCompileErrors());
+
+        // Named, so the signature documents itself; typed where the catalog says so.
+        Assert.Contains("public static string Greeting(object? name)", code, StringComparison.Ordinal);
+        Assert.Contains("public static string Cart(int count)", code, StringComparison.Ordinal);
+        Assert.Contains("public static string Due(global::System.DateOnly when)", code, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_key_with_no_placeholders_is_a_property_so_reading_it_allocates_nothing()
+    {
+        var run = Run(("/p/Resources/Strings.en.json", """{ "Title": "Dashboard" }"""));
+
+        Assert.Contains("public static string Title => __Index switch", Generated(run), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Nested_objects_become_nested_classes()
+    {
+        var run = Run(("/p/Resources/Strings.en.json",
+            """{ "Home": { "Title": "Dashboard", "Sub": { "Deep": "x" } } }"""));
+
+        var code = Generated(run);
+        Assert.Empty(run.GeneratedCompileErrors());
+        Assert.Contains("public static class Home", code, StringComparison.Ordinal);
+        Assert.Contains("public static class Sub", code, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_translation_missing_a_key_is_a_warning_and_falls_back_to_the_neutral_text()
+    {
+        // The normal steady state of every real project, so a warning rather than an error.
+        var run = Run(
+            ("/p/Resources/Strings.en.json", """{ "A": "one", "B": "two" }"""),
+            ("/p/Resources/Strings.hu.json", """{ "A": "egy" }"""));
+
+        var warning = Assert.Single(run.RunResult.Diagnostics, d => d.Id == "RASK052");
+        Assert.Equal(DiagnosticSeverity.Warning, warning.Severity);
+        Assert.Contains("no translation for 'B'", warning.GetMessage(), StringComparison.Ordinal);
+
+        // It still generates, and B answers in the neutral language.
+        Assert.Empty(run.GeneratedCompileErrors());
+        Assert.Contains("\"two\"", Generated(run), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_key_only_a_translation_has_is_a_warning_because_it_generates_nothing()
+    {
+        var run = Run(
+            ("/p/Resources/Strings.en.json", """{ "A": "one" }"""),
+            ("/p/Resources/Strings.hu.json", """{ "A": "egy", "Extra": "többlet" }"""));
+
+        var warning = Assert.Single(run.RunResult.Diagnostics, d => d.Id == "RASK052");
+        Assert.Contains("'Extra' is not in the neutral catalog", warning.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_placeholder_set_that_disagrees_is_an_error_not_a_warning()
+    {
+        // string.Format would throw FormatException the first time that string rendered — in one
+        // language only, which is the worst possible place to discover it.
+        var run = Run(
+            ("/p/Resources/Strings.en.json", """{ "Greeting": "Hello, {name}!" }"""),
+            ("/p/Resources/Strings.hu.json", """{ "Greeting": "Szia, {nev}!" }"""));
+
+        var error = Assert.Single(run.RunResult.Diagnostics, d => d.Id == "RASK051");
+        Assert.Equal(DiagnosticSeverity.Error, error.Severity);
+        Assert.Contains("FormatException", error.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Reordering_placeholders_in_a_translation_is_fine()
+    {
+        // Which is the whole reason placeholders are named: other languages move the arguments.
+        var run = Run(
+            ("/p/Resources/Strings.en.json", """{ "M": "{a} then {b}" }"""),
+            ("/p/Resources/Strings.hu.json", """{ "M": "{b} majd {a}" }"""));
+
+        Assert.Empty(run.RunResult.Diagnostics);
+        Assert.Empty(run.GeneratedCompileErrors());
+    }
+
+    [Theory]
+    [InlineData("""{ "A": "one", "A": "two" }""", "duplicate key")]
+    [InlineData("""{ "A": 42 }""", "not text or a nested object")]
+    [InlineData("""{ "A": "one" """, "expected ',' or '}'")]
+    [InlineData("""{ "A": "an unclosed {brace" }""", "unclosed")]
+    [InlineData("""{ "A": "mixed {0} and {name}" }""", "one or the other")]
+    public void A_catalog_that_cannot_generate_correct_code_is_an_error(string json, string expected)
+    {
+        var run = Run(("/p/Resources/Strings.en.json", json));
+
+        var error = Assert.Single(run.RunResult.Diagnostics, d => d.Id == "RASK051");
+        Assert.Contains(expected, error.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_family_with_no_neutral_catalog_says_which_file_is_missing()
+    {
+        var run = Run(("/p/Resources/Strings.hu.json", """{ "A": "egy" }"""));
+
+        var error = Assert.Single(run.RunResult.Diagnostics, d => d.Id == "RASK051");
+        Assert.Contains("Strings.en.json", error.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_json_file_that_is_not_a_catalog_is_ignored_without_complaint()
+    {
+        // An app's own data sitting in Resources/. An "orphan file" diagnostic here would fire on every
+        // seed file in the repo and teach nothing.
+        var run = Run(
+            ("/p/Resources/Strings.en.json", """{ "A": "one" }"""),
+            ("/p/Resources/seed-data.json", """{ "not": "a catalog" }"""),
+            ("/p/appsettings.json", """{ "Logging": {} }"""));
+
+        Assert.Empty(run.RunResult.Diagnostics);
+    }
+
+    [Fact]
+    public void Two_families_generate_two_independent_classes()
+    {
+        var run = Run(
+            ("/p/Resources/Strings.en.json", """{ "A": "one" }"""),
+            ("/p/Resources/Validation.en.json", """{ "Required": "This field is required." }"""));
+
+        var code = Generated(run);
+        Assert.Empty(run.GeneratedCompileErrors());
+        Assert.Contains("class Strings", code, StringComparison.Ordinal);
+        Assert.Contains("class Validation", code, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_region_falls_back_through_its_parent_language()
+    {
+        var run = Run(
+            ("/p/Resources/Strings.en.json", """{ "A": "one" }"""),
+            ("/p/Resources/Strings.hu.json", """{ "A": "egy" }"""));
+
+        // hu-HU is not a catalog, so the emitted resolver has to walk to hu before giving up on the
+        // neutral language.
+        Assert.Contains("LastIndexOf('-')", Generated(run), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Escapes_and_braces_survive_into_the_generated_literal()
+    {
+        var run = Run(("/p/Resources/Strings.en.json",
+            """{ "Quote": "He said \"hi\"", "Brace": "{{literal}}", "Tab": "a\tb" }"""));
+
+        Assert.Empty(run.RunResult.Diagnostics);
+        Assert.Empty(run.GeneratedCompileErrors());
+    }
+}

--- a/tests/Rask.Generators.Tests/TranslationsOnTheChainSurfaceTests.cs
+++ b/tests/Rask.Generators.Tests/TranslationsOnTheChainSurfaceTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.CodeAnalysis;
+using Rask.Generators.Translations;
+
+namespace Rask.Generators.Tests;
+
+/// <summary>
+///     Proves that a generated catalog member actually <b>binds</b> from inside a markup host.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Asserting that the generator emitted <c>Greeting</c> proves nothing about whether
+///         <c>Strings.Greeting(x)</c> resolves where it is written. Inside a markup host the factory
+///         generator injects a builder entry per component as a <em>member of the host type</em>, and
+///         ordinary member lookup beats namespace-level names — which is exactly how seven analyzers in
+///         this repo were once blind while their tests stayed green.
+///     </para>
+///     <para>
+///         So these run both generators over one compilation, write the catalog by its <b>simple</b>
+///         name (the shadowing-prone form real code uses), and ask the compiler rather than a string.
+///         The test's own namespace matches the generator's default so that simple name is in scope.
+///     </para>
+/// </remarks>
+public class TranslationsOnTheChainSurfaceTests
+{
+    private const string Catalog = """{ "Greeting": "Hello, {name}!", "Title": "Dashboard" }""";
+
+    private static GeneratorRun Run(string body) =>
+        GeneratorDriverFixture.Run(
+            [("App.cs", $$"""
+                using Rask.Core;
+
+                namespace Rask.Generated;
+
+                public partial class Page : Component
+                {
+                    protected override Component Render()
+                    {
+                        {{body}}
+                    }
+                }
+                """)],
+            [new ComponentFactoryGenerator(), new TranslationCatalogGenerator()],
+            [("/p/Resources/Strings.en.json", Catalog)]);
+
+    [Fact]
+    public void A_catalog_member_binds_by_simple_name_inside_a_markup_host()
+    {
+        var run = Run("return Div[P[Strings.Title], P[Strings.Greeting(\"world\")]];");
+
+        Assert.DoesNotContain(run.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Empty(run.GeneratedCompileErrors());
+    }
+
+    [Fact]
+    public void A_missing_key_is_an_ordinary_C_sharp_compile_error()
+    {
+        // The whole point of generating members rather than looking strings up: a typo cannot reach a
+        // running page. No Rask diagnostic is needed, because CS0117 already says it.
+        var run = Run("return Div[P[Strings.Missing]];");
+
+        Assert.DoesNotContain(run.Diagnostics, d => d.Id.StartsWith("RASK", StringComparison.Ordinal));
+        Assert.Contains(run.GeneratedCompileErrors(), d => d.Id is "CS0117" or "CS1061");
+    }
+
+    [Fact]
+    public void A_wrong_argument_count_is_an_ordinary_C_sharp_compile_error()
+    {
+        var run = Run("return Div[P[Strings.Greeting(\"a\", \"b\")]];");
+
+        Assert.Contains(run.GeneratedCompileErrors(), d => d.Id is "CS1501" or "CS1503" or "CS1729");
+    }
+}


### PR DESCRIPTION
Fifth step of the global culture / localization epic. **Stacked on #824** (→ #822 → #821 → #819).

Turns `Resources/Strings.{culture}.json` into compile-checked members.

```jsonc
// Resources/Strings.en.json          // Resources/Strings.hu.json
{ "Greeting": "Hello, {name}!",       { "Greeting": "Szia, {name}!",
  "Home": { "Title": "Dashboard" } }    "Home": { "Title": "Irányítópult" } }
```

```csharp
Div[P[Strings.Home.Title], P[Strings.Greeting(user.Name)]]
```

## The point is what happens when you get it wrong

| Mistake | Result |
|---|---|
| typo'd key | **CS0117** — ordinary C# error, at the call site |
| wrong argument count | **CS1501** |
| placeholder set disagrees between languages | **RASK051**, error |
| a translation is missing a key | **RASK052**, warning; neutral text is used |

A stringly-typed lookup would instead render the *key itself* to a user, which is the classic way a
localized app fails in production. Here it cannot reach a running page.

## Named placeholders, because languages reorder arguments

`{name}`, optionally `{count:int}`, optionally `{price:decimal:C}`.

The correctness rule is that the **set** of names matches the neutral catalog, not the order — so a
Hungarian translation may freely swap `{a}` and `{b}`. But `{nev}` where the neutral catalog says
`{name}` is an **error**, not a warning: `string.Format` would throw `FormatException` the first time
that string rendered, **in that one language only**, which is the worst possible place to discover it.

A missing translation, by contrast, is a **warning** — a partly translated app is the normal state of
every real project, and the neutral text carries the page until it is filled in. Promote it in
`.editorconfig` to gate a release on complete translations.

## No reflection, no satellite assemblies

Lookup is a generated `switch` over a BCP 47 **string**, never a `CultureInfo`. That is what lets an
app ship in three languages under `InvariantGlobalization`, where constructing a culture *throws* —
only placeholder **formatting** falls back to invariant there. A key with no placeholders compiles to
a property returning an interned literal, so reading one allocates nothing.

Fallback walks `hu-HU` → `hu` → neutral. "The key itself" is a state that cannot occur: a key absent
from the neutral catalog generates no member, so nothing can reference it.

## Why the JSON reader is hand-written

This assembly is a Roslyn analyzer — netstandard2.0, loaded into csc and into every IDE, carrying
exactly one package reference. Shipping a serializer beside it is how an analyzer starts failing to
load against whatever version the IDE already has. The grammar needed is tiny, and doing it by hand
keeps precise line/column offsets, so a defect points at the **key** rather than at the file.

## The test that is not a false negative

`TranslationsOnTheChainSurfaceTests` writes `Strings.Title` by **simple name inside a markup host** and
runs both generators over one compilation.

Asserting on generated text would prove nothing here: injected builder entries are members of the host
type, and ordinary member lookup beats namespace-level names — which is exactly how seven analyzers in
this repo were once blind while their tests stayed green.

The test is **self-verifying**: `Div[...]` only compiles because the factory generator injected those
entries, so the host demonstrably has the members that could have shadowed the catalog.

## Also fixed

A malformed catalog produced **two** errors — the real cause, then a "trailing content" complaint from
a reader left sitting mid-document. The second buried the first; follow-on defects are now suppressed.

## Testing

`scripts/run-unit-local.sh` green, pre-push browser E2E gate green. 21 new tests, plus RASK051/052
documented in `docs/diagnostics.md` with the existing descriptor tests covering their shape.

**Scope note:** plural categories (`one`/`few`/`many`/`other`) are not in this PR. They change generated
*signatures* — `Cart` becomes `Cart(int count)` — so they must land before this ships publicly rather
than after. The epic is unmerged and stacked, so that is a follow-up PR in the same series, not a
breaking change to anyone.
