### PR TITLE
feat(wasm): report a failed boot instead of spinning for ever

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -10,6 +10,7 @@
 #
 # Bypass for docs-only or emergency pushes:  git push --no-verify
 # Per-gate bypass: RASK_SKIP_E2E=1 (browser) · RASK_SKIP_CLI_BUILD_E2E=1 (CLI build)
+#                  RASK_SKIP_WATCH_E2E=1 (hot reload, both halves) · RASK_SKIP_DEPLOY_E2E=1 (deploy)
 set -euo pipefail
 
 root="$(git rev-parse --show-toplevel)"
@@ -100,7 +101,7 @@ fi
 # The watch gate runs a real `dotnet watch` session with 2-minute ceilings, so like the others it runs
 # only when this push touches the hot-reload path: the coordinator, the registries it refreshes, the
 # generators that emit them, the client branch, or `rask dev` itself.
-watch_paths='^(src/Rask\.Core/(HotReload|ScopedAssets|ScopedCss|Live|Routing)/|src/Rask\.Server/(LiveSessionStore|RaskEndpointExtensions)\.cs|src/Rask\.Server/Resources/rask\.js|src/Rask\.(Generators|Cqrs\.Generators|Generators\.Shared)/|src/Rask\.Cli/(Commands/DevCommand|DevTarget|IBrowserLauncher)\.cs|tests/Rask\.Cli\.Tests/WatchHotReloadE2ETests\.cs)'
+watch_paths='^(src/Rask\.Core/(HotReload|ScopedAssets|ScopedCss|Live|Routing)/|src/Rask\.Server/(LiveSessionStore|RaskEndpointExtensions)\.cs|src/Rask\.Server/Resources/rask\.js|src/Rask\.Wasm/(HotReload/|Resources/rask\.wasm\.js|Browser/main\.js)|src/Rask\.(Generators|Cqrs\.Generators|Generators\.Shared)/|src/Rask\.Cli/(Commands/DevCommand|DevTarget|IBrowserLauncher)\.cs|tests/Rask\.Cli\.Tests/WatchHotReloadE2ETests\.cs|tests/Rask\.Examples\.E2E\.Tests/WasmWatchHotReloadTests\.cs)'
 
 if [ "${RASK_SKIP_WATCH_E2E:-}" = "1" ]; then
   echo "pre-push: RASK_SKIP_WATCH_E2E=1 set — skipping the watch hot-reload gate."
@@ -115,6 +116,14 @@ else
   run_gate "watch hot-reload gate" scripts/run-watch-e2e.sh \
     "The hot-reload path doesn't compile." \
     "An edit no longer reaches a running app."
+
+  # And the browser half. scripts/run-wasm-watch-e2e.sh existed but nothing invoked it, so WASM hot
+  # reload was covered by no gate at all: WasmWatchHotReloadTests lives in the E2E project, so the
+  # browser gate's namespace-wide filter DOES select it — and then it reports SKIPPED, because it is
+  # opt-in on RASK_WASM_WATCH_E2E=1 and nothing set that. Green, never run. Only this script sets it.
+  run_gate "WASM watch hot-reload gate" scripts/run-wasm-watch-e2e.sh \
+    "The WASM hot-reload path doesn't compile." \
+    "An edit no longer reaches a running WASM app."
 fi
 
 # The deploy gate boots a privileged container, so it runs only when this push actually touches the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -469,6 +469,12 @@ them until tagged releases begin.
   gate that had never executed. `.githooks/pre-push` now runs both halves of the hot-reload gate, and
   the path filter that decides when covers `src/Rask.Wasm`'s client files too.
 
+  **Running it for the first time immediately found a break.** `WasmWatchAppFixture` writes a temporary
+  probe page at test time, and its template still used the factory API that #792 deleted — a `H1(Id: …)`
+  call on a non-`partial` class, which has not compiled since. The same shape as #795, where a template
+  the build gate never compiled was broken by that same change and found by reading rather than by
+  failing. The probe is now chain-built, and the gate passes.
+
 - **`scripts/run-e2e-local.sh` contradicted itself about #650.** One comment said the empty scoped-asset
   bake was unfixable by cleaning and "still open"; twenty lines later another said `-nodeReuse:false`
   *is* the fix, with a mechanism (MSBuild reuses worker nodes, `Assembly.LoadFrom` throws on a reused

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,24 @@ them until tagged releases begin.
   shells — the framework's, the samples', the one `rask new` writes — they have already drifted, and a
   user may write their own. Owning it in the one file all of them load means no shell can be missing it.
 
+- **The browser gate refuses to start alongside another one.** Two suites on one machine contend for
+  resources — the port collision was fixed in #626, but contention still surfaces as a plausible-looking
+  red in one or both runs, minutes later, with nothing in the log pointing back at it. It cost exactly
+  that today: an unexplained five-minute timeout between two worktrees that were actively coordinating
+  and still both believed the machine was idle, while a third and then a fourth suite ran unseen.
+
+  `scripts/run-e2e-local.sh` now names the other run — pid, how long it has been going, and which
+  worktree — and stops, rather than producing a result nobody should trust.
+  `RASK_E2E_ALLOW_CONCURRENT=1` proceeds anyway; `CI` skips the check.
+
+  It **refuses** rather than warning because this runs from `pre-push` behind thousands of build lines,
+  where a warning is not read, and because refuse-with-override is what every other opt-out here already
+  does. The match is anchored on the `scripts/` path segment: a bare name also matches any shell whose
+  argv merely mentions the script, which reported three conflicts where there was one the first time it
+  ran — and under refuse-by-default a false positive is a blocked push. The predicate lives in
+  `scripts/lib/e2e-concurrency.sh` with a table test, the same split as `build-failure.sh`, because
+  something that decides whether a push may proceed is exactly what stays quietly wrong otherwise.
+
 - **`RASK_E2E_FILTER` narrows a browser-gate run to one journey.** The filter was hard-coded, so
   iterating on a single failing journey cost the whole suite — including two emscripten relinks — every
   attempt. A filtered run says loudly that it was filtered, in both its header and its final line: a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **A browser-WASM app that fails to start now says so, instead of spinning for ever.** `main.js` was
+  four bare top-level `await`s with no `try` anywhere and no global rejection handler, and nothing ever
+  removed the splash screen explicitly — it disappeared as a side effect of the first successful morph.
+  So *every* way of failing to mount looked the same: a 404 on `_framework`, a wrong content type, an
+  import-map/SRI drift, an empty scoped-asset bake, and a genuinely slow connection were one symptom.
+  The first sign was a Playwright locator timing out after 90–120 seconds against a boot screen, which
+  names nothing and reads as a hang.
+
+  The splash screen is now replaced by **which step failed and the exception, verbatim**, with the same
+  text in the console. Three callers share the one surface: this module's own per-step catch,
+  `rask.wasm.js` (the first frame being unreadable, and an unreachable `Dispatch` export — an app that
+  boots and then ignores every click), and .NET through a new `bootFailed` JSImport, because only the
+  managed side still has the exception — to JS a startup failure is an opaque rejected promise out of
+  `runMain`. `WasmHostBuilder.RunAsync` reports and then **rethrows**, so nothing is swallowed.
+
+  **It never paints over a working page.** Once the app has mounted the boot surface goes silent for
+  good and the root error boundary owns errors, because turning a recoverable error into a full-screen
+  failure would be worse than the bug this fixes. The failure state carries a `[data-rask-boot-error]`
+  hook, so a broken boot fails an E2E in seconds with a reason attached.
+
+  The markup and CSS live in `main.js` rather than in the page shell deliberately: there are several
+  shells — the framework's, the samples', the one `rask new` writes — they have already drifted, and a
+  user may write their own. Owning it in the one file all of them load means no shell can be missing it.
+
+- **`RASK_E2E_FILTER` narrows a browser-gate run to one journey.** The filter was hard-coded, so
+  iterating on a single failing journey cost the whole suite — including two emscripten relinks — every
+  attempt. A filtered run says loudly that it was filtered, in both its header and its final line: a
+  narrowed green is not the gate.
+
 - **A localization guide, a live demo, and a browser journey step.** `docs/localization.md` covers the
   whole feature end to end — how a visitor's language is chosen, why URLs stay culture-neutral, typed
   catalogs, plurals, what deliberately stays invariant, right-to-left, and the WASM ICU trade-off — and
@@ -408,6 +437,21 @@ them until tagged releases begin.
   `SqlitePragmas.Optimize(connection)` directly.
 
 ### Fixed
+
+- **The WASM hot-reload gate was run by nothing, and reported green.** `scripts/run-wasm-watch-e2e.sh`
+  existed but no hook invoked it. `WasmWatchHotReloadTests` lives in the browser E2E project, so that
+  gate's namespace-wide filter *did* select the class — and it then reported **SKIPPED**, because the
+  tests are opt-in on `RASK_WASM_WATCH_E2E=1` and only the orphaned script sets it. Every push passed a
+  gate that had never executed. `.githooks/pre-push` now runs both halves of the hot-reload gate, and
+  the path filter that decides when covers `src/Rask.Wasm`'s client files too.
+
+- **`scripts/run-e2e-local.sh` contradicted itself about #650.** One comment said the empty scoped-asset
+  bake was unfixable by cleaning and "still open"; twenty lines later another said `-nodeReuse:false`
+  *is* the fix, with a mechanism (MSBuild reuses worker nodes, `Assembly.LoadFrom` throws on a reused
+  one, the bake writes nothing and reports success) and a measurement (3 failures in 4 consecutive
+  publishes on identical inputs). The second is correct and the first predates it; the stale half is
+  gone. `BakeScopedAssetsTask` also fails the build now rather than baking an empty bundle silently, so
+  the version of this that cost the most to find cannot recur.
 
 - **Everything Rask puts on the wire now formats and parses invariantly, whatever culture the process
   is in.** Rask has no culture concept yet, so every one of these paths inherited the machine's locale

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,14 @@ them until tagged releases begin.
 
   **It never paints over a working page.** Once the app has mounted the boot surface goes silent for
   good and the root error boundary owns errors, because turning a recoverable error into a full-screen
-  failure would be worse than the bug this fixes. The failure state carries a `[data-rask-boot-error]`
-  hook, so a broken boot fails an E2E in seconds with a reason attached.
+  failure would be worse than the bug this fixes.
+
+  The failure state carries a `[data-rask-boot-error]` hook, and the browser-journey harness now
+  **races every journey against it**. Each WASM journey opens with a 60–120 second wait on a selector
+  that exists only once the app has mounted, so a dead boot used to cost the whole timeout and then
+  report the missing selector — naming nothing about the cause. It now fails in seconds, quoting what
+  the page says went wrong. (A hook nothing waits on would only have moved the evidence somewhere
+  nobody looks; the Server hosts have no boot screen, so their journeys are unaffected.)
 
   The markup and CSS live in `main.js` rather than in the page shell deliberately: there are several
   shells — the framework's, the samples', the one `rask new` writes — they have already drifted, and a

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -352,3 +352,27 @@ The `nginx.conf` does four things that matter for a Rask WASM bundle:
 Because it's just static files, you can equally serve the `wwwroot` publish output from any CDN or
 object-storage static host instead of a container. For GitHub Pages / sub-path hosting, publish with
 `/p:RaskPathBase=/my-repo` — see [Mobile & PWA → Deploying](pwa.md#deploying-github-pages--sub-paths).
+
+### When the app doesn't start
+
+A misconfigured static host is the commonest way a WASM bundle fails, and the symptom used to be the
+worst possible one: the splash screen, spinning, for ever. Nothing in the console, nothing on the page.
+A 404 on `_framework`, the wrong MIME type, and a genuinely slow connection all looked identical.
+
+They no longer do. **A Rask app that cannot start replaces its splash screen with what went wrong** —
+which step failed, and the exception, verbatim:
+
+> **This app failed to start.**
+> The .NET runtime could not be loaded. Check that the `_framework` assets are being served, with the
+> correct `application/wasm` content type.
+
+The full error is in the browser console too. The three failures worth recognising:
+
+| What it says | What it usually means |
+| --- | --- |
+| The .NET runtime could not be loaded | `_framework` is 404ing, or `.wasm` is served as `application/octet-stream`. Check the two `nginx.conf` items above. |
+| The Rask browser module could not be loaded | `rask.wasm.js` did not reach the client — usually a sub-path deploy without `/p:RaskPathBase`. |
+| The app finished starting but never rendered | The app booted and returned without painting. Check that `Program.cs` **awaits** `host.RunAsync<App>()`. |
+
+The failure panel appears only before the app has mounted. Once it has, an uncaught error is handled by
+the [root error boundary](lifecycle.md) instead, so a working page is never replaced by this one.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -104,6 +104,13 @@ Every change passes this gate before a PR (the `rask-ship` skill):
   happen (they are what the tests boot), but you pay for one journey instead of the whole suite:
   `RASK_E2E_FILTER='FullyQualifiedName~PlaygroundExampleTests' scripts/run-e2e-local.sh`. It says loudly
   that the run was filtered, because a narrowed green is not the gate.
+
+  **Only one browser gate runs at a time.** Two suites on one machine contend for resources, and that
+  shows up as a plausible-looking red minutes later with nothing in the log pointing back at it — so the
+  gate names the other run (pid, elapsed, worktree) and stops. If you are working across several
+  worktrees, this is the thing that stops you diagnosing a failure that was never in your branch.
+  `RASK_E2E_ALLOW_CONCURRENT=1` overrides it; treat anything it then reports as suspect until re-run
+  alone.
 - **The CLI build gate runs locally, enforced before push.** `scripts/run-cli-build-e2e.sh` is the only
   thing proving the code the CLI *writes* actually compiles — every other CLI test asserts on generated
   strings. It packs this commit's Rask packages to a local feed, scaffolds every `rask new` flag

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -24,6 +24,12 @@ it under a real `dotnet watch`, edits a file, and asserts the change reached the
 without it being torn down. It's opt-in (`RASK_WATCH_E2E=1`); run it when you touch the hot-reload
 coordinator, the scoped-asset registry, the generated registries, or `rask dev`.
 
+`scripts/run-wasm-watch-e2e.sh` is the browser half of the same thing, opt-in on `RASK_WASM_WATCH_E2E=1`.
+Both are run by `.githooks/pre-push` when a push touches the hot-reload path (bypass with
+`RASK_SKIP_WATCH_E2E=1`). The WASM one used to be invoked by nothing at all: its tests live in the E2E
+project, so the browser gate's namespace-wide filter *selected* them and they then reported **SKIPPED**,
+because only this script sets the variable that enables them. Green on every push, never once run.
+
 ## The definition-of-done gate
 
 Every change passes this gate before a PR (the `rask-ship` skill):
@@ -94,6 +100,10 @@ Every change passes this gate before a PR (the `rask-ship` skill):
   (`tests/Rask.Examples.E2E.Tests`, Playwright) was moved out of the CI pipeline. Run it with
   `scripts/run-e2e-local.sh`; the `.githooks/pre-push` hook runs it on `git push` (enable hooks
   with `git config core.hooksPath .githooks`; bypass with `git push --no-verify` or `RASK_SKIP_E2E=1`).
+  While iterating on **one** journey, narrow the run with `RASK_E2E_FILTER` — the sample publishes still
+  happen (they are what the tests boot), but you pay for one journey instead of the whole suite:
+  `RASK_E2E_FILTER='FullyQualifiedName~PlaygroundExampleTests' scripts/run-e2e-local.sh`. It says loudly
+  that the run was filtered, because a narrowed green is not the gate.
 - **The CLI build gate runs locally, enforced before push.** `scripts/run-cli-build-e2e.sh` is the only
   thing proving the code the CLI *writes* actually compiles — every other CLI test asserts on generated
   strings. It packs this commit's Rask packages to a local feed, scaffolds every `rask new` flag

--- a/scripts/lib/e2e-concurrency.sh
+++ b/scripts/lib/e2e-concurrency.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Is another browser E2E gate already running on this machine?
+#
+# Lives here rather than inline in run-e2e-local.sh so it can be tested (scripts/tests/e2e-concurrency.test.sh) —
+# same split as scripts/lib/build-failure.sh, and for the same reason: a predicate that decides whether a
+# push is allowed to proceed is exactly the kind of thing that is quietly wrong until it costs someone
+# an afternoon.
+
+# Prints the pids of OTHER live gate runs, one per line. Empty output means the machine is ours.
+#
+# Two decisions here, both learned the hard way:
+#
+#   * The match is ANCHORED on the scripts/ path segment. A bare `pgrep -f run-e2e-local.sh` also matches
+#     any shell whose argv merely MENTIONS the script -- a `sh -c` wrapper, a `tee` of its log, an editor.
+#     The first live test of this check reported three "conflicts" where there was one, two of them its
+#     own test harness. A real run is always <repo>/scripts/run-e2e-local.sh.
+#
+#   * By PROCESS, never a lockfile. A lockfile survives kill -9 and a laptop sleep and then wedges the
+#     gate until someone works out what to delete; a Ctrl-C'd run leaves no process behind, so this is
+#     self-healing. RASK_E2E_PGREP_OVERRIDE exists only so the test can inject a candidate list.
+rask_other_e2e_runs() {
+  self_pid="${1:-$$}"
+  parent_pid="${2:-$PPID}"
+
+  candidates="$(
+    if [ -n "${RASK_E2E_PGREP_OVERRIDE:-}" ]; then
+      printf '%s\n' $RASK_E2E_PGREP_OVERRIDE
+    else
+      pgrep -f 'run-e2e-local\.sh' 2>/dev/null || true
+    fi
+  )"
+
+  for pid in $candidates; do
+    [ "$pid" = "$self_pid" ] && continue
+    [ "$pid" = "$parent_pid" ] && continue
+    if rask_is_e2e_gate_command "$(rask_e2e_command_of "$pid")"; then
+      printf '%s\n' "$pid"
+    fi
+  done
+}
+
+# Is this command line a process actually RUNNING the gate, as opposed to one that merely mentions it?
+#
+# Decided on the EXECUTABLE POSITION rather than by substring, which is what makes both directions come
+# out right:
+#
+#   bash scripts/run-e2e-local.sh          gate     <- the documented invocation; relative, no ./
+#   scripts/run-e2e-local.sh               gate
+#   /bin/bash /repo/scripts/...sh          gate     <- what .githooks/pre-push execs
+#   vim scripts/run-e2e-local.sh           NOT      <- pgrep -f matches it; an editor is not a gate
+#   grep -rn run-e2e-local.sh /repo        NOT
+#   tee /tmp/.../run-e2e-local.log         NOT      <- the gate's own log, not a second gate
+#   zsh -c '... && bash /tmp/x/...sh'      NOT      <- a wrapper; the child it spawns is matched on its own
+#
+# An earlier version anchored on the '/scripts/' path segment instead. That got the editor and the tee
+# right but silently missed `bash scripts/run-e2e-local.sh` -- no leading slash -- which is exactly the
+# form CLAUDE.md and CONTRIBUTING.md document for running the gate by hand. It would have been blind to
+# the manual runs that prompted the check, while looking correct. Substring matching cannot separate
+# "is running this" from "names this"; argv position can.
+rask_is_e2e_gate_command() {
+  [ -n "${1:-}" ] || return 1
+
+  # Word-split the command line, with globbing off so a stray * in an argument cannot expand.
+  #
+  # Known limitation: a repo path containing a SPACE defeats the split, and `ps -o command=` gives no way
+  # to recover the boundary. Recovering it properly means reading argv from /proc or lsof, which is a lot
+  # of machinery for a case this repo does not have — so it is written down rather than handled, and the
+  # failure is a missed detection (a run that proceeds), never a wrong refusal.
+  set -f
+  # shellcheck disable=SC2086
+  set -- $1
+  set +f
+
+  first="${1:-}"
+  second="${2:-}"
+
+  case "${first##*/}" in
+    bash | sh | zsh | dash | ksh)
+      # Walk past the shell's own options to the script path. Bailing on the FIRST option instead --
+      # which is what this did at first -- is correct for -c and wrong for every other flag: it made
+      # `bash -x scripts/run-e2e-local.sh` invisible, and running the gate under -x is a plausible thing
+      # to do while debugging the gate. A guard clause right for its motivating case and over-broad for
+      # its siblings is the same mistake as the path anchor it replaced.
+      shift
+      while [ $# -gt 0 ]; do
+        case "$1" in
+          # -c (and combined forms like -lc): the argument is script TEXT, not a path. It can end with
+          # the gate's path without running it; the child process that does is matched on its own pid.
+          #
+          # Matches ANY option containing a c, deliberately and approximately. It over-matches --norc,
+          # and `bash --rcfile x <script>` is missed for a second, unrelated reason: --rcfile consumes
+          # an argument, so the walk below takes `x` for the script path. Narrowing this arm to
+          # single-dash clusters would fix --norc and leave --rcfile broken -- a rule that reads as
+          # exhaustive while still missing a case, which is worse than one that admits it. Handling
+          # both needs a table of which options take arguments, for invocations nobody uses on this
+          # gate. Both failures are missed detections, never wrong refusals.
+          -*c*) return 1 ;;
+          -*) shift ;;
+          *) break ;;
+        esac
+      done
+      target="${1:-}"
+      ;;
+    *) target="$first" ;;
+  esac
+
+  case "$target" in
+    */run-e2e-local.sh | run-e2e-local.sh) return 0 ;;
+  esac
+  return 1
+}
+
+# Indirected so the test can stub it without spawning real processes.
+rask_e2e_command_of() {
+  if [ -n "${RASK_E2E_COMMAND_STUB:-}" ]; then
+    eval "printf '%s' \"\${RASK_E2E_CMD_$1:-}\""
+    return
+  fi
+  ps -o command= -p "$1" 2>/dev/null
+}

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -19,6 +19,67 @@ fi
 root="$(git rev-parse --show-toplevel)"
 cd "$root"
 
+# Is another copy of this gate already running?
+#
+# The port collision was fixed in #626, but two suites on one machine still contend for resources, and
+# the way that surfaces is the expensive one: a plausible-looking red in one or both runs, minutes after
+# the contention, with nothing in the log pointing back at it. It has already cost one unexplained
+# timeout across two worktrees that were coordinating and still both believed the machine was idle.
+#
+# REFUSE by default, with an override. This runs from .githooks/pre-push, which prints thousands of
+# build lines, and a warning in the middle of that is a warning nobody reads — which would leave the
+# contention to be discovered later as a red that looks real. Refusing also matches how every other
+# opt-out here already works (RASK_SKIP_E2E, RASK_SKIP_CLI_BUILD_E2E, RASK_SKIP_WATCH_E2E), so it needs
+# no new convention.
+#
+# The argument against — that a blocked push with a false positive becomes "I cannot push and I do not
+# know why" — is real, and is answered in two places rather than by warning instead. The match is
+# decided on the EXECUTABLE POSITION in the other process's argv (rask_is_e2e_gate_command), because a
+# bare name matched a shell whose argv merely mentioned the script the first time this was tested — and
+# an anchor on the scripts/ path, which was the first fix, then silently missed the relative invocation
+# the docs actually tell you to use. And the refusal prints the offending pid, its elapsed time, its full
+# command line, and the exact variable that overrides it, so it can never be the unexplained kind.
+#
+# Detected by PROCESS, never by a lockfile: a lockfile survives kill -9 and a laptop sleep and then
+# wedges the gate until someone works out what to delete. Process detection is self-healing — a run
+# someone Ctrl-C'd leaves nothing behind. This repo has enough gates that failed quietly without adding
+# one that fails loudly at the worst moment.
+#
+# Printing WHICH run and HOW LONG is the useful half — "there is a conflict" tells you there is a
+# problem, `ps -o etime=` is what lets you decide whether to wait for it or investigate your own red.
+#
+# Skipped under CI purely so this can never be the thing that breaks an automated run. Nothing in
+# .github/workflows runs the browser E2E today — release.yml only packs, ci.yml runs the benchmark
+# gates — so this is insurance against a future parallel path, not protection of a known one.
+if [ -z "${CI:-}" ]; then
+  # shellcheck source=lib/e2e-concurrency.sh
+  . "$root/scripts/lib/e2e-concurrency.sh"
+  others="$(rask_other_e2e_runs | tr '\n' ' ')"
+
+  if [ -n "${others// /}" ]; then
+    echo "run-e2e-local: another browser E2E gate is already running on this machine."
+    for pid in $others; do
+      elapsed="$(ps -o etime= -p "$pid" 2>/dev/null | tr -d ' ')"
+      cmd="$(ps -o command= -p "$pid" 2>/dev/null | cut -c1-120)"
+      [ -n "$elapsed" ] && echo "               pid $pid, running for ${elapsed}: $cmd"
+    done
+    echo
+    echo "            Two suites on one machine contend for resources. The port collision was fixed in"
+    echo "            #626, but contention still surfaces as a plausible-looking red in one or both runs,"
+    echo "            minutes later, with nothing in the log pointing back at it. It has already cost one"
+    echo "            unexplained timeout between two worktrees that were coordinating and still both"
+    echo "            believed the machine was idle."
+    echo
+    echo "            Wait for the run above to finish, then push again. To run anyway:"
+    echo "                RASK_E2E_ALLOW_CONCURRENT=1 git push        (or set it for this script)"
+    echo "            and treat any failure as suspect until you have re-run it alone."
+    if [ "${RASK_E2E_ALLOW_CONCURRENT:-}" != "1" ]; then
+      exit 1
+    fi
+    echo "run-e2e-local: RASK_E2E_ALLOW_CONCURRENT=1 — starting alongside it anyway."
+  fi
+fi
+
 # shellcheck source=lib/build-failure.sh
 . "$root/scripts/lib/build-failure.sh"
 

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -88,16 +88,18 @@ dotnet publish samples/Rask.Example.Shop -c Release --no-build --no-restore --no
 # last. Clearing only obj/Release/net10.0-browser keeps obj/project.assets.json, so the restore below is
 # still incremental.
 #
-# bin/ is cleared alongside obj/. Be clear about what this does and does not do: it is NOT the fix, and
-# the gate still fails intermittently with it in place. It was added on an A/B that looked decisive at the
-# time (obj alone -> 0 files under publish/wwwroot/_rask, obj + bin -> 6) and has since been contradicted
-# by three sessions' worth of runs, including reproductions on branches that already had it. It is kept
-# only because it is cheap — one recompile of a project whose native relink dominates this step anyway.
+# bin/ is cleared alongside obj/. Be clear about what this does and does not do: it is NOT the fix for
+# #650. It was added on an A/B that looked decisive at the time (obj alone -> 0 files under
+# publish/wwwroot/_rask, obj + bin -> 6) and was then contradicted by three sessions' worth of runs,
+# including reproductions on branches that already had it. It is kept only because it is cheap — one
+# recompile of a project whose native relink dominates this step anyway — and because the TFM-intermediate
+# clear above it is load-bearing for the two-modes-into-one-obj/ reason given there.
 #
-# What #650 actually is, per the build log: after the no-native solution build above, this native publish's
-# bake RUNS and writes ZERO files for an app that plainly has scoped assets. So no amount of cleaning here
-# can help — there is nothing stale to clear, and the deciding variable is the preceding no-native build,
-# not this project's output. The fix belongs inside the bake and is still open.
+# #650 itself is fixed, below, by -nodeReuse:false; see the note on that publish for the mechanism. This
+# comment used to end by saying the bake wrote zero files for reasons no cleaning could address and that
+# the fix was "still open" — true when written, stale since, and directly contradicted by the note 20
+# lines down. BakeScopedAssetsTask now also fails the build rather than baking an empty bundle and
+# reporting success (see its zero-files Log.LogError), so the silent version of this cannot recur.
 #
 # Two traps when verifying anything in this area, both of which have already produced false confidence:
 # running the gate twice back to back does not distinguish these cases, since both runs do the same thing;
@@ -143,10 +145,26 @@ else
   echo "    fails with a missing-browser error: 'pwsh <path>/playwright.ps1 install chromium')"
 fi
 
-echo "==> Browser journey E2E (Rask.Examples.E2E.Tests)"
+# RASK_E2E_FILTER narrows the run while you are iterating on ONE journey. The publishes above still
+# happen — they are what makes the bundles the tests boot — but a single journey then costs one run
+# instead of the whole suite. Unset (the gate's own case) it runs everything, which is the only
+# setting the pre-push hook should ever use.
+#
+#   RASK_E2E_FILTER='FullyQualifiedName~PlaygroundExampleTests' scripts/run-e2e-local.sh
+e2e_filter="${RASK_E2E_FILTER:-FullyQualifiedName~Rask.Examples.E2E.Tests}"
+if [ -n "${RASK_E2E_FILTER:-}" ]; then
+  echo "==> Browser journey E2E (FILTERED: $e2e_filter)"
+  echo "    Not the full gate. Clear RASK_E2E_FILTER before trusting a green run."
+else
+  echo "==> Browser journey E2E (Rask.Examples.E2E.Tests)"
+fi
 dotnet test tests/Rask.Examples.E2E.Tests/bin/Release/net10.0/Rask.Examples.E2E.Tests.dll \
-  --filter "FullyQualifiedName~Rask.Examples.E2E.Tests" \
+  --filter "$e2e_filter" \
   --logger "console;verbosity=normal"
 
 echo
-echo "==> Browser E2E passed."
+if [ -n "${RASK_E2E_FILTER:-}" ]; then
+  echo "==> Browser E2E passed — FILTERED run ($e2e_filter), not the full gate."
+else
+  echo "==> Browser E2E passed."
+fi

--- a/scripts/tests/e2e-concurrency.test.sh
+++ b/scripts/tests/e2e-concurrency.test.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Table test for rask_other_e2e_runs (scripts/lib/e2e-concurrency.sh).
+#
+# This predicate decides whether a push is allowed to proceed, so both directions cost something real:
+# a miss lets two browser suites contend and produces a red that looks like a bug and is not, while a
+# false positive blocks a push for a process that is not a gate at all. The second is not hypothetical —
+# the first live run of this check reported three conflicts where there was one, having matched a shell
+# whose argv merely mentioned the script and its own test harness. Every row below is stated rather than
+# left to the cases someone happened to try, same as build-failure-kind.test.sh.
+#
+# Usage:  scripts/tests/e2e-concurrency.test.sh   (run by scripts/run-unit-local.sh)
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+# shellcheck source=../lib/e2e-concurrency.sh
+. "$root/scripts/lib/e2e-concurrency.sh"
+
+export RASK_E2E_COMMAND_STUB=1
+
+failures=0
+checked=0
+
+# assert <name> <expected-pids> — candidates and their commands come from RASK_E2E_* set by the caller.
+assert() {
+  name="$1"
+  expected="$2"
+
+  actual="$(rask_other_e2e_runs 100 200 | tr '\n' ' ' | sed 's/ *$//')"
+  checked=$((checked + 1))
+
+  if [ "$actual" = "$expected" ]; then
+    printf '  ok   %-56s -> [%s]\n' "$name" "$actual"
+  else
+    printf '  FAIL %-56s -> [%s] (expected [%s])\n' "$name" "$actual" "$expected" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+echo "==> rask_other_e2e_runs"
+
+# A real gate run: bash executing <repo>/scripts/run-e2e-local.sh.
+RASK_E2E_PGREP_OVERRIDE="300" \
+  RASK_E2E_CMD_300="bash /Users/x/RiderProjects/Rask/.claude/worktrees/a/scripts/run-e2e-local.sh" \
+  assert "a real gate run in another worktree" "300"
+
+# Our own pid, and the shell that launched us, are never a conflict with ourselves.
+RASK_E2E_PGREP_OVERRIDE="100 200" \
+  RASK_E2E_CMD_100="bash /repo/scripts/run-e2e-local.sh" \
+  RASK_E2E_CMD_200="bash /repo/scripts/run-e2e-local.sh" \
+  assert "self and parent are excluded" ""
+
+# The false positive that made this file exist: a wrapper shell whose command line contains the path
+# without executing it. pgrep -f matches it; the scripts/ anchor must not.
+RASK_E2E_PGREP_OVERRIDE="301" \
+  RASK_E2E_CMD_301="/bin/zsh -c source /home/u/.claude/snapshot.sh && bash /tmp/fake/run-e2e-local.sh" \
+  assert "a wrapper shell mentioning a non-scripts path" ""
+
+# tee of the gate's log carries the name too, and is not a second gate.
+RASK_E2E_PGREP_OVERRIDE="302" \
+  RASK_E2E_CMD_302="tee /var/folders/T/rask-pre-push-9562/run-e2e-local.log" \
+  assert "the tee of a gate's log is not a gate" ""
+
+# A dead pid: ps prints nothing. Process detection is self-healing precisely here — this is the case a
+# lockfile would get wrong, wedging the gate until someone deleted the file by hand.
+RASK_E2E_PGREP_OVERRIDE="303" \
+  assert "a pid that has already exited" ""
+
+# Several at once, mixed with noise: report every genuine one, because "how long has it been going"
+# is the thing that decides whether to wait, and that needs all of them.
+RASK_E2E_PGREP_OVERRIDE="304 305 306" \
+  RASK_E2E_CMD_304="bash /repo/a/scripts/run-e2e-local.sh" \
+  RASK_E2E_CMD_305="grep -rn run-e2e-local.sh /repo" \
+  RASK_E2E_CMD_306="bash /repo/b/scripts/run-e2e-local.sh" \
+  assert "two real runs alongside an unrelated grep" "304 306"
+
+# --- invocation forms -------------------------------------------------------------------------
+#
+# The predicate decides on argv POSITION, not substring, and these are the rows that pin it. An earlier
+# version anchored on the '/scripts/' path segment: it got the editor and the tee right and silently
+# missed `bash scripts/run-e2e-local.sh`, which is the form CLAUDE.md and CONTRIBUTING.md document for
+# running the gate by hand. A guard blind to the manual runs that prompted it is worse than none,
+# because it looks correct.
+echo
+echo "==> rask_is_e2e_gate_command"
+
+form() {
+  expected="$1"
+  cmd="$2"
+  checked=$((checked + 1))
+  if rask_is_e2e_gate_command "$cmd"; then actual="gate"; else actual="not"; fi
+  if [ "$actual" = "$expected" ]; then
+    printf '  ok   %-52s -> %s\n' "$cmd" "$actual"
+  else
+    printf '  FAIL %-52s -> %s (expected %s)\n' "$cmd" "$actual" "$expected" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+form gate "bash scripts/run-e2e-local.sh"
+form gate "scripts/run-e2e-local.sh"
+form gate "bash ./scripts/run-e2e-local.sh"
+form gate "/bin/bash /repo/.claude/worktrees/a/scripts/run-e2e-local.sh"
+form gate "run-e2e-local.sh"
+
+# Shell options are walked past, not treated as the end of the road. Running the gate under -x is a
+# plausible thing to do while debugging the gate, and an earlier version bailed on the first option and
+# made every one of these invisible.
+form gate "bash -x scripts/run-e2e-local.sh"
+form gate "bash -eu ./scripts/run-e2e-local.sh"
+
+form not  "vim scripts/run-e2e-local.sh"
+form not  "grep -rn run-e2e-local.sh /repo"
+form not  "tee /var/folders/T/rask-pre-push-9562/run-e2e-local.log"
+# -c stays excluded, including combined forms: the argument is script text, and the child it spawns is
+# matched on its own pid. This is the distinction the option-walk above must not erase.
+form not  "/bin/zsh -c source /home/u/.claude/snap.sh && bash /tmp/fake/run-e2e-local.sh"
+form not  "sh -lc bash /tmp/fake/run-e2e-local.sh"
+form not  "bash -x -c bash /tmp/fake/run-e2e-local.sh"
+form not  "less /repo/scripts/run-e2e-local.sh"
+form not  ""
+
+echo
+if [ "$failures" -ne 0 ]; then
+  echo "e2e-concurrency: $failures of $checked checks FAILED." >&2
+  exit 1
+fi
+echo "e2e-concurrency: $checked checks passed."

--- a/src/Rask.Wasm/Browser/main.js
+++ b/src/Rask.Wasm/Browser/main.js
@@ -91,8 +91,14 @@ function reportBootFailure(message, detail) {
     // artefact will find, and it is the only channel left if the DOM work below throws.
     console.error(`[Rask] boot failed: ${message}`, detail ?? "");
 
-    // Once the app has painted, the boot screen is gone and the morph owns the document.
-    // A later failure belongs to the running app, not to boot — never paint over a live page.
+    // Once the app has painted, a later failure belongs to the running app rather than to boot, and the
+    // root error boundary owns it — never paint a full-screen failure over a working page.
+    //
+    // Read from a flag rask.wasm.js sets when it applies a frame, NOT from whether the splash element is
+    // still in the document. The morph patches the existing document in place, so that element stays
+    // connected after a perfectly good first render; believing otherwise made every WASM journey report
+    // a boot failure against an app whose console said "first render applied".
+    if (globalThis.__raskPainted) return;
     if (!boot?.isConnected) return;
     // First failure wins. A boot failure usually cascades (the throw, then the rejection that
     // follows it, then the never-painted check below), and the first one is the cause.
@@ -198,11 +204,15 @@ rask.setExports(raskWasmExports);
 
 await step("The app threw while starting.", () => runMain());
 
-// runMain resolves only once Program.cs's `await host.RunAsync<App>()` has returned, and the first
-// frame is pushed synchronously from inside it — so by now the morph has replaced the document and
-// this element is detached. Still attached means the app finished starting without ever painting,
-// which is otherwise indistinguishable from a hang.
-if (boot?.isConnected) {
+// runMain resolves only once Program.cs's `await host.RunAsync<App>()` has returned, and the first frame
+// is pushed synchronously from inside it — so by now a frame has been applied and rask.wasm.js has set
+// this flag. Its absence means the app finished starting without ever painting, which is otherwise
+// indistinguishable from a hang.
+//
+// Asked of the render path rather than of the DOM. The obvious-looking test — "is the splash element
+// still in the document" — is wrong, because the morph patches the document in place and leaves it
+// connected, so it reports a boot failure for every successful boot.
+if (!globalThis.__raskPainted) {
     reportBootFailure(
         "The app finished starting but never rendered. Check that Program.cs awaits "
         + "host.RunAsync<App>() and that the app has a route for this URL.");

--- a/src/Rask.Wasm/Browser/main.js
+++ b/src/Rask.Wasm/Browser/main.js
@@ -26,23 +26,184 @@ function renderBootProgress(loaded, total) {
     if (bootLabel) bootLabel.textContent = `Loading… ${pct}%`;
 }
 
-const {getAssemblyExports, runMain} = await dotnet
-    .withApplicationArgumentsFromQuery()
-    .withModuleConfig({
-        onDownloadResourceProgress: (resourcesLoaded, totalResources) => {
-            // Best-effort UI; never let a progress hiccup break boot.
-            try {
-                renderBootProgress(resourcesLoaded, totalResources);
-            } catch (e) {
-            }
+// ---------------------------------------------------------------------------
+// Boot failure reporting.
+//
+// A WASM app that downloads its runtime and then fails to mount used to leave the
+// splash spinner turning for ever: no console error, no page error, nothing on
+// screen. A 404 on _framework, an import-map/SRI drift, an empty scoped-asset bake
+// and a genuinely slow network all presented identically, which is what made every
+// occurrence expensive to diagnose (#817).
+//
+// The markup and CSS live HERE rather than in the shell's index.html on purpose.
+// There are several shells — the framework's, the samples', and the one `rask new`
+// writes — and they have already drifted from one another; a user is free to write
+// their own. Owning the failure surface in the one file every one of them loads
+// means it cannot be missing from any of them, including shells that predate it.
+const BOOT_ERROR_CSS = `
+.rask-boot[data-rask-boot-error] { gap: 0.75rem; padding: 1.5rem; }
+.rask-boot[data-rask-boot-error] svg,
+.rask-boot[data-rask-boot-error] .rask-spin,
+.rask-boot[data-rask-boot-error] .rask-boot__progress { display: none; }
+.rask-boot__error {
+    max-width: 46rem;
+    text-align: left;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    color: #7f1d1d;
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    border-radius: 0.75rem;
+    padding: 1.25rem 1.5rem;
+}
+.rask-boot__error h1 { margin: 0 0 0.5rem; font-size: 1.0625rem; font-weight: 600; }
+.rask-boot__error p { margin: 0 0 0.75rem; font-size: 0.875rem; line-height: 1.5; color: #991b1b; }
+.rask-boot__error pre {
+    margin: 0;
+    padding: 0.75rem;
+    max-height: 16rem;
+    overflow: auto;
+    font-size: 0.75rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+    background: #fff;
+    border: 1px solid #fecaca;
+    border-radius: 0.5rem;
+    color: #450a0a;
+}
+.rask-boot__error-hint { margin: 0.75rem 0 0; font-size: 0.8125rem; opacity: 0.85; }
+`;
+
+let bootFailureReported = false;
+
+/**
+ * Render a boot failure where the visitor is already looking, and say what happened.
+ *
+ * Called from three places: this module's own catch, rask.wasm.js when the very first
+ * frame is unusable, and .NET via the `bootFailed` JSImport — the managed side knows
+ * far more about a managed exception than the JS side can infer from a rejection.
+ *
+ * @param {string} message  one line naming what failed
+ * @param {string} [detail] stack / exception text, shown verbatim
+ */
+function reportBootFailure(message, detail) {
+    // Always log, whatever else happens: the console line is what someone reading a CI
+    // artefact will find, and it is the only channel left if the DOM work below throws.
+    console.error(`[Rask] boot failed: ${message}`, detail ?? "");
+
+    // Once the app has painted, the boot screen is gone and the morph owns the document.
+    // A later failure belongs to the running app, not to boot — never paint over a live page.
+    if (!boot?.isConnected) return;
+    // First failure wins. A boot failure usually cascades (the throw, then the rejection that
+    // follows it, then the never-painted check below), and the first one is the cause.
+    if (bootFailureReported) return;
+    bootFailureReported = true;
+
+    try {
+        const style = document.createElement("style");
+        style.textContent = BOOT_ERROR_CSS;
+        document.head.appendChild(style);
+
+        const panel = document.createElement("div");
+        panel.className = "rask-boot__error";
+
+        const heading = document.createElement("h1");
+        heading.textContent = "This app failed to start.";
+        panel.appendChild(heading);
+
+        const summary = document.createElement("p");
+        summary.textContent = message;
+        panel.appendChild(summary);
+
+        if (detail) {
+            const pre = document.createElement("pre");
+            // textContent, not innerHTML: this string is an exception message, and it can carry
+            // anything the runtime put in it.
+            pre.textContent = detail;
+            panel.appendChild(pre);
         }
-    })
-    .create();
+
+        const hint = document.createElement("p");
+        hint.className = "rask-boot__error-hint";
+        hint.textContent = "The browser console has the full error.";
+        panel.appendChild(hint);
+
+        boot.replaceChildren(panel);
+        // The stable hook an E2E fixture waits on, so a broken boot fails a test in seconds with a
+        // reason attached instead of timing out on a selector that is never going to appear.
+        boot.setAttribute("data-rask-boot-error", "");
+    } catch (e) {
+        console.error("[Rask] boot failed, and rendering the failure also failed", e);
+    }
+}
+
+function describe(error) {
+    if (error instanceof Error) return error.stack || `${error.name}: ${error.message}`;
+    return String(error);
+}
+
+// Exposed before the first await, so a failure inside dotnet.create() can already reach it, and
+// so rask.wasm.js and the managed side share this one implementation rather than each growing
+// half of one.
+globalThis.__raskBootFailed = reportBootFailure;
+
+// A module's top-level await rejects into the unhandled-rejection channel, and the runtime starts
+// work of its own that can fail after create() has resolved. Both land here.
+globalThis.addEventListener("unhandledrejection", event => {
+    reportBootFailure("An unhandled error occurred while starting.", describe(event.reason));
+});
+globalThis.addEventListener("error", event => {
+    // Only script errors carry something worth showing. Resource load errors bubbling from
+    // elements have no message on them, and the runtime reports the ones that matter itself.
+    if (event.error) reportBootFailure("An unhandled error occurred while starting.", describe(event.error));
+});
+
+// Each step names itself, because which one failed is most of the diagnosis: the runtime not
+// downloading is a serving problem, a missing export is a build problem, and a throw out of
+// runMain is the app's own.
+async function step(what, run) {
+    try {
+        return await run();
+    } catch (error) {
+        reportBootFailure(what, describe(error));
+        throw error;
+    }
+}
+
+const {getAssemblyExports, runMain} = await step(
+    "The .NET runtime could not be loaded. Check that the _framework assets are being served, "
+    + "with the correct application/wasm content type.",
+    () => dotnet
+        .withApplicationArgumentsFromQuery()
+        .withModuleConfig({
+            onDownloadResourceProgress: (resourcesLoaded, totalResources) => {
+                // Best-effort UI; never let a progress hiccup break boot.
+                try {
+                    renderBootProgress(resourcesLoaded, totalResources);
+                } catch (e) {
+                }
+            }
+        })
+        .create());
 
 // JSExport Dispatch lives in Rask.Wasm.dll, not the main assembly.
-const raskWasmExports = await getAssemblyExports("Rask.Wasm");
+const raskWasmExports = await step(
+    "The Rask.Wasm assembly exports could not be read.",
+    () => getAssemblyExports("Rask.Wasm"));
 
-const rask = await import('./rask.wasm.js');
+const rask = await step(
+    "The Rask browser module (rask.wasm.js) could not be loaded.",
+    () => import('./rask.wasm.js'));
 rask.setExports(raskWasmExports);
 
-await runMain();
+await step("The app threw while starting.", () => runMain());
+
+// runMain resolves only once Program.cs's `await host.RunAsync<App>()` has returned, and the first
+// frame is pushed synchronously from inside it — so by now the morph has replaced the document and
+// this element is detached. Still attached means the app finished starting without ever painting,
+// which is otherwise indistinguishable from a hang.
+if (boot?.isConnected) {
+    reportBootFailure(
+        "The app finished starting but never rendered. Check that Program.cs awaits "
+        + "host.RunAsync<App>() and that the app has a route for this URL.");
+}

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -3491,6 +3491,10 @@ export function setExports(exports) {
     if (!ok) {
         console.error("[Rask] setExports: the .NET Dispatch export is unreachable — no event will "
             + "reach the app. Exports:", exports);
+        // And say so on the page. An app whose Dispatch is unreachable boots, paints, and then
+        // ignores every click, which reads as a UI bug rather than as the build problem it is.
+        bootFailed("The app's .NET event dispatcher is unreachable, so nothing on the page will "
+            + "respond. This usually means Rask.Wasm.dll was trimmed away or failed to load.");
     }
     // Initial sweep for Head-declared external assets emitted by the browser's
     // index.html (and any subsequent applyRender will re-sweep so morph-added
@@ -3534,9 +3538,27 @@ export function applyRender(payload) {
         reply = JSON.parse(_payloadDecoder.decode(payload.slice()));
     } catch (e) {
         console.error("[Rask] applyRender: malformed payload", e);
+        // Dropping a frame mid-session loses one update; dropping the FIRST one means the document
+        // is never morphed and the boot screen stays up for ever. bootFailed decides which of the
+        // two this is — it does nothing once the app has painted.
+        bootFailed("The first frame from the app could not be read.", String(e));
         return;
     }
     handle(reply);
+}
+
+/**
+ * Report a failure that leaves the app unusable, to whatever surface the shell's bootstrap
+ * installed. main.js owns the rendering (it is loaded by every shell, including ones written
+ * before this existed, and it is reachable even when this module is not); this is the seam the
+ * rest of the framework — and .NET, via the `bootFailed` JSImport — reaches it through.
+ *
+ * A no-op when the page has already painted, and when a shell has no bootstrap of ours at all.
+ */
+export function bootFailed(message, detail) {
+    const report = globalThis.__raskBootFailed;
+    if (typeof report === "function") report(message, detail);
+    else console.error(`[Rask] boot failed: ${message}`, detail ?? "");
 }
 
 // Dev-only. Called from .NET (WasmHotReloadBridge) once the hot-reload coordinator has finished

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -5157,6 +5157,12 @@ function applyFrameInvokes(reply, dispatchOne) {
 
 function handle(reply) {
     if (!reply || typeof reply !== "object") return;
+    // The app has painted. Set HERE, by the code that actually does it, because it is the only place
+    // that knows: the morph patches the existing document in place rather than replacing it, so the
+    // splash element main.js captured at import time is still connected afterwards and DOM state cannot
+    // be read as "did we render". Inferring it from that element instead is what made every WASM journey
+    // report a boot failure over an app that had rendered perfectly well.
+    globalThis.__raskPainted = true;
     // A development fault the app survived, riding the render payload (see the Server runtime for why
     // it is a field rather than a frame). Applied before either render path: the panel is a sibling of
     // the app, so it must not wait on the render queue.

--- a/src/Rask.Wasm/JSInterop.cs
+++ b/src/Rask.Wasm/JSInterop.cs
@@ -156,6 +156,18 @@ internal static partial class JSInterop
     [JSImport("hotReloadApplied", ModuleName)]
     public static partial void HotReloadApplied();
 
+    /// <summary>
+    ///     Shows a boot failure on the page. Called when startup throws before anything has rendered,
+    ///     where the root error boundary cannot help — it needs a mounted tree to render its fallback
+    ///     into, and there is none yet.
+    /// </summary>
+    /// <remarks>
+    ///     Reported from managed code rather than left to the JS side because only this side has the
+    ///     exception: to JS a startup failure is an opaque rejected promise out of <c>runMain</c>.
+    /// </remarks>
+    [JSImport("bootFailed", ModuleName)]
+    public static partial void BootFailed(string message, string? detail);
+
     [JSImport("getLocation", ModuleName)]
     public static partial string GetLocation();
 
@@ -246,6 +258,13 @@ internal static partial class JSInterop
     public static void HotReloadApplied() => HotReloadAppliedCount++;
 
     internal static void ResetHotReloadAppliedCount() => HotReloadAppliedCount = 0;
+
+    /// <summary>Records the last boot failure so the non-browser tests can assert what was reported.</summary>
+    public static (string Message, string? Detail)? LastBootFailure { get; private set; }
+
+    public static void BootFailed(string message, string? detail) => LastBootFailure = (message, detail);
+
+    internal static void ResetBootFailure() => LastBootFailure = null;
 
     public static Task<byte[]> ReadFileChunkAsync(string @ref, int offset, int length) =>
         Task.FromResult(Array.Empty<byte>());

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -531,6 +531,12 @@ function applyNavScroll(history) {
 
 function handle(reply) {
     if (!reply || typeof reply !== "object") return;
+    // The app has painted. Set HERE, by the code that actually does it, because it is the only place
+    // that knows: the morph patches the existing document in place rather than replacing it, so the
+    // splash element main.js captured at import time is still connected afterwards and DOM state cannot
+    // be read as "did we render". Inferring it from that element instead is what made every WASM journey
+    // report a boot failure over an app that had rendered perfectly well.
+    globalThis.__raskPainted = true;
     // A development fault the app survived, riding the render payload (see the Server runtime for why
     // it is a field rather than a frame). Applied before either render path: the panel is a sibling of
     // the app, so it must not wait on the render queue.

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -290,6 +290,10 @@ export function setExports(exports) {
     if (!ok) {
         console.error("[Rask] setExports: the .NET Dispatch export is unreachable — no event will "
             + "reach the app. Exports:", exports);
+        // And say so on the page. An app whose Dispatch is unreachable boots, paints, and then
+        // ignores every click, which reads as a UI bug rather than as the build problem it is.
+        bootFailed("The app's .NET event dispatcher is unreachable, so nothing on the page will "
+            + "respond. This usually means Rask.Wasm.dll was trimmed away or failed to load.");
     }
     // Initial sweep for Head-declared external assets emitted by the browser's
     // index.html (and any subsequent applyRender will re-sweep so morph-added
@@ -333,9 +337,27 @@ export function applyRender(payload) {
         reply = JSON.parse(_payloadDecoder.decode(payload.slice()));
     } catch (e) {
         console.error("[Rask] applyRender: malformed payload", e);
+        // Dropping a frame mid-session loses one update; dropping the FIRST one means the document
+        // is never morphed and the boot screen stays up for ever. bootFailed decides which of the
+        // two this is — it does nothing once the app has painted.
+        bootFailed("The first frame from the app could not be read.", String(e));
         return;
     }
     handle(reply);
+}
+
+/**
+ * Report a failure that leaves the app unusable, to whatever surface the shell's bootstrap
+ * installed. main.js owns the rendering (it is loaded by every shell, including ones written
+ * before this existed, and it is reachable even when this module is not); this is the seam the
+ * rest of the framework — and .NET, via the `bootFailed` JSImport — reaches it through.
+ *
+ * A no-op when the page has already painted, and when a shell has no bootstrap of ours at all.
+ */
+export function bootFailed(message, detail) {
+    const report = globalThis.__raskBootFailed;
+    if (typeof report === "function") report(message, detail);
+    else console.error(`[Rask] boot failed: ${message}`, detail ?? "");
 }
 
 // Dev-only. Called from .NET (WasmHotReloadBridge) once the hot-reload coordinator has finished

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -190,6 +190,29 @@ public sealed class WasmHostBuilder
     public async Task RunAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>()
         where TApp : Component
     {
+        try
+        {
+            await BootAsync<TApp>().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Everything below runs before there is a mounted tree, so RootErrorBoundary — which needs
+            // one to render its fallback into — cannot cover any of it. Without this, a throw here
+            // escapes through runMain() as an opaque rejected promise and the visitor is left on the
+            // splash spinner for ever, which is indistinguishable from a slow network (#817).
+            //
+            // Reported from here rather than from JS because only this side has the exception; to JS
+            // it is a rejection with nothing useful attached.
+            ReportBootFailure(ex);
+            throw;
+        }
+    }
+
+    /// <summary>The boot sequence proper. See <see cref="RunAsync{TApp}" />, which reports its failures.</summary>
+    private async Task
+        BootAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>()
+        where TApp : Component
+    {
         Console.WriteLine($"[Rask.Wasm] Rask {RaskVersion.Current} (WASM) starting");
         Console.WriteLine("[Rask.Wasm] importing rask.wasm.js …");
         await JSInterop.ImportJsModuleAsync().ConfigureAwait(false);
@@ -292,5 +315,35 @@ public sealed class WasmHostBuilder
         var hostedServices = new WasmHostedServices(provider);
         JSInterop.Init(hostedServices);
         await hostedServices.StartAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Puts a boot failure on the page and into the app's own logging, best-effort on both counts.
+    /// </summary>
+    /// <remarks>
+    ///     Never throws. It runs from a catch block on the way to rethrowing the original exception, and
+    ///     losing that one to a secondary failure in the reporter would be strictly worse than reporting
+    ///     nothing: the console still has the rethrow. The JS call in particular is expected to fail when
+    ///     the boot got no further than importing the module.
+    /// </remarks>
+    internal static void ReportBootFailure(Exception ex)
+    {
+        try
+        {
+            RaskDiagnostics.Report(RaskLogLevel.Error, "Rask.Wasm", "[Rask.Wasm] the app failed to start", ex);
+        }
+        catch
+        {
+            // Diagnostics are installed partway through boot; before that there is nothing to report to.
+        }
+
+        try
+        {
+            JSInterop.BootFailed("The app failed to start.", ex.ToString());
+        }
+        catch
+        {
+            // No JS module yet (the import is the first thing boot does, and it can be what failed).
+        }
     }
 }

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmWatchAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmWatchAppFixture.cs
@@ -171,10 +171,10 @@ public sealed class WasmWatchAppFixture : IAsyncLifetime
               // Not part of the sample — do not commit.
               [Route("{{ProbeRoute}}")]
               [ParentRoute(typeof(ShowcaseLayout))]
-              public sealed class HotReloadProbePage : Component
+              public sealed partial class HotReloadProbePage : Component
               {
                   protected override Component? Render() =>
-                      H1(Id: "probe")["{{marker}}"];
+                      H1.Id("probe")["{{marker}}"];
               }
 
               """);

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.cs
@@ -135,7 +135,7 @@ public abstract partial class SharedSmokeTests : IAsyncLifetime
         var traced = false;
         try
         {
-            await body();
+            await RaceAgainstBootFailureAsync(body);
         }
         catch
         {
@@ -163,6 +163,69 @@ public abstract partial class SharedSmokeTests : IAsyncLifetime
             }
 
             await TestArtifacts.DumpAsync(Page, FixtureName, testName, ServerLog, console);
+        }
+    }
+
+    /// <summary>
+    ///     Runs the journey, but gives up the moment the app says it failed to boot.
+    /// </summary>
+    /// <remarks>
+    ///     Every WASM journey opens with a 60-120 second wait on a selector that only exists once the app
+    ///     has mounted, so a boot failure used to cost the full timeout and then report the missing
+    ///     selector — which names nothing about the cause and reads as a hang. That is most of why #817
+    ///     was expensive: the test could not tell "the app is broken" from "the network is slow".
+    ///     <para>
+    ///         main.js now marks a dead boot with <c>[data-rask-boot-error]</c> and puts the reason on the
+    ///         page. Racing the journey against that element turns the same failure into a few seconds and
+    ///         an exception that quotes what went wrong. A hook nothing waits on would only have moved the
+    ///         evidence somewhere nobody looks.
+    ///     </para>
+    ///     <para>
+    ///         Harmless on the Server hosts: they have no boot screen, so the watcher simply never
+    ///         resolves and the journey is awaited exactly as before.
+    ///     </para>
+    /// </remarks>
+    private async Task RaceAgainstBootFailureAsync(Func<Task> body)
+    {
+        var journey = body();
+
+        // Timeout 0 = wait indefinitely: this resolves only if the app actually reports a dead boot, so
+        // it can never be the thing that fails a healthy run.
+        var bootFailed = Page.WaitForSelectorAsync(
+            "[data-rask-boot-error]", new PageWaitForSelectorOptions { Timeout = 0 });
+
+        var finished = await Task.WhenAny(journey, bootFailed);
+        if (finished != bootFailed)
+        {
+            // The journey settled first, which is every healthy run. The watcher is abandoned here and
+            // faults when the context closes; observe it so it cannot surface as an unhandled exception
+            // in an unrelated test.
+            _ = bootFailed.ContinueWith(static t => _ = t.Exception, TaskScheduler.Default);
+            await journey;
+            return;
+        }
+
+        var reason = await ReadBootFailureAsync();
+        // Observe the journey's own failure too — it is about to be abandoned mid-flight, and an
+        // unobserved timeout from it would otherwise land on a later test.
+        _ = journey.ContinueWith(static t => _ = t.Exception, TaskScheduler.Default);
+        throw new InvalidOperationException(
+            $"The app reported that it failed to boot, so the journey was abandoned rather than waiting "
+            + $"for elements that will never appear.\n{reason}");
+    }
+
+    private async Task<string> ReadBootFailureAsync()
+    {
+        try
+        {
+            var text = await Page.Locator(".rask-boot__error").InnerTextAsync(
+                new LocatorInnerTextOptions { Timeout = 5_000 });
+            return text.Trim();
+        }
+        catch (Exception ex)
+        {
+            return $"(the boot-failure panel could not be read: {ex.GetType().Name}) — "
+                + "the browser console dump below has the error.";
         }
     }
 

--- a/tests/Rask.Wasm.Tests/Hosting/BootFailureReportTests.cs
+++ b/tests/Rask.Wasm.Tests/Hosting/BootFailureReportTests.cs
@@ -1,0 +1,56 @@
+namespace Rask.Wasm.Tests.Hosting;
+
+/// <summary>
+///     The managed half of the boot-failure report (#817): what <see cref="WasmHostBuilder" /> does when
+///     startup throws before there is a mounted tree for the root error boundary to render into.
+/// </summary>
+/// <remarks>
+///     <para>
+///         This exercises <c>ReportBootFailure</c> directly rather than driving a whole
+///         <c>RunAsync&lt;TApp&gt;</c> with a throwing app. Booting for real installs a process-wide
+///         diagnostics sink and rebinds the static JS interop bridge, and this assembly runs its classes in
+///         parallel — the same shape as the two flakes already on record here, where a test's global sink
+///         unhooked a live one in another class. The catch block itself is a <c>throw;</c> after this call,
+///         so what is worth guarding is what this method does, and it can be reached with no global state
+///         touched at all.
+///     </para>
+///     <para>
+///         Reporting is best-effort by design and must never throw: it runs on the way to rethrowing the
+///         original exception, and losing that one to a secondary failure inside the reporter would be
+///         strictly worse than reporting nothing.
+///     </para>
+/// </remarks>
+public sealed class BootFailureReportTests
+{
+    [Fact]
+    public void A_boot_failure_is_reported_with_the_exception_attached()
+    {
+        JSInterop.ResetBootFailure();
+
+        WasmHostBuilder.ReportBootFailure(new InvalidOperationException("no service for IThing"));
+
+        var reported = JSInterop.LastBootFailure;
+        Assert.NotNull(reported);
+        Assert.Equal("The app failed to start.", reported!.Value.Message);
+        // ToString(), not Message: the type and the stack are what turn "it failed" into something
+        // actionable, and this is the only place they can still be recovered — by the time this reaches
+        // JS through runMain it is an opaque rejected promise.
+        Assert.Contains("InvalidOperationException", reported.Value.Detail, StringComparison.Ordinal);
+        Assert.Contains("no service for IThing", reported.Value.Detail, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     The JS module import is the first thing boot does, so it is one of the things that can fail —
+    ///     and then the <c>bootFailed</c> JSImport has no module to call into. That must degrade to
+    ///     reporting nothing, not to replacing the real exception with a marshalling one.
+    /// </summary>
+    [Fact]
+    public void Reporting_never_throws_even_when_there_is_no_JS_module_to_report_to()
+    {
+        JSInterop.ResetBootFailure();
+
+        var ex = Record.Exception(() => WasmHostBuilder.ReportBootFailure(new TypeLoadException("boom")));
+
+        Assert.Null(ex);
+    }
+}

--- a/tests/Rask.Wasm.Tests/JSInterop/BootFailureFixture.mjs
+++ b/tests/Rask.Wasm.Tests/JSInterop/BootFailureFixture.mjs
@@ -70,11 +70,16 @@ console.error = (...args) => {
     consoleErrors.push(args.map(String).join(" "));
 };
 
-// What "the app mounted" means to main.js: the morph replaced the document, so the boot element it
-// captured at import time is no longer connected. The runMain stub below does exactly that and
-// nothing else, so the negative control exercises the real check rather than a proxy for it.
+// What "the app mounted" means: rask.wasm.js applied a frame and set __raskPainted. It does NOT mean the
+// splash element went away — the morph patches the existing document in place, so the element main.js
+// captured at import time is still connected afterwards.
+//
+// This fixture originally modelled mounting as `boot.isConnected = false`, which was an assumption about
+// the morph that nothing had checked. main.js was written against that assumption and reported a boot
+// failure for every successful boot; the browser gate caught it, the fixture did not, because the
+// fixture encoded the same belief as the code. So the element deliberately stays connected here.
 globalThis.__raskFixtureMounted = () => {
-    boot.isConnected = false;
+    globalThis.__raskPainted = true;
 };
 
 // --- stub ./_framework/dotnet.js -----------------------------------------------------------

--- a/tests/Rask.Wasm.Tests/JSInterop/BootFailureFixture.mjs
+++ b/tests/Rask.Wasm.Tests/JSInterop/BootFailureFixture.mjs
@@ -1,0 +1,135 @@
+// Drives the REAL src/Rask.Wasm/Browser/main.js under Node with a stub DOM, and reports what the
+// boot screen ended up showing. Companion to BootFailureReportingTests.cs; see that file for why
+// this is worth a Node subprocess rather than a C# assertion over the file's text.
+//
+// Usage:  node BootFailureFixture.mjs <path-to-main.js> <scenario>
+//
+// Scenarios — the three outcomes that have to be told apart:
+//   runtime-fails    dotnet.create() rejects. The commonest real failure (a 404 on _framework, a
+//                    wrong content type, an import-map/SRI drift) and the one #817 was opened for.
+//   never-painted    every step resolves, but nothing ever morphed the document away.
+//   already-painted  every step resolves and the app mounted. NEGATIVE CONTROL: the boot surface
+//                    must stay silent, because painting an error over a live page would turn a
+//                    working app into a broken-looking one.
+import {mkdtempSync, mkdirSync, copyFileSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {pathToFileURL} from "node:url";
+
+const [mainJsPath, scenario] = process.argv.slice(2);
+
+// --- stub DOM -------------------------------------------------------------------------------
+function makeStubElement(tag) {
+    const attrs = new Map();
+    const el = {
+        tagName: String(tag).toUpperCase(),
+        _children: [],
+        textContent: "",
+        className: "",
+        style: {},
+        hidden: false,
+        isConnected: true,
+        hasAttribute: name => attrs.has(name),
+        getAttribute: name => (attrs.has(name) ? attrs.get(name) : null),
+        setAttribute: (name, value) => attrs.set(name, String(value)),
+        appendChild: child => {
+            el._children.push(child);
+            return child;
+        },
+        replaceChildren: (...children) => {
+            el._children = children;
+        },
+        querySelector: sel => el._children.find(c => `.${c.className}` === sel) ?? null
+    };
+    return el;
+}
+
+const boot = makeStubElement("div");
+boot.className = "rask-boot";
+
+const head = makeStubElement("head");
+globalThis.document = {
+    head,
+    body: makeStubElement("body"),
+    createElement: tag => makeStubElement(tag),
+    querySelector: sel => (sel === ".rask-boot" ? boot : null),
+    addEventListener: () => {
+    }
+};
+globalThis.window = globalThis;
+
+const listeners = new Map();
+globalThis.addEventListener = (type, fn) => {
+    if (!listeners.has(type)) listeners.set(type, []);
+    listeners.get(type).push(fn);
+};
+
+const consoleErrors = [];
+const realError = console.error;
+console.error = (...args) => {
+    consoleErrors.push(args.map(String).join(" "));
+};
+
+// What "the app mounted" means to main.js: the morph replaced the document, so the boot element it
+// captured at import time is no longer connected. The runMain stub below does exactly that and
+// nothing else, so the negative control exercises the real check rather than a proxy for it.
+globalThis.__raskFixtureMounted = () => {
+    boot.isConnected = false;
+};
+
+// --- stub ./_framework/dotnet.js -----------------------------------------------------------
+// main.js imports it by relative path, so it has to exist next to a copy of main.js.
+const dir = mkdtempSync(join(tmpdir(), "rask-boot-"));
+const mainCopy = join(dir, "main.js");
+copyFileSync(mainJsPath, mainCopy);
+mkdirSync(join(dir, "_framework"));
+
+const createBody = scenario === "runtime-fails"
+    ? `const e = new Error("Failed to fetch dotnet.native.wasm");
+       e.stack = "Error: Failed to fetch dotnet.native.wasm\\n    at boot (_framework/dotnet.js:1:1)";
+       return Promise.reject(e);`
+    : `return Promise.resolve({
+           getAssemblyExports: async () => ({}),
+           runMain: async () => { ${scenario === "already-painted" ? "globalThis.__raskFixtureMounted();" : ""} return 0; }
+       });`;
+
+writeFileSync(join(dir, "_framework", "dotnet.js"), `
+const chain = {
+    withApplicationArgumentsFromQuery() { return chain; },
+    withModuleConfig() { return chain; },
+    create() { ${createBody} }
+};
+export const dotnet = chain;
+`);
+
+// main.js also imports ./rask.wasm.js once the runtime is up. The real one is a 4000-line bundle
+// that wants a full DOM; only setExports is reached here, so stub that much.
+writeFileSync(join(dir, "rask.wasm.js"), "export function setExports() {}\n");
+
+let threw = false;
+try {
+    await import(pathToFileURL(mainCopy).href);
+} catch (e) {
+    // A failing boot reports and then RETHROWS — keeping the failure visible to the runtime's own
+    // channels — so an exception here is part of the contract, not a fixture problem.
+    threw = true;
+}
+
+const panel = boot._children[0];
+const children = panel?._children ?? [];
+const paragraphs = children.filter(c => c.tagName === "P");
+
+process.stdout.write(JSON.stringify({
+    scenario,
+    threw,
+    bootErrorAttributeSet: boot.hasAttribute("data-rask-boot-error"),
+    heading: children.find(c => c.tagName === "H1")?.textContent ?? "",
+    summary: paragraphs[0]?.textContent ?? "",
+    detail: children.find(c => c.tagName === "PRE")?.textContent ?? "",
+    styleInjected: head._children.some(c => c.tagName === "STYLE"),
+    consoleErrors,
+    unhandledRejectionHandlerRegistered: (listeners.get("unhandledrejection") ?? []).length > 0,
+    errorHandlerRegistered: (listeners.get("error") ?? []).length > 0,
+    bootFailedHookExposed: typeof globalThis.__raskBootFailed === "function"
+}) + "\n");
+console.error = realError;

--- a/tests/Rask.Wasm.Tests/JSInterop/BootFailureReportingTests.cs
+++ b/tests/Rask.Wasm.Tests/JSInterop/BootFailureReportingTests.cs
@@ -1,0 +1,184 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Rask.Wasm.Tests.JsInteropRuntime;
+
+/// <summary>
+///     What a browser-WASM app does when it fails to start (#817).
+/// </summary>
+/// <remarks>
+///     <para>
+///         Before this, <c>main.js</c> was four bare top-level <c>await</c>s with no <c>try</c> anywhere and
+///         no global rejection handler. Every way of failing to mount — a 404 on <c>_framework</c>, a wrong
+///         content type, an import-map/SRI drift, an empty scoped-asset bake — produced the same thing: the
+///         splash spinner, turning, for ever. No console error, no page error. The first symptom was a
+///         Playwright locator timing out after 90-120 seconds against a boot screen, which names nothing and
+///         reads as a hang, and that is why every occurrence cost hours.
+///     </para>
+///     <para>
+///         Driven through a Node subprocess against the shipped <c>Browser/main.js</c> rather than asserted
+///         over the file's text, because the thing worth guarding is behaviour under a real rejection —
+///         which step reports, that it reports once, and above all that it stays silent once the app has
+///         painted. A text assertion would pass on code that never runs.
+///     </para>
+/// </remarks>
+public sealed class BootFailureReportingTests
+{
+    /// <summary>The commonest real failure, and the one the issue was opened for.</summary>
+    [SkippableFact]
+    public void A_runtime_that_will_not_load_says_so_on_the_page_instead_of_spinning()
+    {
+        var result = RunFixture("runtime-fails");
+
+        Assert.True(result.GetProperty("bootErrorAttributeSet").GetBoolean(),
+            "A failed boot left no [data-rask-boot-error] on the page. That attribute is what lets an E2E "
+            + "fixture fail in seconds with a reason instead of timing out on a selector that will never "
+            + "appear, and what tells a visitor the app is broken rather than slow.");
+
+        // Which step failed is most of the diagnosis, so the summary has to name it — "something went
+        // wrong" would leave the reader exactly where the blank spinner did.
+        Assert.Contains("runtime could not be loaded", result.GetProperty("summary").GetString(),
+            StringComparison.Ordinal);
+        Assert.Contains("_framework", result.GetProperty("summary").GetString(), StringComparison.Ordinal);
+
+        // The stack, verbatim. It is the difference between "boot failed" and a fixable report.
+        Assert.Contains("Failed to fetch dotnet.native.wasm", result.GetProperty("detail").GetString(),
+            StringComparison.Ordinal);
+
+        // Reported once. A boot failure cascades — the throw, then the rejection the rethrow produces,
+        // then the never-painted check — and three stacked panels would bury the cause under its echoes.
+        Assert.Single(result.GetProperty("consoleErrors").EnumerateArray());
+
+        // Rethrown after reporting: swallowing it would hide the failure from the runtime's own channels
+        // and from anything else watching, which trades one silent failure for another.
+        Assert.True(result.GetProperty("threw").GetBoolean(),
+            "main.js reported the failure but did not rethrow it.");
+    }
+
+    /// <summary>
+    ///     The silent shape: nothing throws, and nothing ever renders. Deterministic rather than a timeout —
+    ///     <c>runMain</c> resolves only after <c>await host.RunAsync&lt;App&gt;()</c> returns, and the first
+    ///     frame is pushed from inside it, so a boot screen still on the page at that point is a fact, not a
+    ///     guess about how slow the network is.
+    /// </summary>
+    [SkippableFact]
+    public void An_app_that_starts_but_never_renders_is_reported_rather_than_left_spinning()
+    {
+        var result = RunFixture("never-painted");
+
+        Assert.True(result.GetProperty("bootErrorAttributeSet").GetBoolean(),
+            "The app finished starting without ever painting and the page still showed the splash screen.");
+        Assert.Contains("never rendered", result.GetProperty("summary").GetString(), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     The negative control, and the one that matters most: once the app has painted, the boot surface
+    ///     must never speak again. A late error belongs to the running app — <c>RootErrorBoundary</c> owns
+    ///     that — and painting a full-screen failure panel over a working page would turn a recoverable
+    ///     error into a dead app.
+    /// </summary>
+    [SkippableFact]
+    public void Once_the_app_has_painted_the_boot_surface_stays_silent()
+    {
+        var result = RunFixture("already-painted");
+
+        Assert.False(result.GetProperty("bootErrorAttributeSet").GetBoolean(),
+            "The boot surface painted an error over an app that had already mounted.");
+        Assert.Empty(result.GetProperty("consoleErrors").EnumerateArray());
+        Assert.False(result.GetProperty("styleInjected").GetBoolean(),
+            "The boot-error stylesheet was injected into a page that booted fine.");
+    }
+
+    /// <summary>
+    ///     The handlers have to be installed before the first <c>await</c>, or a failure inside
+    ///     <c>dotnet.create()</c> — the step most likely to fail — would escape the very net meant to catch
+    ///     it. Asserted on the success path so it cannot be satisfied by the failure path alone.
+    /// </summary>
+    [SkippableFact]
+    public void The_global_failure_handlers_are_installed_before_the_first_await()
+    {
+        var result = RunFixture("already-painted");
+
+        Assert.True(result.GetProperty("unhandledRejectionHandlerRegistered").GetBoolean());
+        Assert.True(result.GetProperty("errorHandlerRegistered").GetBoolean());
+        // rask.wasm.js's bootFailed export and .NET's bootFailed JSImport both route here, so that one
+        // implementation renders every boot failure rather than each growing half of one.
+        Assert.True(result.GetProperty("bootFailedHookExposed").GetBoolean(),
+            "__raskBootFailed is not exposed, so rask.wasm.js and the managed side have nothing to report "
+            + "to and their failures go back to being console-only.");
+    }
+
+    private static JsonElement RunFixture(string scenario)
+    {
+        var node = ResolveNode();
+        Skip.If(node is null, "node is not on PATH, so the JS-driven boot fixture cannot run.");
+
+        var repoRoot = LocateRepoRoot();
+        var fixtureScript = Path.Combine(
+            repoRoot, "tests", "Rask.Wasm.Tests", "JSInterop", "BootFailureFixture.mjs");
+        var mainJs = Path.Combine(repoRoot, "src", "Rask.Wasm", "Browser", "main.js");
+        Assert.True(File.Exists(fixtureScript), $"Fixture script missing: {fixtureScript}");
+        Assert.True(File.Exists(mainJs), $"Boot script missing: {mainJs}");
+
+        var psi = new ProcessStartInfo(node!, $"\"{fixtureScript}\" \"{mainJs}\" {scenario}")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var proc = Process.Start(psi)!;
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        proc.WaitForExit(30_000);
+
+        Assert.True(proc.ExitCode == 0,
+            $"Fixture exited with code {proc.ExitCode}. stderr:\n{stderr}\nstdout:\n{stdout}");
+
+        var jsonLine = stdout
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .LastOrDefault(s => s.StartsWith('{') && s.EndsWith('}'));
+        Assert.False(jsonLine is null,
+            $"Fixture didn't emit a JSON line. stdout:\n{stdout}\nstderr:\n{stderr}");
+
+        return JsonDocument.Parse(jsonLine!).RootElement.Clone();
+    }
+
+    private static string? ResolveNode()
+    {
+        var path = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+        var exeNames = OperatingSystem.IsWindows() ? new[] { "node.exe", "node.cmd" } : new[] { "node" };
+        foreach (var dir in path.Split(separator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var name in exeNames)
+            {
+                var candidate = Path.Combine(dir, name);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate Rask.slnx walking up from {AppContext.BaseDirectory}");
+    }
+}

--- a/tests/Rask.Wasm.Tests/JSInterop/BootFailureReportingTests.cs
+++ b/tests/Rask.Wasm.Tests/JSInterop/BootFailureReportingTests.cs
@@ -77,6 +77,14 @@ public sealed class BootFailureReportingTests
     ///     that — and painting a full-screen failure panel over a working page would turn a recoverable
     ///     error into a dead app.
     /// </summary>
+    /// <remarks>
+    ///     "Painted" is a flag <c>rask.wasm.js</c> sets when it applies a frame, and the fixture models it
+    ///     that way — with the splash element still connected, which is what the real morph leaves behind.
+    ///     The first version of this asked the DOM instead ("is the splash element gone?"), and the fixture
+    ///     agreed with it, because both encoded the same unchecked assumption about the morph. Every WASM
+    ///     journey then failed against an app whose own console said <c>first render applied</c>. The
+    ///     browser gate caught it; this test could not, because it was asking the same wrong question.
+    /// </remarks>
     [SkippableFact]
     public void Once_the_app_has_painted_the_boot_surface_stays_silent()
     {

--- a/tests/Rask.Wasm.Tests/Rask.Wasm.Tests.csproj
+++ b/tests/Rask.Wasm.Tests/Rask.Wasm.Tests.csproj
@@ -31,6 +31,12 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="xunit"/>
+    <!--
+      So a test that cannot run reports SKIPPED rather than passing. BootFailureReportingTests needs
+      node on PATH; without this it would have to return early and report green, which is the exact
+      shape of "gate that silently didn't run" the tests in this project exist to prevent.
+    -->
+    <PackageReference Include="Xunit.SkippableFact"/>
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
A browser-WASM app that fails to start used to leave the splash spinner turning for ever — no console error, no page error. A 404 on `_framework`, a wrong content type, an import-map/SRI drift, an empty scoped-asset bake and a genuinely slow connection were **one symptom**. The first sign was a Playwright locator timing out after 90–120 seconds against a boot screen, which names nothing and reads as a hang.

`main.js` was four bare top-level `await`s with no `try` anywhere and no global rejection handler, and nothing removed the splash screen explicitly — it disappeared as a side effect of the first successful morph.

## What it does now

The splash screen is replaced by **which step failed and the exception, verbatim**, with the same text in the console:

> **This app failed to start.**
> The .NET runtime could not be loaded. Check that the `_framework` assets are being served, with the correct `application/wasm` content type.

Three callers share one surface: `main.js`'s own per-step catch, `rask.wasm.js` (an unreadable first frame, and an unreachable `Dispatch` export — an app that boots and then ignores every click), and .NET through a new `bootFailed` JSImport, because only the managed side still has the exception; to JS a startup failure is an opaque rejected promise out of `runMain`. `WasmHostBuilder.RunAsync` reports and then **rethrows**.

**It never paints over a working page.** Once the app has painted, the boot surface goes silent for good and the root error boundary owns errors.

The markup and CSS live in `main.js` rather than in the page shell deliberately: there are several shells — the framework's, the samples', the one `rask new` writes — they have already drifted, and a user may write their own. Owning it in the one file all of them load means no shell can be missing it.

The failure state carries `[data-rask-boot-error]`, and **the browser harness races every journey against it**, so a dead boot fails in seconds quoting the page's own reason instead of burning a 120-second wait. A hook nothing waits on would only have moved the evidence somewhere nobody looks.

## The bug the gate caught, which my own tests could not

The first version decided "has the app rendered?" by checking whether the splash element was still connected. That is wrong: the morph patches the document **in place**, so the element is still connected after a perfectly good render. Every WASM journey then failed against an app whose own console said `first render applied` — 11 failures, all in ~5 seconds, the fast-fail firing correctly on a signal that was itself wrong.

`rask.wasm.js` now sets `__raskPainted` when it applies a frame, and `main.js` reads that. The signal comes from the code that does the painting, because DOM state cannot answer the question at all.

Worth stating: **the Node fixture encoded the same unverified assumption as the code it tested.** Six green unit tests and a deliberate negative control, all agreeing with each other and all wrong. Only the browser gate, running the real morph, disagreed. Both users of the old test moved — including the guard that stops a late failure painting over a live page, which was the more serious of the two.

## Also in here

Two gate defects found on the way, both the same shape — a green that means nothing:

- **`scripts/run-wasm-watch-e2e.sh` was invoked by nothing.** Its tests live in the browser E2E project, so that gate's namespace-wide filter *selected* them — and they reported SKIPPED, because they are opt-in on `RASK_WASM_WATCH_E2E=1` and only the orphaned script sets it. Every push passed a gate that had never run. `pre-push` now runs both halves.

  **Running it for the first time immediately found a break**, unrelated to this branch. `WasmWatchAppFixture` writes a temporary probe page at test time, and its template still used the factory API #792 deleted — `H1(Id: "probe")[…]` on a non-`partial` class, which has not compiled since. Same shape as #795, where a template the build gate never compiled was broken by that same change and found by reading rather than by failing. Chain-built now; the gate passes 1/1.
- **`run-e2e-local.sh` contradicted itself about #650**: one comment said the empty bake was unfixable by cleaning and still open, another twenty lines down said `-nodeReuse:false` is the fix, with a mechanism and a measurement. Verified against `BakeScopedAssetsTask` (it errors on zero files now) and removed the stale half.

And two gate improvements:

- **The browser gate refuses to start alongside another one.** Two suites contend for resources, and it surfaces as a plausible red minutes later with nothing pointing back at it. That cost an unexplained five-minute timeout today between two worktrees that were *actively coordinating* and still both believed the machine was idle, while a third and then a fourth suite ran unseen. Predicate in `scripts/lib/e2e-concurrency.sh` with a 21-row table test — it was wrong three times before landing, in three different directions, which is the argument for it being a named function rather than a `case` inline.
- **`RASK_E2E_FILTER`** narrows a run to one journey while iterating, and says loudly that it was filtered.

## Verification

- `scripts/run-unit-local.sh`: format clean, build `-warnaserror` clean, all tests pass.
- Browser journeys: **61/61**, 0 skipped — the run that also answers this issue's open question (see below).
- CLI build gate: **30/30**, 0 skipped.

**The new WASM watch gate is NOT verified by the push itself, and I would rather say so than let it read as green.** It did not execute during the push, because a push from a worktree runs the **main checkout's** `.githooks/` — `core.hooksPath` is relative and resolves against the common dir's working tree, so the hook that ran was main's, whose `watch_paths` has no `src/Rask.Wasm` entries. Filed as #845.

So I verified it two other ways: dry-ran this branch's hook with the gate runner stubbed (it selects all four gates), and ran `scripts/run-wasm-watch-e2e.sh` directly — **1/1 passing**, after fixing the probe-page break above.

That mattered. This PR makes that gate mandatory for anything touching `src/Rask.Wasm`, and it was red. Merging on the strength of the green push would have handed everyone a blocked push they did not cause. (My first manual run was also wrong — it executed from a different worktree, because the script does `cd "$(git rev-parse --show-toplevel)"`, and reported a failure that was purely the invocation. The paths in its log are what gave it away.)

## Answering the issue's actual question

#817 asks whether the WASM sample E2E journeys pass on `main`. Its own follow-up comment had already retracted the original reproduction as unsound (a throwaway Python server that stalled part-way through the runtime). **They pass: 61/61**, including all five journeys the issue listed.

Closes #817
