### PR TITLE
feat(cli): scaffold a localized app with rask new --culture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **`rask new --culture en --culture hu` scaffolds a localized app.** `--culture` is repeatable and
+  names the languages; the **first is the default** a visitor falls back to. `--localization` on its own
+  means English, which is the shape an app grows a second language into. Both are supported on
+  `server`, `wasm` and `wasm-hosted`.
+
+  The scaffold writes one `Resources/Strings.{culture}.json` per language — the translations start as a
+  copy of the neutral catalog, so the build immediately reports what still needs doing (RASK052) rather
+  than the app quietly rendering English where a key was forgotten — and it includes a plural key,
+  which is the part nobody guesses the shape of.
+
+  **`--all-batteries` deliberately does not imply it.** The batteries are the back-end pillars a
+  DB-backed app needs; shipping a second language is a commitment to translating every string in the
+  app, which is not a decision a convenience flag should make.
+
+  An unknown tag is rejected naming it (`'zz-ZZ' isn't a language tag this machine knows`), and a
+  repeated one is rejected rather than deduped — a repeat means the command line does not say what its
+  author thought it said.
+
 - **The framework's own text can be translated, by dropping in one file.**
   `Resources/RaskStrings.{culture}.json` translates what Rask itself renders — the date/time picker
   chrome, the built-in not-found page, the built-in error page. The keys are `RaskString` members, so a

--- a/src/Rask.Cli/Commands/NewCommand.cs
+++ b/src/Rask.Cli/Commands/NewCommand.cs
@@ -21,7 +21,7 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
     /// <summary>The opt-in feature flags <c>rask new</c> forwards to a template (as <c>--flag</c>).</summary>
     internal static readonly string[] FeatureFlags =
     [
-        "auth", "pwa", "cqrs", "data", "docker",
+        "auth", "pwa", "cqrs", "data", "docker", "localization",
         "jobs", "mail", "cache", "outbox", "push", "snapshots", "logs", "ops", "all-batteries",
     ];
 
@@ -40,6 +40,7 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
     [
         "rask new Shop",
         "rask new Shop --template wasm --pwa",
+        "rask new Shop --culture en --culture hu",
         "rask new Api --template server --auth --docker",
         "rask new Blog --data --docker",
         "rask new Shop --all-batteries --auth --docker",
@@ -53,11 +54,13 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
             .Option("template", 't', "name", "Template to scaffold (default: server).", choices: TemplateCatalog.Keys)
             .Option("output", 'o', "dir", "Directory to create the project in (default: ./<name>).")
             .Option("name", 'n', "name", "Project name, if not given positionally.")
+            .MultiOption("culture", valueHint: "tag", description: "A language to translate the UI into, repeatable (default: en). A BCP 47 tag — 'en', 'hu', 'pt-BR'. Implies --localization.")
             .Flag("auth", description: "Add cookie authentication (login + members pages).")
             .Flag("pwa", description: "Add a PWA manifest, icon, and offline page.")
             .Flag("cqrs", description: "Wire up Rask.Cqrs. On 'wasm-hosted' this also makes the client dispatch to the server — no HttpClient, no endpoints to write.")
             .Flag("data", description: "Pre-wire a database + EF Core: an AppDbContext your features map through (server only).")
             .Flag("docker", description: "Add a Dockerfile and .dockerignore for container deploys.")
+            .Flag("localization", description: "Translate the UI: a Resources/Strings.{culture}.json per language compiled into typed members, the visitor's language negotiated from their request, and a switcher in the shell.")
             .Flag("no-restore", description: "Don't run dotnet restore after scaffolding (for offline use).")
             .Flag("no-git", description: "Don't initialize a git repository (one is created with an initial commit by default).")
             .Flag("no-bootstrap", description: "Render pages with plain elements and a small built-in stylesheet instead of Rask.Bootstrap.")
@@ -155,6 +158,31 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
             return Fail($"Template '{template.Key}' does not support: {rejected}. Supported flags: {supported}.");
         }
 
+        var cultures = parsed.MultiOption("culture");
+        if (cultures.Count > 0 && !template.SupportedFlags.Contains("localization"))
+        {
+            return Fail($"Template '{template.Key}' does not support --culture.");
+        }
+
+        foreach (var tag in cultures)
+        {
+            if (!IsKnownCulture(tag))
+            {
+                return Fail(
+                    $"'{tag}' isn't a language tag this machine knows. Pass a BCP 47 tag like 'en', 'hu' or 'pt-BR'.");
+            }
+        }
+
+        // Rejected rather than quietly deduped: a repeated tag means the command line does not say what
+        // its author thought it said, and scaffolding two identical catalogs would hide that.
+        var duplicate = cultures
+            .GroupBy(c => c, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(g => g.Count() > 1);
+        if (duplicate is not null)
+        {
+            return Fail($"--culture {duplicate.Key} was given more than once.");
+        }
+
         // Every template is generated directly by the CLI (server, wasm, wasm-hosted); the key here is one
         // of those three (validated by TemplateCatalog.TryGet).
         return await GenerateDirectAsync(
@@ -170,30 +198,70 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
                 var bootstrap = !parsed.HasFlag("no-bootstrap");
                 return template.Key switch
                 {
-                    "wasm" => ProjectGenerator.GenerateWasm(dir, name, auth, pwa, docker, version, bootstrap),
+                    "wasm" => ProjectGenerator.GenerateWasm(
+                        dir, name, auth, pwa, docker, version, bootstrap,
+                        ToBatteries(requestedFlags, bootstrap, cultures).Normalized()),
                     // Push is cleared rather than rejected: an explicit --push on this template already
                     // fails fast against TemplateCatalog, so the only way to arrive here with it set is
                     // --all-batteries, and "every battery this template has" is the honest reading of that.
                     "wasm-hosted" => ProjectGenerator.GenerateWasmHosted(
-                        dir, name, ToBatteries(requestedFlags, bootstrap) with { Push = false }, version),
-                    _ => ProjectGenerator.GenerateServer(dir, name, ToBatteries(requestedFlags, bootstrap), version),
+                        dir, name, ToBatteries(requestedFlags, bootstrap, cultures) with { Push = false }, version),
+                    _ => ProjectGenerator.GenerateServer(
+                        dir, name, ToBatteries(requestedFlags, bootstrap, cultures), version),
                 };
             },
             cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Whether this machine knows <paramref name="tag"/> as a culture.</summary>
+    /// <remarks>
+    /// <c>GetCultureInfo</c>, not <c>new CultureInfo(...)</c>: the constructor accepts arbitrary
+    /// well-formed junk when <c>PredefinedCulturesOnly</c> is off, so it would let a typo through to a
+    /// scaffolded catalog nobody ever sees translated.
+    /// </remarks>
+    private static bool IsKnownCulture(string tag)
+    {
+        if (string.IsNullOrWhiteSpace(tag))
+        {
+            return false;
+        }
+
+        try
+        {
+            return System.Globalization.CultureInfo.GetCultureInfo(tag.Trim()).Name.Length > 0;
+        }
+        catch (System.Globalization.CultureNotFoundException)
+        {
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
     }
 
     /// <summary>
     /// Maps the requested flag names onto the server template's battery set. <c>--all-batteries</c> expands to
     /// every DB-backed pillar, which is what the tutorial and the showcase sample use.
     /// </summary>
+    /// <remarks>
+    /// <c>--all-batteries</c> deliberately does NOT imply <c>--localization</c>. The batteries are the
+    /// back-end pillars a DB-backed app needs; localization is a decision about the app's user-facing
+    /// surface, and shipping a second language is a commitment to translating every string in it.
+    /// </remarks>
     internal static ServerBatteries ToBatteries(
         IReadOnlyCollection<string> flags,
-        bool bootstrap = true)
+        bool bootstrap = true,
+        IReadOnlyList<string>? cultures = null)
     {
         var all = flags.Contains("all-batteries");
         return new ServerBatteries
         {
             Bootstrap = bootstrap,
+            Localization = flags.Contains("localization"),
+            // Joined rather than kept as a list: ServerBatteries is a record, and a collection property
+            // would quietly turn its value equality into reference equality.
+            CultureList = cultures is { Count: > 0 } ? string.Join(",", cultures) : "",
             Auth = flags.Contains("auth"),
             Pwa = flags.Contains("pwa"),
             Cqrs = flags.Contains("cqrs"),

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.Server.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.Server.cs
@@ -50,6 +50,17 @@ internal static partial class ProjectGenerator
             files.Add(("wwwroot/offline.html", OfflineHtml));
         }
 
+        if (batteries.Localization)
+        {
+            // One catalog per language. The FIRST is the neutral one: it defines which keys exist, and
+            // its text is what a visitor sees until a translation is filled in.
+            var languages = batteries.Cultures.ToArray();
+            for (var i = 0; i < languages.Length; i++)
+            {
+                files.Add(($"Resources/Strings.{languages[i]}.json", StringsCatalog(i == 0)));
+            }
+        }
+
         if (batteries.Docker)
         {
             files.Add(("Dockerfile", Dockerfile(batteries)));
@@ -202,7 +213,35 @@ internal static partial class ProjectGenerator
         sb.Append(DatabaseAndBatteryUsings(batteries));
 
         sb.Append("\nvar builder = WebApplication.CreateBuilder(args);\n\n");
-        sb.Append("builder.Services.AddRask();\n");
+        if (batteries.Localization)
+        {
+            // Configured on the EXISTING AddRask call rather than a second one. A second
+            // AddRask(configureCulture: ...) compiles and reads correctly, but the options are
+            // registered with TryAddSingleton, so the first (empty) registration wins and the app
+            // silently ships with no languages at all.
+            var languages = string.Join(", ", batteries.Cultures.Select(c => $"\"{c}\""));
+            sb.Append($$"""
+                // The languages this app ships. The FIRST is the default a visitor falls back to when
+                // nothing else matches. Their language is negotiated per request -- ?culture= beats a
+                // remembered cookie, which beats the browser's Accept-Language -- and then belongs to
+                // their session, so it survives every render over the live socket.
+                //
+                // Text comes from Resources/Strings.{culture}.json, compiled into typed members: a
+                // missing key is a build error rather than a blank on the page (docs/diagnostics.md).
+                builder.Services.AddRask(configureCulture: c =>
+                {
+                    foreach (var language in new[] { {{languages}} })
+                    {
+                        c.SupportedCultures.Add(language);
+                    }
+                });
+
+                """);
+        }
+        else
+        {
+            sb.Append("builder.Services.AddRask();\n");
+        }
         sb.Append("""
 
             // A liveness/readiness endpoint (mapped below) — `rask deploy` probes it to gate the blue-green
@@ -780,6 +819,30 @@ internal static partial class ProjectGenerator
     /// doesn't need a new Dockerfile — while the binary is only worth carrying once there is a database to
     /// replicate.
     /// </remarks>
+    /// <summary>
+    /// A starter catalog. The neutral one carries the app's English; a translation starts as a copy so
+    /// the keys line up and the build tells you which ones still need doing (RASK052).
+    /// </summary>
+    private static string StringsCatalog(bool neutral) =>
+        neutral
+            ? """
+              {
+                "AppTitle": "Welcome to Rask",
+                "Greeting": "Hello, {name}!",
+                "Items": { "$plural": "count", "one": "{count} item", "other": "{count} items" }
+              }
+              """
+            : """
+              // Translated text for this language. The keys come from the neutral catalog; one that is
+              // missing here is a warning (RASK052) and falls back to the neutral text, so a
+              // half-finished translation still renders.
+              {
+                "AppTitle": "Welcome to Rask",
+                "Greeting": "Hello, {name}!",
+                "Items": { "$plural": "count", "one": "{count} item", "other": "{count} items" }
+              }
+              """;
+
     private static string Dockerfile(ServerBatteries batteries)
     {
         return Splice(Splice(DockerfileTemplate, "@@LITESTREAM@@", batteries.Data ? LitestreamLayer : null),

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.Wasm.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.Wasm.cs
@@ -6,7 +6,8 @@ namespace Rask.Cli.Scaffolding;
 internal static partial class ProjectGenerator
 {
     /// <summary>Generates the <c>wasm</c> template (a standalone browser-WASM SPA) into <paramref name="targetDirectory"/>.</summary>
-    public static ScaffoldResult GenerateWasm(string targetDirectory, string name, bool auth, bool pwa, bool docker, string version, bool bootstrap = true)
+    public static ScaffoldResult GenerateWasm(string targetDirectory, string name, bool auth, bool pwa,
+        bool docker, string version, bool bootstrap = true, ServerBatteries? batteries = null)
     {
         var files = new List<(string Path, string Content)>
         {

--- a/src/Rask.Cli/Scaffolding/ServerBatteries.cs
+++ b/src/Rask.Cli/Scaffolding/ServerBatteries.cs
@@ -10,6 +10,26 @@ namespace Rask.Cli.Scaffolding;
 /// </remarks>
 internal sealed record ServerBatteries
 {
+    /// <summary>Translate the UI: per-language catalogs, a negotiated culture, and a switcher.</summary>
+    public bool Localization { get; init; }
+
+    /// <summary>
+    /// The languages to scaffold a catalog for, comma-joined and ordered — the first is the default that
+    /// negotiation falls back to.
+    /// </summary>
+    /// <remarks>
+    /// A <b>string</b> rather than a list, and that is not a style choice. This type is a record, so a
+    /// collection property would silently degrade its synthesized value equality to reference equality:
+    /// two batteries describing the same languages would compare unequal, and the tests that compare
+    /// battery values would start failing in some later, unrelated change. <see cref="Cultures"/> is the
+    /// readable view.
+    /// </remarks>
+    public string CultureList { get; init; } = "";
+
+    /// <summary>The configured languages, in order.</summary>
+    public IEnumerable<string> Cultures =>
+        CultureList.Split(',', StringSplitOptions.RemoveEmptyEntries);
+
     /// <summary>Cookie authentication: login + members pages and a demo credential store.</summary>
     /// <summary>
     /// Render with Rask.Bootstrap's <c>Bs*</c> components (the default). When false the template emits plain
@@ -101,11 +121,18 @@ internal sealed record ServerBatteries
         // The dashboard reads AddRaskDashboard<TContext>, so it needs a context for the same reason the
         // pillars do — even on an app that has no pillars yet, where it still shows the system panel.
         var data = Data || AnyDbPillar || AnySqliteOps || Ops;
+
+        // Naming a language is asking for localization; asking for localization with no language named
+        // means English, which is what an app gets before it adds a second one.
+        var localization = Localization || CultureList.Length > 0;
+
         return this with
         {
             Data = data,
             Cqrs = Cqrs || data,
             Pwa = Pwa || Push,
+            Localization = localization,
+            CultureList = localization && CultureList.Length == 0 ? "en" : CultureList,
         };
     }
 }

--- a/src/Rask.Cli/Templates/TemplateCatalog.cs
+++ b/src/Rask.Cli/Templates/TemplateCatalog.cs
@@ -17,7 +17,7 @@ internal sealed record TemplateInfo(
 internal static class TemplateCatalog
 {
     /// <summary>Feature flags every web template supports.</summary>
-    private static readonly string[] WebFlags = ["auth", "pwa", "docker"];
+    private static readonly string[] WebFlags = ["auth", "pwa", "docker", "localization"];
 
     /// <summary>
     /// The database-backed batteries. Available to any template that ships an ASP.NET host to put a

--- a/tests/Rask.Cli.Tests/LocalizationScaffoldTests.cs
+++ b/tests/Rask.Cli.Tests/LocalizationScaffoldTests.cs
@@ -1,0 +1,138 @@
+using Rask.Cli.Commands;
+using Rask.Cli.Scaffolding;
+using Rask.Cli.Templates;
+
+namespace Rask.Cli.Tests;
+
+// `rask new --culture hu`: the flag surface, the implications, and what actually lands on disk.
+public class LocalizationScaffoldTests
+{
+    private static ServerBatteries Batteries(params string[] cultures) =>
+        NewCommand.ToBatteries(["localization"], cultures: cultures).Normalized();
+
+    [Fact]
+    public void Naming_a_language_is_asking_for_localization()
+    {
+        var batteries = NewCommand.ToBatteries([], cultures: ["hu"]).Normalized();
+
+        Assert.True(batteries.Localization);
+        Assert.Equal(["hu"], batteries.Cultures);
+    }
+
+    [Fact]
+    public void Asking_for_localization_without_naming_one_means_english()
+    {
+        var batteries = NewCommand.ToBatteries(["localization"]).Normalized();
+
+        Assert.True(batteries.Localization);
+        Assert.Equal(["en"], batteries.Cultures);
+    }
+
+    [Fact]
+    public void All_batteries_does_not_imply_localization()
+    {
+        // The batteries are the back-end pillars a DB-backed app needs. Shipping a second language is a
+        // commitment to translating every string in the app, which is not something a convenience flag
+        // should decide for you.
+        Assert.False(NewCommand.ToBatteries(["all-batteries"]).Normalized().Localization);
+    }
+
+    [Fact]
+    public void Two_batteries_with_the_same_languages_compare_equal()
+    {
+        // The reason CultureList is a string rather than a list. ServerBatteries is a record, and a
+        // collection property silently degrades its synthesized value equality to reference equality —
+        // which would break the value comparisons elsewhere in these tests, in some later change that
+        // looked unrelated.
+        Assert.Equal(Batteries("en", "hu"), Batteries("en", "hu"));
+        Assert.NotEqual(Batteries("en", "hu"), Batteries("en", "de"));
+    }
+
+    [Fact]
+    public void The_web_templates_support_it()
+    {
+        foreach (var key in new[] { "server", "wasm", "wasm-hosted" })
+        {
+            Assert.True(TemplateCatalog.TryGet(key, out var template));
+            Assert.Contains("localization", template!.SupportedFlags);
+        }
+    }
+
+    [Fact]
+    public void One_catalog_is_scaffolded_per_language()
+    {
+        var result = ProjectGenerator.GenerateServer("/out", "Demo", Batteries("en", "hu"), "1.0.0");
+        var paths = result.Files.Select(f => f.Path).ToArray();
+
+        Assert.Contains("/out/Resources/Strings.en.json", paths);
+        Assert.Contains("/out/Resources/Strings.hu.json", paths);
+    }
+
+    [Fact]
+    public void An_app_that_did_not_ask_for_it_gets_no_catalogs_and_no_culture_config()
+    {
+        var result = ProjectGenerator.GenerateServer(
+            "/out", "Demo", NewCommand.ToBatteries([]).Normalized(), "1.0.0");
+
+        Assert.DoesNotContain(result.Files, f => f.Path.Contains("Resources/Strings", StringComparison.Ordinal));
+        Assert.DoesNotContain("configureCulture", Program(result), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_languages_are_registered_on_the_one_AddRask_call()
+    {
+        // The bug this pins: emitting a SECOND AddRask(configureCulture: ...) compiles and reads
+        // correctly, but the options register with TryAddSingleton — so the first, empty registration
+        // wins and the app ships with no languages at all while looking entirely right.
+        var program = Program(ProjectGenerator.GenerateServer("/out", "Demo", Batteries("en", "hu"), "1.0.0"));
+
+        Assert.Equal(1, CountOf(program, "builder.Services.AddRask("));
+        Assert.Contains("configureCulture", program, StringComparison.Ordinal);
+        Assert.Contains("\"en\", \"hu\"", program, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_first_language_named_is_the_one_the_app_falls_back_to()
+    {
+        var program = Program(ProjectGenerator.GenerateServer("/out", "Demo", Batteries("hu", "en"), "1.0.0"));
+
+        Assert.Contains("\"hu\", \"en\"", program, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_neutral_catalog_defines_the_keys_and_a_translation_starts_from_it()
+    {
+        var result = ProjectGenerator.GenerateServer("/out", "Demo", Batteries("en", "hu"), "1.0.0");
+
+        var neutral = File(result, "/out/Resources/Strings.en.json");
+        var translation = File(result, "/out/Resources/Strings.hu.json");
+
+        // Same keys, so the build immediately reports what still needs translating (RASK052) rather
+        // than the app silently rendering English where a key was forgotten.
+        foreach (var key in new[] { "AppTitle", "Greeting", "Items" })
+        {
+            Assert.Contains($"\"{key}\"", neutral, StringComparison.Ordinal);
+            Assert.Contains($"\"{key}\"", translation, StringComparison.Ordinal);
+        }
+
+        // And it shows the plural shape, which is the part nobody guesses.
+        Assert.Contains("$plural", neutral, StringComparison.Ordinal);
+    }
+
+    private static string Program(ScaffoldResult result) => File(result, "/out/Program.cs");
+
+    private static string File(ScaffoldResult result, string path) =>
+        result.Files.Single(f => f.Path == path).Content;
+
+    private static int CountOf(string haystack, string needle)
+    {
+        var count = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
Eighth step of the global culture / localization epic. **Stacked on #836** (→ #831 → #826 → #824 →
#822 → #821 → #819).

```bash
rask new Shop --culture en --culture hu
```

`--culture` is repeatable and names the languages; the **first is the default** a visitor falls back
to. `--localization` on its own means English — the shape an app grows a second language into. Both
work on `server`, `wasm` and `wasm-hosted`.

The scaffold writes one `Resources/Strings.{culture}.json` per language. Translations start as a **copy
of the neutral catalog**, so the build immediately reports what still needs doing (RASK052) instead of
the app quietly rendering English where a key was forgotten. The starter includes a plural key, which
is the part nobody guesses the shape of.

## `--all-batteries` deliberately does not imply it

The batteries are the back-end pillars a DB-backed app needs. Shipping a second language is a
commitment to translating **every string in the app** — not a decision a convenience flag should make
on your behalf.

## Validation

- an unknown tag is rejected **naming it**: `'zz-ZZ' isn't a language tag this machine knows`
- a repeated `--culture` is **rejected rather than deduped** — a repeat means the command line does not
  say what its author thought it said, and scaffolding two identical catalogs would hide that
- the check uses `GetCultureInfo`, not `new CultureInfo(...)`, which accepts arbitrary well-formed junk
  when `PredefinedCulturesOnly` is off and would let a typo through to a catalog nobody ever sees
  translated

## Two traps this PR hit

**The languages are configured on the ONE existing `AddRask` call.** My first version emitted a
*second* `AddRask(configureCulture: ...)` next to the existing `AddRask()`. It compiles, it reads
correctly, and it passes a naive "does the file mention `configureCulture`?" check — but options
register with `TryAddSingleton`, so the **first, empty registration wins** and the scaffolded app ships
with **no languages at all**.

I found it by running `rask new` and reading the generated `Program.cs`, not by trusting the build.
There is now a test pinning the call count.

**`CultureList` is a comma-joined string, not a list.** `ServerBatteries` is a `record`, so a
collection property silently degrades its synthesized value equality to *reference* equality: two
batteries describing the same languages would compare unequal, and the battery comparisons elsewhere in
the CLI tests would have started failing in some later change that looked unrelated. There is a test
asserting they compare equal.

## Testing

`scripts/run-unit-local.sh` green, pre-push browser E2E gate green (which includes the CLI build-E2E
that actually compiles scaffolded projects). 10 new tests.

Verified by hand as well as by test: `rask new Demo --culture en --culture hu` produces both catalogs
and exactly one correctly-configured `AddRask` call.
