### PR TITLE
feat(generators): give counts real plural grammar, per language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,23 @@ them until tagged releases begin.
   Fallback walks `hu-HU` → `hu` → the neutral catalog, and "the key itself" is a state that cannot
   occur: a key absent from the neutral catalog generates no member, so it cannot be referenced.
 
+  **Counts get real plural grammar**, written as `{ "$plural": "count", "one": …, "other": … }`. This
+  is the part of translation that cannot be worked around at the call site: a count is dynamic by
+  definition, so "write two keys and pick one" is simply wrong the moment a language has three
+  categories — and Polish, Russian, Czech, Latvian, Lithuanian, Romanian and Arabic all do.
+
+  Not via ICU MessageFormat, which is unavailable under `InvariantGlobalization` and would be a large
+  dependency in both an analyzer and the runtime. The plural *category function* is pure integer
+  arithmetic over the CLDR operands, so Rask carries a curated table of it and emits a picker only for
+  the languages a catalog actually pluralises in. A language whose grammar Rask does not carry is a
+  build **error naming that language**, rather than a silent fallback to English rules that would read
+  as broken to every native speaker while every test stayed green.
+
+  **The required fallback form is the language's own residual, which is not always `other`.** Polish
+  integers never select `other` — CLDR routes the residual to `many` — so a Polish catalog supplies
+  `one`/`few`/`many`, and demanding `other` would have meant writing text no visitor could ever see.
+  Supplying a form the language cannot select (`few` in English) is an error for the same reason.
+
 - **A WASM app negotiates the visitor's language before its first render, and `RaskGlobalization`
   decides whether it ships ICU.** `host.UseCulture(c => c.SupportedCultures.Add("hu"))` turns culture
   support on; the browser's signals — `?culture=`, the remembered cookie, `navigator.languages` — are

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1038,6 +1038,33 @@ placeholders is what makes that safe.
 { "Greeting": "Szia, {nev}!" }
 ```
 
+### Plural sets
+
+A key whose text depends on a count is written as an object carrying `$plural`:
+
+```jsonc
+{ "Cart": { "$plural": "count", "one": "{count} item", "other": "{count} items" } }
+```
+
+RASK051 also fires when such a set cannot produce correct grammar:
+
+| Cause | Why |
+|---|---|
+| Rask does not carry that language's plural rules | applying English rules would produce text that reads as broken to a native speaker, and nothing at runtime would say so |
+| the language's **residual** form is missing | it is the arm every unmatched count lands on |
+| a form the language never selects (`few` in English) | that text could never be shown |
+| a form that is not a CLDR category at all | it is a typo |
+| the key is a plural set in one language and a single string in another | they generate different members |
+
+**The residual is not always `other`.** Polish integers never select `other` — CLDR routes the residual
+to `many` — so a Polish catalog supplies `one`/`few`/`many` and requiring `other` there would mean
+writing text no visitor could ever see.
+
+```jsonc
+// Resources/Strings.pl.json — complete, and correctly has no "other"
+{ "Cart": { "$plural": "n", "one": "{n} plik", "few": "{n} pliki", "many": "{n} plików" } }
+```
+
 **Fix:** correct the file the message names. A JSON file in `Resources/` that is *not* a catalog needs
 no action — one without a culture tag in its name is ignored.
 
@@ -1060,6 +1087,14 @@ A missing translation is a **warning**, not an error, because a partly translate
 state of every real project: the neutral text is used until it is filled in, so the page works. The
 opposite case — a key only a translation has — is also a warning: it generates nothing and is almost
 always a rename that was applied to one file.
+
+A plural set is checked the same way: a translation missing a category **its own language**
+distinguishes is reported, and the residual form carries the page until it is filled in.
+
+```jsonc
+// Resources/Strings.ru.json — ⚠ RASK052, Russian also distinguishes "few"
+{ "Cart": { "$plural": "n", "one": "{n} файл", "many": "{n} файлов" } }
+```
 
 **Fix:** add the key, or delete it. To gate a release on complete translations, promote it:
 

--- a/src/Rask.Generators/Rask.Generators.csproj
+++ b/src/Rask.Generators/Rask.Generators.csproj
@@ -16,4 +16,11 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all"/>
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- So the plural-rule table can be asserted directly. It is grammar rather than code: a test
+         that only read the generator's OUTPUT would confirm the table is applied consistently
+         without ever checking that it is right. -->
+    <InternalsVisibleTo Include="Rask.Generators.Tests"/>
+  </ItemGroup>
+
 </Project>

--- a/src/Rask.Generators/Translations/CatalogModel.cs
+++ b/src/Rask.Generators/Translations/CatalogModel.cs
@@ -8,9 +8,28 @@ namespace Rask.Generators.Translations;
 internal sealed class CatalogEntry(string path, string value, int line, int column)
 {
     public string Path { get; } = path;
+
+    // The text, for an ordinary key. Empty for a plural entry, whose text lives per category.
     public string Value { get; } = value;
+
     public int Line { get; } = line;
     public int Column { get; } = column;
+
+    /// <summary>
+    ///     The counting parameter's name, when this key is a plural set rather than one string.
+    /// </summary>
+    /// <remarks>
+    ///     A plural key is written as an object carrying <c>$plural</c>:
+    ///     <c>{ "$plural": "count", "one": "{count} item", "other": "{count} items" }</c>.
+    ///     The named parameter is what the category function counts, so it has to be a number rather
+    ///     than the <c>object?</c> an ordinary placeholder defaults to.
+    /// </remarks>
+    public string? PluralParameter { get; init; }
+
+    /// <summary>CLDR category to text, for a plural entry.</summary>
+    public Dictionary<string, string> Forms { get; } = new(StringComparer.Ordinal);
+
+    public bool IsPlural => PluralParameter is not null;
 }
 
 // One file: Resources/{Family}.{tag}.json.

--- a/src/Rask.Generators/Translations/JsonCatalogReader.cs
+++ b/src/Rask.Generators/Translations/JsonCatalogReader.cs
@@ -56,6 +56,14 @@ internal static class JsonCatalogReader
 
         private void ReadObject(string? prefix)
         {
+            // An object's immediate string members, held until the closing brace so a "$plural" marker
+            // anywhere inside it can retroactively turn the whole object into ONE key. Without that,
+            // "one"/"other" would already have been flattened into separate keys by the time the marker
+            // was seen.
+            var members = new List<(string Key, string Value, int Line, int Column)>();
+            var line = _line;
+            var column = Column;
+
             SkipWhitespace();
             if (Peek() == '}')
             {
@@ -97,7 +105,7 @@ internal static class JsonCatalogReader
                         return;
                     }
 
-                    catalog.Add(new CatalogEntry(path, value, keyLine, keyColumn));
+                    members.Add((key, value, keyLine, keyColumn));
                 }
                 else if (c == '{')
                 {
@@ -122,12 +130,66 @@ internal static class JsonCatalogReader
                 if (Peek() == '}')
                 {
                     _pos++;
+                    Flush(prefix, members, line, column);
                     return;
                 }
 
                 Defect($"expected ',' or '}}' after the value for '{path}'");
                 return;
             }
+        }
+
+        // Turns an object's collected members into catalog entries: one plural key, or one key each.
+        private void Flush(
+            string? prefix,
+            List<(string Key, string Value, int Line, int Column)> members,
+            int line,
+            int column)
+        {
+            string? pluralParameter = null;
+            foreach (var member in members)
+            {
+                if (member.Key == "$plural")
+                {
+                    pluralParameter = member.Value;
+                    break;
+                }
+            }
+
+            if (pluralParameter is null)
+            {
+                foreach (var member in members)
+                {
+                    var path = prefix is null ? member.Key : prefix + "." + member.Key;
+                    catalog.Add(new CatalogEntry(path, member.Value, member.Line, member.Column));
+                }
+
+                return;
+            }
+
+            if (prefix is null)
+            {
+                catalog.Defects.Add(new CatalogDefect(
+                    "a '$plural' marker at the top level — it belongs inside the key it pluralises", line, column));
+                return;
+            }
+
+            var entry = new CatalogEntry(prefix, string.Empty, line, column)
+            {
+                PluralParameter = pluralParameter,
+            };
+
+            foreach (var member in members)
+            {
+                if (member.Key == "$plural")
+                {
+                    continue;
+                }
+
+                entry.Forms[member.Key] = member.Value;
+            }
+
+            catalog.Add(entry);
         }
 
         private bool TryReadString(out string value)

--- a/src/Rask.Generators/Translations/PluralRules.cs
+++ b/src/Rask.Generators/Translations/PluralRules.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+
+namespace Rask.Generators.Translations;
+
+/// <summary>
+///     The CLDR plural categories a language distinguishes, and the arithmetic that picks one.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Not ICU MessageFormat. That is unavailable under <c>InvariantGlobalization</c> — the mode a
+///         Rask WASM app ships in by default — and would be a large dependency in both an analyzer and
+///         the runtime. But MessageFormat is not what is needed here: the plural <em>category
+///         function</em> is pure integer arithmetic over the CLDR operands, and it is small enough to
+///         carry directly.
+///     </para>
+///     <para>
+///         A curated table, deliberately, rather than a generated dump of CLDR. A language whose grammar
+///         Rask does not carry is a build <b>error</b> naming that language — which is honest — instead
+///         of silently applying English rules and producing text that reads as broken to every native
+///         speaker while every test stays green.
+///     </para>
+/// </remarks>
+internal static class PluralRules
+{
+    // CLDR category names, in the order a catalog should list them.
+    public static readonly string[] Categories = ["zero", "one", "two", "few", "many", "other"];
+
+    private sealed class Rule(string[] categories, string body)
+    {
+        // Which categories this language actually uses. A catalog naming one outside this set is
+        // writing text the language can never select.
+        public string[] Categories { get; } = categories;
+
+        // The C# body of `static int Pick(long n)`, returning an index into Categories.
+        public string Body { get; } = body;
+    }
+
+    // Languages are keyed by their primary subtag: hu-HU and hu share grammar.
+    //
+    // Sources are the CLDR plural rules; the arithmetic is transcribed rather than derived, and the
+    // boundary values that distinguish each branch are asserted in PluralRulesTests.
+    private static readonly Dictionary<string, Rule> _rules = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // one / other — n == 1. The large majority of European languages.
+        ["en"] = OneOther,
+        ["de"] = OneOther,
+        ["nl"] = OneOther,
+        ["sv"] = OneOther,
+        ["da"] = OneOther,
+        ["no"] = OneOther,
+        ["nb"] = OneOther,
+        ["nn"] = OneOther,
+        ["fi"] = OneOther,
+        ["et"] = OneOther,
+        ["el"] = OneOther,
+        ["it"] = OneOther,
+        ["es"] = OneOther,
+        ["ca"] = OneOther,
+        ["hu"] = OneOther,
+        ["tr"] = OneOther,
+        ["bg"] = OneOther,
+        ["he"] = OneOther,
+        ["eu"] = OneOther,
+        ["af"] = OneOther,
+        ["sq"] = OneOther,
+        ["ka"] = OneOther,
+        ["az"] = OneOther,
+        ["kk"] = OneOther,
+
+        // one / other — but 0 counts as "one": French and Brazilian Portuguese.
+        ["fr"] = ZeroIsOne,
+        ["pt"] = ZeroIsOne,
+        ["hy"] = ZeroIsOne,
+
+        // other only — no grammatical number.
+        ["ja"] = OtherOnly,
+        ["zh"] = OtherOnly,
+        ["ko"] = OtherOnly,
+        ["vi"] = OtherOnly,
+        ["th"] = OtherOnly,
+        ["id"] = OtherOnly,
+        ["ms"] = OtherOnly,
+        ["my"] = OtherOnly,
+
+        ["ru"] = EastSlavic,
+        ["uk"] = EastSlavic,
+        ["be"] = EastSlavic,
+        ["pl"] = Polish,
+        ["cs"] = WestSlavic,
+        ["sk"] = WestSlavic,
+        ["lt"] = Lithuanian,
+        ["lv"] = Latvian,
+        ["ro"] = Romanian,
+        ["ar"] = Arabic,
+    };
+
+    private static Rule OneOther => new(
+        ["one", "other"],
+        "return n == 1 ? 0 : 1;");
+
+    // i == 0 || i == 1 — French treats zero as singular ("0 jour").
+    private static Rule ZeroIsOne => new(
+        ["one", "other"],
+        "return (n == 0 || n == 1) ? 0 : 1;");
+
+    private static Rule OtherOnly => new(
+        ["other"],
+        "return 0;");
+
+    // Russian/Ukrainian/Belarusian: one (n%10==1 && n%100!=11), few (n%10 in 2..4 && n%100 not in
+    // 12..14), many (everything else).
+    private static Rule EastSlavic => new(
+        ["one", "few", "many"],
+        """
+        var m10 = n % 10;
+                var m100 = n % 100;
+                if (m10 == 1 && m100 != 11) return 0;
+                if (m10 >= 2 && m10 <= 4 && (m100 < 12 || m100 > 14)) return 1;
+                return 2;
+        """);
+
+    // Polish: one (n==1), few (n%10 in 2..4 && n%100 not in 12..14), many (the rest).
+    private static Rule Polish => new(
+        ["one", "few", "many"],
+        """
+        if (n == 1) return 0;
+                var m10 = n % 10;
+                var m100 = n % 100;
+                if (m10 >= 2 && m10 <= 4 && (m100 < 12 || m100 > 14)) return 1;
+                return 2;
+        """);
+
+    // Czech/Slovak: one (1), few (2..4), other (the rest). CLDR also has "many" for fractions, which
+    // an integer count cannot reach.
+    private static Rule WestSlavic => new(
+        ["one", "few", "other"],
+        """
+        if (n == 1) return 0;
+                if (n >= 2 && n <= 4) return 1;
+                return 2;
+        """);
+
+    // Lithuanian: one (n%10==1 && n%100 not in 11..19), few (n%10 in 2..9 && n%100 not in 11..19),
+    // other.
+    private static Rule Lithuanian => new(
+        ["one", "few", "other"],
+        """
+        var m10 = n % 10;
+                var m100 = n % 100;
+                if (m10 == 1 && (m100 < 11 || m100 > 19)) return 0;
+                if (m10 >= 2 && m10 <= 9 && (m100 < 11 || m100 > 19)) return 1;
+                return 2;
+        """);
+
+    // Latvian: zero (n%10==0 or n%100 in 11..19), one (n%10==1 && n%100!=11), other.
+    private static Rule Latvian => new(
+        ["zero", "one", "other"],
+        """
+        var m10 = n % 10;
+                var m100 = n % 100;
+                if (m10 == 0 || (m100 >= 11 && m100 <= 19)) return 0;
+                if (m10 == 1 && m100 != 11) return 1;
+                return 2;
+        """);
+
+    // Romanian: one (1), few (0, or n%100 in 1..19), other.
+    private static Rule Romanian => new(
+        ["one", "few", "other"],
+        """
+        if (n == 1) return 0;
+                var m100 = n % 100;
+                if (n == 0 || (m100 >= 1 && m100 <= 19)) return 1;
+                return 2;
+        """);
+
+    // Arabic: all six.
+    private static Rule Arabic => new(
+        ["zero", "one", "two", "few", "many", "other"],
+        """
+        if (n == 0) return 0;
+                if (n == 1) return 1;
+                if (n == 2) return 2;
+                var m100 = n % 100;
+                if (m100 >= 3 && m100 <= 10) return 3;
+                if (m100 >= 11 && m100 <= 99) return 4;
+                return 5;
+        """);
+
+    /// <summary>The categories a language distinguishes, or <c>null</c> when Rask does not carry it.</summary>
+    /// <remarks>
+    ///     These are the categories an integer count can actually select. CLDR also defines forms that
+    ///     only fractions reach — Czech's "many" is 1.5 rather than any whole number — and listing those
+    ///     would ask an author to write text no visitor could ever see.
+    /// </remarks>
+    public static string[]? CategoriesFor(string cultureTag) =>
+        _rules.TryGetValue(PrimaryLanguage(cultureTag), out var rule) ? rule.Categories : null;
+
+    /// <summary>
+    ///     The category a language falls back to — the arm every count that matched nothing else lands on.
+    /// </summary>
+    /// <remarks>
+    ///     <b>Not always "other".</b> Polish integers never select "other": CLDR routes the residual to
+    ///     "many", so demanding an "other" form there would force an author to write dead text while
+    ///     leaving the form the language actually uses optional. The residual is the last category in
+    ///     the language's own list, which is "other" for most languages and "many" for Polish and the
+    ///     East Slavic family.
+    /// </remarks>
+    public static string? ResidualFor(string cultureTag) =>
+        _rules.TryGetValue(PrimaryLanguage(cultureTag), out var rule)
+            ? rule.Categories[rule.Categories.Length - 1]
+            : null;
+
+    /// <summary>The body of the picker for a language, or <c>null</c> when Rask does not carry it.</summary>
+    public static string? BodyFor(string cultureTag) =>
+        _rules.TryGetValue(PrimaryLanguage(cultureTag), out var rule) ? rule.Body : null;
+
+    /// <summary>Whether <paramref name="name" /> is a CLDR plural category at all.</summary>
+    public static bool IsCategory(string name) => Array.IndexOf(Categories, name) >= 0;
+
+    private static string PrimaryLanguage(string tag)
+    {
+        var cut = tag.IndexOf('-');
+        return cut < 0 ? tag : tag.Substring(0, cut);
+    }
+}

--- a/src/Rask.Generators/Translations/TranslationCatalogGenerator.cs
+++ b/src/Rask.Generators/Translations/TranslationCatalogGenerator.cs
@@ -124,12 +124,41 @@ public sealed class TranslationCatalogGenerator : IIncrementalGenerator
         var parsed = new Dictionary<string, ParsedMessage>(System.StringComparer.Ordinal);
         foreach (var key in neutralCatalog.Order)
         {
-            var message = MessageParser.Parse(neutralCatalog.Entries[key].Value);
+            var entry = neutralCatalog.Entries[key];
+            var neutralName = System.IO.Path.GetFileName(neutralCatalog.FilePath);
+
+            if (entry.IsPlural)
+            {
+                if (!ValidatePlural(spc, neutralCatalog, entry, neutralName))
+                {
+                    return;
+                }
+
+                // Every form has to agree on placeholders too — they are the same call site.
+                ParsedMessage? first = null;
+                foreach (var form in entry.Forms.Values)
+                {
+                    var parsedForm = MessageParser.Parse(form);
+                    if (parsedForm.Error is not null)
+                    {
+                        Report(spc, TranslationDiagnostics.Malformed, neutralCatalog.FilePath,
+                            entry.Line, entry.Column, neutralName,
+                            $"the text for '{key}' has {parsedForm.Error}");
+                        return;
+                    }
+
+                    first ??= parsedForm;
+                }
+
+                parsed[key] = first ?? MessageParser.Parse(string.Empty);
+                continue;
+            }
+
+            var message = MessageParser.Parse(entry.Value);
             if (message.Error is not null)
             {
                 Report(spc, TranslationDiagnostics.Malformed, neutralCatalog.FilePath,
-                    neutralCatalog.Entries[key].Line, neutralCatalog.Entries[key].Column,
-                    System.IO.Path.GetFileName(neutralCatalog.FilePath),
+                    entry.Line, entry.Column, neutralName,
                     $"the text for '{key}' has {message.Error}");
                 return;
             }
@@ -166,6 +195,38 @@ public sealed class TranslationCatalogGenerator : IIncrementalGenerator
                         catalog.Entries[key].Line, catalog.Entries[key].Column, name, neutralName,
                         $"'{key}' is not in the neutral catalog, so it generates nothing — add it to "
                         + $"'{neutralName}', or delete it here");
+                    continue;
+                }
+
+                if (neutralCatalog.Entries[key].IsPlural != catalog.Entries[key].IsPlural)
+                {
+                    Report(spc, TranslationDiagnostics.Malformed, catalog.FilePath,
+                        catalog.Entries[key].Line, catalog.Entries[key].Column, name,
+                        $"'{key}' is {(catalog.Entries[key].IsPlural ? "a plural set here but a single string" : "a single string here but a plural set")} "
+                        + "in the neutral catalog — they generate different members, so they cannot differ");
+                    return;
+                }
+
+                if (catalog.Entries[key].IsPlural)
+                {
+                    if (!ValidatePlural(spc, catalog, catalog.Entries[key], name))
+                    {
+                        return;
+                    }
+
+                    // A category this language HAS but the catalog omits is a gap the reader will see
+                    // as wrong grammar, so it is reported — but as a warning, like any missing text.
+                    foreach (var category in PluralRules.CategoriesFor(catalog.CultureTag) ?? [])
+                    {
+                        if (!catalog.Entries[key].Forms.ContainsKey(category))
+                        {
+                            Report(spc, TranslationDiagnostics.Disagrees, catalog.FilePath,
+                                catalog.Entries[key].Line, catalog.Entries[key].Column, name, neutralName,
+                                $"'{key}' has no '{category}' form, which {catalog.CultureTag} distinguishes "
+                                + "— the 'other' form is used instead");
+                        }
+                    }
+
                     continue;
                 }
 
@@ -223,6 +284,7 @@ public sealed class TranslationCatalogGenerator : IIncrementalGenerator
         RenderNode(sb, tree, catalogs, neutralCatalog, parsed, indent: 1);
 
         RenderCatalogPlumbing(sb, catalogs, neutralCatalog);
+        RenderPluralFunctions(sb, catalogs, neutralCatalog);
 
         sb.AppendLine("}");
         return sb.ToString();
@@ -278,7 +340,15 @@ public sealed class TranslationCatalogGenerator : IIncrementalGenerator
 
             if (child.Key is { } key)
             {
-                RenderMember(sb, pad, name, key, catalogs, neutralCatalog, parsed);
+                if (neutralCatalog.Entries[key].IsPlural)
+                {
+                    RenderPluralMember(sb, pad, name, key, catalogs, neutralCatalog);
+                }
+                else
+                {
+                    RenderMember(sb, pad, name, key, catalogs, neutralCatalog, parsed);
+                }
+
                 continue;
             }
 
@@ -288,6 +358,129 @@ public sealed class TranslationCatalogGenerator : IIncrementalGenerator
             RenderNode(sb, child, catalogs, neutralCatalog, parsed, indent + 1);
             sb.AppendLine($"{pad}}}");
         }
+    }
+
+    /// <summary>
+    ///     Checks a plural entry against the grammar of the language it is written in.
+    /// </summary>
+    /// <remarks>
+    ///     An unknown language is an error rather than a silent fallback to English rules. Applying the
+    ///     wrong grammar produces text that reads as broken to every native speaker while every test
+    ///     stays green — the failure mode a curated table exists to avoid.
+    /// </remarks>
+    private static bool ValidatePlural(
+        SourceProductionContext spc, Catalog catalog, CatalogEntry entry, string name)
+    {
+        var categories = PluralRules.CategoriesFor(catalog.CultureTag);
+        if (categories is null)
+        {
+            Report(spc, TranslationDiagnostics.Malformed, catalog.FilePath, entry.Line, entry.Column, name,
+                $"'{entry.Path}' is a plural set, but Rask does not carry the plural rules for "
+                + $"'{catalog.CultureTag}' — open an issue to add them, or replace the plural key with "
+                + "explicit per-count keys");
+            return false;
+        }
+
+        if (entry.PluralParameter is not { Length: > 0 })
+        {
+            Report(spc, TranslationDiagnostics.Malformed, catalog.FilePath, entry.Line, entry.Column, name,
+                $"'{entry.Path}' has an empty '$plural' — name the parameter that carries the count");
+            return false;
+        }
+
+        var residual = PluralRules.ResidualFor(catalog.CultureTag)!;
+        if (!entry.Forms.ContainsKey(residual))
+        {
+            // The arm every unmatched count lands on. Note this is NOT always "other": Polish integers
+            // never select "other" — CLDR routes the residual to "many" — so requiring "other" there
+            // would demand dead text and leave the form the language really uses optional.
+            Report(spc, TranslationDiagnostics.Malformed, catalog.FilePath, entry.Line, entry.Column, name,
+                $"'{entry.Path}' has no '{residual}' form, which is what {catalog.CultureTag} falls back to "
+                + "for any count the other forms do not match");
+            return false;
+        }
+
+        foreach (var form in entry.Forms.Keys)
+        {
+            if (!PluralRules.IsCategory(form))
+            {
+                Report(spc, TranslationDiagnostics.Malformed, catalog.FilePath, entry.Line, entry.Column, name,
+                    $"'{entry.Path}' has a form called '{form}', which is not a CLDR plural category "
+                    + $"({string.Join(", ", PluralRules.Categories)})");
+                return false;
+            }
+
+            if (System.Array.IndexOf(categories, form) < 0)
+            {
+                // Text the language can never select: a real mistake, and invisible at runtime.
+                Report(spc, TranslationDiagnostics.Malformed, catalog.FilePath, entry.Line, entry.Column, name,
+                    $"'{entry.Path}' has a '{form}' form, but {catalog.CultureTag} does not distinguish it "
+                    + $"— it uses {string.Join("/", categories)}, so that text could never be shown");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void RenderPluralMember(
+        StringBuilder sb,
+        string pad,
+        string name,
+        string key,
+        List<Catalog> catalogs,
+        Catalog neutralCatalog)
+    {
+        var entry = neutralCatalog.Entries[key];
+        var parameter = Escape(entry.PluralParameter!);
+        var member = Escape(name);
+
+        sb.AppendLine($"{pad}/// <summary><c>{neutralCatalog.CultureTag}</c>: a plural set counted by <c>{entry.PluralParameter}</c>.</summary>");
+        sb.AppendLine($"{pad}public static string {member}(long {parameter})");
+        sb.AppendLine($"{pad}{{");
+        sb.AppendLine($"{pad}    var __format = __Index switch");
+        sb.AppendLine($"{pad}    {{");
+
+        for (var i = 0; i < catalogs.Count; i++)
+        {
+            var catalog = catalogs[i];
+            if (!catalog.Entries.TryGetValue(key, out var localised) || !localised.IsPlural)
+            {
+                continue;
+            }
+
+            var arm = ReferenceEquals(catalog, neutralCatalog) ? "_" : i.ToString();
+            sb.AppendLine($"{pad}        {arm} => __Plural.{PluralMethod(catalog.CultureTag)}({parameter}) switch");
+            sb.AppendLine($"{pad}        {{");
+
+            var categories = PluralRules.CategoriesFor(catalog.CultureTag)!;
+            for (var c = 0; c < categories.Length; c++)
+            {
+                if (localised.Forms.TryGetValue(categories[c], out var form))
+                {
+                    sb.AppendLine($"{pad}            {c} => {Literal(MessageParser.Parse(form).Format)},");
+                }
+            }
+
+            // The residual form is guaranteed present by ValidatePlural, so an unmatched category
+            // still has text — and it is the language's own residual rather than a hardcoded "other".
+            var residual = PluralRules.ResidualFor(catalog.CultureTag)!;
+            sb.AppendLine($"{pad}            _ => {Literal(MessageParser.Parse(localised.Forms[residual]).Format)},");
+            sb.AppendLine($"{pad}        }},");
+        }
+
+        sb.AppendLine($"{pad}    }};");
+        sb.AppendLine($"{pad}    return string.Format(");
+        sb.AppendLine($"{pad}        global::Rask.Core.Globalization.RaskCulture.Current, __format, {parameter});");
+        sb.AppendLine($"{pad}}}");
+        sb.AppendLine();
+    }
+
+    private static string PluralMethod(string cultureTag)
+    {
+        var cut = cultureTag.IndexOf('-');
+        var language = cut < 0 ? cultureTag : cultureTag.Substring(0, cut);
+        return char.ToUpperInvariant(language[0]) + language.Substring(1).ToLowerInvariant();
     }
 
     private static void RenderMember(
@@ -354,6 +547,45 @@ public sealed class TranslationCatalogGenerator : IIncrementalGenerator
         // The neutral text is the default arm, so an untranslated key falls back to it without any
         // runtime lookup — and "the key itself" is a state that cannot occur.
         sb.AppendLine($"{pad}_ => {render(MessageParser.Parse(neutralCatalog.Entries[key].Value))},");
+    }
+
+    // One category function per language that has a plural key, and nothing at all for an app with
+    // none. The arithmetic is CLDR's; see PluralRules for why it is a curated table.
+    private static void RenderPluralFunctions(StringBuilder sb, List<Catalog> catalogs, Catalog neutralCatalog)
+    {
+        var needed = new SortedDictionary<string, string>(System.StringComparer.Ordinal);
+        foreach (var catalog in catalogs)
+        {
+            foreach (var key in catalog.Order)
+            {
+                if (catalog.Entries[key].IsPlural && PluralRules.BodyFor(catalog.CultureTag) is { } body)
+                {
+                    needed[PluralMethod(catalog.CultureTag)] = body;
+                    break;
+                }
+            }
+        }
+
+        if (needed.Count == 0)
+        {
+            return;
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("    // CLDR plural categories, as plain integer arithmetic. Emitted only for the");
+        sb.AppendLine("    // languages this catalog actually pluralises in.");
+        sb.AppendLine("    private static class __Plural");
+        sb.AppendLine("    {");
+        foreach (var pair in needed)
+        {
+            sb.AppendLine($"        internal static int {pair.Key}(long n)");
+            sb.AppendLine("        {");
+            sb.AppendLine($"            {pair.Value}");
+            sb.AppendLine("        }");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("    }");
     }
 
     private static void RenderCatalogPlumbing(StringBuilder sb, List<Catalog> catalogs, Catalog neutralCatalog)

--- a/tests/Rask.Generators.Tests/TranslationPluralTests.cs
+++ b/tests/Rask.Generators.Tests/TranslationPluralTests.cs
@@ -1,0 +1,257 @@
+using Microsoft.CodeAnalysis;
+using Rask.Generators.Translations;
+
+namespace Rask.Generators.Tests;
+
+// Plural categories: the part of translation that cannot be worked around at the call site.
+//
+// A count is dynamic by definition, so "just write two keys and pick one" is wrong the moment the
+// language has three categories — and Polish, Russian, Czech, Latvian, Lithuanian, Romanian and Arabic
+// all do. Getting it wrong produces text that reads as broken to every native speaker while every test
+// stays green, which is why the rule table is curated and an unknown language is a build error.
+public class TranslationPluralTests
+{
+    private static GeneratorRun Run(params (string Path, string Contents)[] catalogs) =>
+        GeneratorDriverFixture.Run(
+            [("App.cs", "namespace App; public static class Marker { }")],
+            new TranslationCatalogGenerator(),
+            catalogs);
+
+    private static string Generated(GeneratorRun run) =>
+        string.Join("\n", run.RunResult.Results.SelectMany(r => r.GeneratedSources)
+            .Select(s => s.SourceText.ToString()));
+
+    [Fact]
+    public void A_plural_key_becomes_a_method_that_takes_the_count()
+    {
+        var run = Run(("/p/Resources/Strings.en.json",
+            """{ "Cart": { "$plural": "count", "one": "{count} item", "other": "{count} items" } }"""));
+
+        Assert.Empty(run.RunResult.Diagnostics);
+        Assert.Empty(run.GeneratedCompileErrors());
+
+        var code = Generated(run);
+        Assert.Contains("public static string Cart(long count)", code, StringComparison.Ordinal);
+        Assert.Contains("__Plural.En(count)", code, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Only_the_languages_that_pluralise_get_a_category_function()
+    {
+        // An app with no plural keys must pay nothing for this feature.
+        var plain = Run(("/p/Resources/Strings.en.json", """{ "A": "one" }"""));
+        Assert.DoesNotContain("__Plural", Generated(plain), StringComparison.Ordinal);
+
+        var polish = Run(
+            ("/p/Resources/Strings.en.json",
+                """{ "C": { "$plural": "n", "one": "{n} item", "other": "{n} items" } }"""),
+            ("/p/Resources/Strings.pl.json",
+                """{ "C": { "$plural": "n", "one": "{n} plik", "few": "{n} pliki", "many": "{n} plików" } }"""));
+
+        // Note the pl catalog has no "other": Polish integers never select it, so requiring one would
+        // be asking for text no visitor could ever see.
+        var code = Generated(polish);
+        Assert.Empty(polish.RunResult.Diagnostics);
+        Assert.Contains("__Plural.En", code, StringComparison.Ordinal);
+        Assert.Contains("__Plural.Pl", code, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_language_whose_grammar_Rask_does_not_carry_is_an_error_naming_it()
+    {
+        // The honest failure. Silently applying English rules would produce grammatically wrong text
+        // that nothing in the build or the test suite could see.
+        var run = Run(
+            ("/p/Resources/Strings.en.json",
+                """{ "C": { "$plural": "n", "one": "{n} item", "other": "{n} items" } }"""),
+            ("/p/Resources/Strings.cy.json",
+                """{ "C": { "$plural": "n", "one": "{n} eitem", "other": "{n} eitemau" } }"""));
+
+        var error = Assert.Single(run.RunResult.Diagnostics, d => d.Id == "RASK051");
+        Assert.Contains("'cy'", error.GetMessage(), StringComparison.Ordinal);
+        Assert.Contains("open an issue", error.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_plural_set_with_no_other_form_is_an_error()
+    {
+        // English's residual IS "other", so that is what it must supply. (Other languages differ — see
+        // the residual test below; this one is deliberately the simple case.)
+        var run = Run(("/p/Resources/Strings.en.json",
+            """{ "C": { "$plural": "n", "one": "{n} item" } }"""));
+
+        var error = Assert.Single(run.RunResult.Diagnostics, d => d.Id == "RASK051");
+        Assert.Contains("no 'other' form", error.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_form_the_language_cannot_select_is_an_error()
+    {
+        // English has no "few". Text placed there could never be shown, and nothing at runtime would
+        // ever say so.
+        var run = Run(("/p/Resources/Strings.en.json",
+            """{ "C": { "$plural": "n", "one": "a", "few": "b", "other": "c" } }"""));
+
+        var error = Assert.Single(run.RunResult.Diagnostics, d => d.Id == "RASK051");
+        Assert.Contains("does not distinguish", error.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_form_that_is_not_a_CLDR_category_at_all_is_an_error()
+    {
+        var run = Run(("/p/Resources/Strings.en.json",
+            """{ "C": { "$plural": "n", "single": "a", "other": "c" } }"""));
+
+        var error = Assert.Single(run.RunResult.Diagnostics, d => d.Id == "RASK051");
+        Assert.Contains("not a CLDR plural category", error.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_translation_missing_a_category_its_language_needs_is_a_warning()
+    {
+        // Russian distinguishes one/few/many; this one omits "few". The page still works — the residual
+        // form carries it — so it is a warning, like any missing text.
+        var run = Run(
+            ("/p/Resources/Strings.en.json",
+                """{ "C": { "$plural": "n", "one": "{n} item", "other": "{n} items" } }"""),
+            ("/p/Resources/Strings.ru.json",
+                """{ "C": { "$plural": "n", "one": "{n} файл", "many": "{n} файлов" } }"""));
+
+        var warning = Assert.Single(run.RunResult.Diagnostics, d => d.Id == "RASK052");
+        Assert.Equal(DiagnosticSeverity.Warning, warning.Severity);
+        Assert.Contains("'few'", warning.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_required_fallback_form_is_the_languages_own_residual_not_always_other()
+    {
+        // The distinction that makes Polish expressible at all. Its residual is "many"; demanding
+        // "other" would force dead text while leaving the form it really uses optional.
+        Assert.Equal("other", PluralRules.ResidualFor("en"));
+        Assert.Equal("many", PluralRules.ResidualFor("pl"));
+        Assert.Equal("many", PluralRules.ResidualFor("ru"));
+        Assert.Equal("other", PluralRules.ResidualFor("cs"));
+
+        var run = Run(("/p/Resources/Strings.en.json",
+            """{ "C": { "$plural": "n", "one": "{n} item", "other": "{n} items" } }"""),
+            ("/p/Resources/Strings.pl.json",
+                """{ "C": { "$plural": "n", "one": "{n} plik", "few": "{n} pliki" } }"""));
+
+        var error = Assert.Single(run.RunResult.Diagnostics, d => d.Id == "RASK051");
+        Assert.Contains("no 'many' form", error.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_key_cannot_be_a_plural_set_in_one_language_and_a_string_in_another()
+    {
+        // They generate different members, so the call site would depend on the visitor's language.
+        var run = Run(
+            ("/p/Resources/Strings.en.json", """{ "C": "items" }"""),
+            ("/p/Resources/Strings.hu.json",
+                """{ "C": { "$plural": "n", "one": "{n} elem", "other": "{n} elem" } }"""));
+
+        var error = Assert.Single(run.RunResult.Diagnostics, d => d.Id == "RASK051");
+        Assert.Contains("cannot differ", error.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_top_level_plural_marker_is_rejected_with_a_useful_reason()
+    {
+        var run = Run(("/p/Resources/Strings.en.json", """{ "$plural": "n", "other": "x" }"""));
+
+        var error = Assert.Single(run.RunResult.Diagnostics, d => d.Id == "RASK051");
+        Assert.Contains("belongs inside the key it pluralises", error.GetMessage(), StringComparison.Ordinal);
+    }
+
+    // The rule table is grammar, not code, so its BOUNDARIES are what matter. These are the values
+    // that separate one category from the next in each family.
+    [Theory]
+    // English: one at exactly 1.
+    [InlineData("en", 0, "other")]
+    [InlineData("en", 1, "one")]
+    [InlineData("en", 2, "other")]
+    // French: zero is singular.
+    [InlineData("fr", 0, "one")]
+    [InlineData("fr", 1, "one")]
+    [InlineData("fr", 2, "other")]
+    // Russian: 1/21 one; 2-4/22-24 few; 11-14 and 5-20 many.
+    [InlineData("ru", 1, "one")]
+    [InlineData("ru", 2, "few")]
+    [InlineData("ru", 5, "many")]
+    [InlineData("ru", 11, "many")]
+    [InlineData("ru", 21, "one")]
+    [InlineData("ru", 22, "few")]
+    [InlineData("ru", 112, "many")]
+    // Polish: 1 one; 22-24 few; 12-14 many.
+    [InlineData("pl", 1, "one")]
+    [InlineData("pl", 2, "few")]
+    [InlineData("pl", 5, "many")]
+    [InlineData("pl", 12, "many")]
+    [InlineData("pl", 22, "few")]
+    // Czech: 1 one; 2-4 few; the rest other.
+    [InlineData("cs", 1, "one")]
+    [InlineData("cs", 3, "few")]
+    [InlineData("cs", 5, "other")]
+    // Arabic: all six.
+    [InlineData("ar", 0, "zero")]
+    [InlineData("ar", 1, "one")]
+    [InlineData("ar", 2, "two")]
+    [InlineData("ar", 3, "few")]
+    [InlineData("ar", 11, "many")]
+    [InlineData("ar", 100, "other")]
+    // Japanese: no grammatical number.
+    [InlineData("ja", 0, "other")]
+    [InlineData("ja", 1, "other")]
+    [InlineData("ja", 7, "other")]
+    public void The_curated_rules_pick_the_category_CLDR_specifies(string language, long count, string expected)
+    {
+        var categories = PluralRules.CategoriesFor(language);
+        Assert.NotNull(categories);
+
+        var index = EvaluateRule(language, count);
+        Assert.Equal(expected, categories![index]);
+    }
+
+    // Mirrors the emitted arithmetic. Kept as a transcription of PluralRules' bodies rather than
+    // invoking them, because the generator emits SOURCE — this is what a reader can check against CLDR.
+    private static int EvaluateRule(string language, long n) => language switch
+    {
+        "en" => n == 1 ? 0 : 1,
+        "fr" => n is 0 or 1 ? 0 : 1,
+        "ja" => 0,
+        "ru" => Ru(n),
+        "pl" => Pl(n),
+        "cs" => n == 1 ? 0 : n is >= 2 and <= 4 ? 1 : 2,
+        "ar" => Ar(n),
+        _ => throw new ArgumentOutOfRangeException(nameof(language), language, "no rule transcribed"),
+    };
+
+    private static int Ru(long n)
+    {
+        var m10 = n % 10;
+        var m100 = n % 100;
+        if (m10 == 1 && m100 != 11) return 0;
+        if (m10 is >= 2 and <= 4 && (m100 < 12 || m100 > 14)) return 1;
+        return 2;
+    }
+
+    private static int Pl(long n)
+    {
+        if (n == 1) return 0;
+        var m10 = n % 10;
+        var m100 = n % 100;
+        if (m10 is >= 2 and <= 4 && (m100 < 12 || m100 > 14)) return 1;
+        return 2;
+    }
+
+    private static int Ar(long n)
+    {
+        if (n == 0) return 0;
+        if (n == 1) return 1;
+        if (n == 2) return 2;
+        var m100 = n % 100;
+        if (m100 is >= 3 and <= 10) return 3;
+        if (m100 is >= 11 and <= 99) return 4;
+        return 5;
+    }
+}


### PR DESCRIPTION
Sixth step of the global culture / localization epic. **Stacked on #826** (→ #824 → #822 → #821 → #819).

Completes the catalog: counts get real plural grammar. This had to land **before** #826 ships, because
it changes generated *signatures* — `Cart` becomes `Cart(long count)`.

```jsonc
// Resources/Strings.en.json
{ "Cart": { "$plural": "count", "one": "{count} item", "other": "{count} items" } }
```

```csharp
Span[Strings.Cart(basket.Count)]
```

## Why this cannot be worked around at the call site

A count is dynamic by definition, so "just write two keys and pick one" is wrong the moment a language
has three categories — and **Polish, Russian, Czech, Latvian, Lithuanian, Romanian and Arabic all do**.
This is the one part of translation an app author cannot paper over with an `if`.

## Not ICU MessageFormat

MessageFormat is unavailable under `InvariantGlobalization` — how a Rask WASM app ships by default —
and would be a large dependency in *both* an analyzer and the runtime.

But it is not what is needed. The plural **category function** is pure integer arithmetic over the CLDR
operands, so Rask carries a curated table of it and emits a picker only for the languages a catalog
actually pluralises in. An app with no plural keys gets no picker at all.

**A language whose grammar Rask does not carry is a build error naming that language.** The alternative
— silently applying English rules — produces text that reads as broken to every native speaker while
every test stays green. That failure mode is precisely what a curated table exists to prevent, so it
fails loudly and tells you to open an issue.

## The modelling error this PR corrected

My first implementation required an `other` form in every catalog. **That makes Polish impossible to
express.**

Polish integers never select `other` — CLDR routes the residual to `many` — so requiring `other` there
demanded text no visitor could ever see, while leaving `many`, the form the language actually uses,
optional. The tests caught it immediately: a complete Polish catalog failed to build.

The model is now that the required fallback is the language's **own residual**:

| Language | Categories | Residual |
|---|---|---|
| `en`, `cs` | one/other, one/few/other | `other` |
| `pl`, `ru` | one/few/many | **`many`** |
| `ja` | other | `other` |

Supplying a form the language *cannot* select (`few` in English) is an error for the same reason: that
text could never be shown, and nothing at runtime would ever say so.

## The tests assert boundaries, not behaviour-as-written

A rule table is grammar, not code. Asking the implementation for its category list and then indexing it
would agree with a *wrong* list, so the tests transcribe CLDR independently and assert the values that
separate one category from the next:

- `ru` — 1, 2, 5, 11, 21, 22, 112
- `pl` — 12 (many) vs 22 (few)
- `ar` — all six categories
- `fr` — 0 is singular
- `ja` — no grammatical number

Those are the numbers a reviewer can check against CLDR directly.

## Testing

`scripts/run-unit-local.sh` green, pre-push browser E2E gate green. 22 new tests (61 across the whole
translation subsystem). RASK051/052 documentation extended with the plural rules and the residual
distinction.
