### PR TITLE
docs(sqlite): record that EF 11 fixes only half the decimal collation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,12 @@ them until tagged releases begin.
   query time, at the cost of a DDL that only a connection registering the collation can query. Both are
   documented, and the documented snippet is compiled and run by a test.
 
+  The culture half is fixed upstream in **EF Core 11.0.0 preview 1**
+  ([dotnet/efcore#37432](https://github.com/dotnet/efcore/issues/37432)), which adds
+  `CultureInfo.InvariantCulture` to the parse — but that fix still uses `decimal.Parse`, not `TryParse`,
+  so on EF 11 the collation continues to throw and terminate the process the moment a value that is not
+  a number reaches the column. Rask's registration stays: it is the only one that is total.
+
   Arithmetic, comparisons and `Sum`/`Average`/`Min`/`Max` were never affected — those translate through
   EF's `ef_add`/`ef_compare`/`ef_sum`/… helpers, which take typed `decimal` parameters. `docs/sqlite.md`
   and `docs/data-access.md` claimed EF "falls back to REAL for `ORDER BY` and aggregates" and that "EF

--- a/src/Rask.SQLite/SqliteCollations.cs
+++ b/src/Rask.SQLite/SqliteCollations.cs
@@ -42,6 +42,15 @@ namespace Rask.SQLite;
 /// file exactly as before.
 /// </para>
 /// <para>
+/// <b>Do not delete this when EF Core is upgraded.</b> The culture half is fixed upstream in EF Core
+/// 11.0.0 preview 1 (<a href="https://github.com/dotnet/efcore/issues/37432">dotnet/efcore#37432</a>),
+/// which adds <see cref="CultureInfo.InvariantCulture"/> to the parse — but the fix still uses
+/// <c>decimal.Parse</c>, not <c>TryParse</c>, so on EF 11 the collation continues to <b>throw, and take
+/// the process with it</b>, the moment a value that is not a number reaches the column. EF 11 fixes the
+/// first two bullets above and leaves the third; this registration is the only one that is total.
+/// Re-check <c>SqliteRelationalConnection.InitializeDbConnection</c> before removing it.
+/// </para>
+/// <para>
 /// It must run on <b>every</b> connection open, not once: Microsoft.Data.Sqlite pools connections and
 /// <c>Deactivate()</c> un-registers functions and collations when one is returned to the pool.
 /// </para>


### PR DESCRIPTION
## Why

Following #827, I checked whether the underlying EF Core bug was worth reporting upstream. It is
already reported — [dotnet/efcore#37432](https://github.com/dotnet/efcore/issues/37432), filed against
EF Core 10.0.0, **closed as completed** against the **11.0.0** milestone.

That creates a trap. Whoever eventually bumps the EF version will find a closed "fixed" issue and
reasonably conclude `SqliteCollations` is now redundant. Deleting it would reintroduce a process crash.

## Because the upstream fix is only half a fix

EF Core `main` now reads:

```csharp
sqliteConnection.CreateCollation(
    "EF_DECIMAL",
    (x, y) => decimal.Compare(
        decimal.Parse(x, NumberStyles.Number, CultureInfo.InvariantCulture),
        decimal.Parse(y, NumberStyles.Number, CultureInfo.InvariantCulture)));
```

`InvariantCulture` was added — that fixes the two culture cases (`de-DE` mis-sorting, `en-HU` throwing).
It is still `decimal.Parse`, **not `TryParse`**. A collation runs inside SQLite's native comparison loop,
where a managed exception cannot be unwound, so on EF 11 an `ORDER BY` still **terminates the process**
the moment a value that is not a number reaches the column — which SQLite's dynamic typing permits from
any direct `INSERT`, an external tool, or a legacy row.

So EF 11 fixes two of the three failure modes `SqliteCollations` documents and leaves the third. Rask's
registration remains the only one that is total.

Worth noting the upstream repro (`tr-TR`) only covers the mis-sort. Neither the process-termination case
nor the junk-data case appears in that issue.

## What changed

Documentation only — no behaviour, no API.

- `SqliteCollations` remarks: a "do not delete this when EF Core is upgraded" note with the issue link
  and an instruction to re-read `SqliteRelationalConnection.InitializeDbConnection` before removing
  anything. Written where someone doing the upgrade will actually be looking.
- The `CHANGELOG` entry for #827 records the same.

**This does not propose an upgrade.** Rask stays on EF Core 10 stable (`10.0.11`, no preview); the note
is forward-looking only, and on EF 10 none of the three failure modes is fixed upstream.
