### PR TITLE
test(cli): guard that every --template key produces its own project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,19 @@ them until tagged releases begin.
   iterating on a single failing journey cost the whole suite — including two emscripten relinks — every
   attempt. A filtered run says loudly that it was filtered, in both its header and its final line: a
   narrowed green is not the gate.
+- **A guard that every `--template` key produces its own project.** `rask new --template native` used to
+  scaffold a *server* app: the catalog still advertised the key after the native host was deleted, and
+  `NewCommand`'s switch had no arm for it, so it fell through to the default. The parser accepted the
+  value, the CLI announced "Creating Rask native mobile app…", and wrote something else. Nothing threw.
+
+  The existing tests assert that `native` specifically is gone, which is keyed on a string and would not
+  catch the same fall-through under a new key. What actually characterises the bug is a template
+  producing output **identical to another template's**, so that is what is asserted now — pairwise, over
+  every accepted key, driven through the real `NewCommand`. It needs to know nothing about what any
+  template should contain: a key with no arm lands on the default and is caught by construction.
+
+  Proven by failing it. Adding a `mobile` key with no arm turns it red with *"--template mobile produces
+  exactly the same project as --template server"*.
 
 - **A localization guide, a live demo, and a browser journey step.** `docs/localization.md` covers the
   whole feature end to end — how a visitor's language is chosen, why URLs stay culture-neutral, typed

--- a/tests/Rask.Cli.Tests/TemplateParityTests.cs
+++ b/tests/Rask.Cli.Tests/TemplateParityTests.cs
@@ -1,0 +1,124 @@
+using System.Security.Cryptography;
+using System.Text;
+using Rask.Cli.Commands;
+using Rask.Cli.Templates;
+
+namespace Rask.Cli.Tests;
+
+/// <summary>
+///     Every <c>--template</c> key the parser accepts produces its own project, and no two produce the
+///     same one.
+/// </summary>
+/// <remarks>
+///     <para>
+///         This is the guard #830 asked for, and it is aimed at the *mechanism* of that bug rather than
+///         its name. <c>TemplateCatalog</c> advertised a <c>native</c> template after the native host was
+///         deleted; <c>NewCommand</c>'s switch had no <c>native</c> arm, so it fell through to
+///         <c>_ =&gt; GenerateServer(...)</c>. The parser accepted the value, the CLI announced
+///         "Creating Rask native mobile app…", and wrote a server-rendered app. Nothing threw, so nothing
+///         caught it.
+///     </para>
+///     <para>
+///         The existing tests assert that <c>native</c> specifically is gone. That is worth having, but it
+///         is keyed on a string: the same fall-through can recur under any new key. What actually
+///         characterises the bug is that a template produced output *identical to another template's* —
+///         so that is what this asserts, and it needs to know nothing about what each template should
+///         contain. A key with no generator arm lands on the default and is caught by construction.
+///     </para>
+///     <para>
+///         Both halves matter. "Every key produces something" catches a key wired to nothing; "no two keys
+///         produce the same thing" catches a key wired to the wrong thing, which is the shape that shipped.
+///     </para>
+///     <para>
+///         Proven by failing it, not just by passing: adding a <c>mobile</c> entry to the catalog with no
+///         arm in the switch — the exact shape of #830 — turns this red with
+///         <c>--template mobile produces exactly the same project as --template server</c>. A guard for a
+///         bug that no longer exists is worth only what it does when the bug comes back.
+///     </para>
+/// </remarks>
+public sealed class TemplateParityTests
+{
+    private const string WorkingDirectory = "/proj";
+
+    public static TheoryData<string> AcceptedTemplateKeys()
+    {
+        var data = new TheoryData<string>();
+        foreach (var key in TemplateCatalog.Keys)
+        {
+            data.Add(key);
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(AcceptedTemplateKeys))]
+    public async Task Every_accepted_template_key_scaffolds_something(string key)
+    {
+        var (console, fingerprint) = await ScaffoldAsync(key);
+
+        Assert.True(
+            fingerprint.Length > 0,
+            $"--template {key} is accepted by the parser but produced no files and ran no scaffolder. "
+            + $"stderr: {console}");
+    }
+
+    [Fact]
+    public async Task No_two_template_keys_produce_the_same_project()
+    {
+        var byFingerprint = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var key in TemplateCatalog.Keys)
+        {
+            var (_, fingerprint) = await ScaffoldAsync(key);
+            var hash = Hash(fingerprint);
+
+            Assert.False(
+                byFingerprint.TryGetValue(hash, out var twin),
+                $"--template {key} produces exactly the same project as --template {twin}. That is what a "
+                + "key with no arm in NewCommand's generator switch looks like: the parser accepts it, the "
+                + "CLI reports creating it, and the default arm writes something else. It is how "
+                + "'--template native' shipped as a server app (#830).");
+
+            byFingerprint[hash] = key;
+        }
+
+        Assert.Equal(TemplateCatalog.Keys.Count, byFingerprint.Count);
+    }
+
+    /// <summary>
+    ///     Drives the real <see cref="Commands.NewCommand"/>, so the generator switch under test is the one
+    ///     that ships. Returns the console's error text and a stable description of everything the run
+    ///     produced — the files it wrote, and the external scaffolders it invoked.
+    /// </summary>
+    /// <remarks>
+    ///     The invocations are part of the fingerprint because a front-end template's identity partly lives
+    ///     there: `create-vite --template react` versus `--template preact` is the difference between two
+    ///     of these templates, and the files either writes can be identical.
+    /// </remarks>
+    private static async Task<(string Console, string Fingerprint)> ScaffoldAsync(string key)
+    {
+        var console = new StringConsole();
+        var fs = new FakeFileSystem();
+        var runner = new FakeProcessRunner();
+        var command = new NewCommand(console, fs, runner, WorkingDirectory);
+
+        await command.ExecuteAsync(["App", "--template", key], CancellationToken.None);
+
+        var builder = new StringBuilder();
+        foreach (var file in fs.Files.OrderBy(f => f.Key, StringComparer.Ordinal))
+        {
+            builder.Append(file.Key).Append('\0').Append(Hash(file.Value)).Append('\n');
+        }
+
+        foreach (var invocation in runner.Invocations)
+        {
+            builder.Append("run\0").Append(string.Join(' ', invocation.Arguments)).Append('\n');
+        }
+
+        return (console.ErrorText, builder.ToString());
+    }
+
+    private static string Hash(string value) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+}


### PR DESCRIPTION
`rask new --template native` used to scaffold a **server** app. `TemplateCatalog` still advertised the key after the native host was deleted, and `NewCommand`'s switch had no arm for it, so it fell through to `_ => GenerateServer(...)`. The parser accepted the value, the CLI announced *"Creating Rask native mobile app 'MyApp'…"*, and wrote something else. Nothing threw.

The bug itself is already fixed on `main`, and two tests pin it — but both are keyed on the literal string `native`. The same fall-through can recur under any new key, and the next one would be just as silent.

## What this asserts instead

What actually characterises the bug is that a template produced output **identical to another template's**. So that is what is tested: pairwise distinctness across every accepted `--template` key, driven through the real `NewCommand` so the switch under test is the one that ships.

It needs to know nothing about what any template should contain — a key with no arm lands on the default and is caught by construction. Both halves earn their place:

- *every key produces something* catches a key wired to nothing;
- *no two keys produce the same thing* catches a key wired to the wrong thing, which is the shape that shipped.

The fingerprint covers files written **and** external scaffolder invocations, because a front-end template's identity partly lives there: `create-vite --template react` versus `--template preact` is the whole difference between two of these, and the files either writes can be identical.

## Proven by failing it

A guard for a bug that no longer exists is worth only what it does when the bug comes back. Adding a `mobile` key to the catalog with no arm in the switch — the exact shape of #830 — turns it red:

```
--template mobile produces exactly the same project as --template server. That is what a key
with no arm in NewCommand's generator switch looks like: the parser accepts it, the CLI reports
creating it, and the default arm writes something else. It is how '--template native' shipped as
a server app (#830).
```

Reverted after the check; the test file records it so the next person does not have to re-derive it.

## Verification

- `scripts/run-unit-local.sh`: format clean, build `-warnaserror` clean.
- Browser journey gate + CLI build gate: green on push.
- Re-validated against `main` after #849 landed (which rewrote `NewCommand` and moved `localization` out of `WebFlags`): **11/11**. Worth noting because #849 is exactly the kind of change that could have invalidated the guard's assumptions, and did not.

Closes #830
