### PR TITLE
docs(sqlite): link the upstream issue tracking the collation crash EF 11 leaves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,9 @@ them until tagged releases begin.
   ([dotnet/efcore#37432](https://github.com/dotnet/efcore/issues/37432)), which adds
   `CultureInfo.InvariantCulture` to the parse — but that fix still uses `decimal.Parse`, not `TryParse`,
   so on EF 11 the collation continues to throw and terminate the process the moment a value that is not
-  a number reaches the column. Rask's registration stays: it is the only one that is total.
+  a number reaches the column — tracked upstream as
+  [dotnet/efcore#38870](https://github.com/dotnet/efcore/issues/38870). Rask's registration stays until
+  that closes: it is the only one that is total.
 
   Arithmetic, comparisons and `Sum`/`Average`/`Min`/`Max` were never affected — those translate through
   EF's `ef_add`/`ef_compare`/`ef_sum`/… helpers, which take typed `decimal` parameters. `docs/sqlite.md`

--- a/src/Rask.SQLite/SqliteCollations.cs
+++ b/src/Rask.SQLite/SqliteCollations.cs
@@ -47,8 +47,10 @@ namespace Rask.SQLite;
 /// which adds <see cref="CultureInfo.InvariantCulture"/> to the parse — but the fix still uses
 /// <c>decimal.Parse</c>, not <c>TryParse</c>, so on EF 11 the collation continues to <b>throw, and take
 /// the process with it</b>, the moment a value that is not a number reaches the column. EF 11 fixes the
-/// first two bullets above and leaves the third; this registration is the only one that is total.
-/// Re-check <c>SqliteRelationalConnection.InitializeDbConnection</c> before removing it.
+/// first two bullets above and leaves the third, which is tracked upstream as
+/// <a href="https://github.com/dotnet/efcore/issues/38870">dotnet/efcore#38870</a>; until that closes,
+/// this registration is the only one that is total. Re-check
+/// <c>SqliteRelationalConnection.InitializeDbConnection</c> before removing it.
 /// </para>
 /// <para>
 /// It must run on <b>every</b> connection open, not once: Microsoft.Data.Sqlite pools connections and


### PR DESCRIPTION
Follows #832. That PR recorded that EF 11's fix for [dotnet/efcore#37432](https://github.com/dotnet/efcore/issues/37432) adds `InvariantCulture` but keeps `decimal.Parse`, so the collation still terminates the process when a value that is not a number reaches a decimal column.

That remaining half is now filed upstream as [dotnet/efcore#38870](https://github.com/dotnet/efcore/issues/38870), with a minimal repro run under `InvariantCulture` to keep it separate from #37432.

Linking it from the `SqliteCollations` remarks and the changelog turns *"re-read EF's source before removing this"* into *"check whether that issue closed"* — the question someone doing an EF upgrade can actually answer quickly.

Documentation only: no behaviour, no API. Rask stays on EF Core 10 stable.