### PR TITLE
fix(samples): say when an orientation read failed, instead of looking unclicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -644,6 +644,24 @@ them until tagged releases begin.
   publishes on identical inputs). The second is correct and the first predates it; the stale half is
   gone. `BakeScopedAssetsTask` also fails the build now rather than baking an empty bundle silently, so
   the version of this that cost the most to find cannot recur.
+- **The orientation demo no longer makes a failed read look like a click that never landed.**
+  `OrientationDemo.Read()` reported a thrown read into `_status` and left `_current` untouched — so the
+  "Current:" line the reader is actually looking at still said `(read to see)`, exactly as it does
+  before the button is ever pressed. It now says `read failed`, with the detail staying in `_status`.
+
+  The same catch had a second symptom: `Lock()` set `"Locked to {to}"` and *then* read back, so a
+  failing read-back overwrote it with `"Failed: …"` — reporting a lock that had in fact succeeded as
+  one that had not. The read now happens first and the lock claims its status last.
+
+  The E2E assertion changed with it, and had to. It was `Not.ToContainText("read to see")`, which is
+  satisfied by *anything* that is not the placeholder — including the new `read failed`, so the fix
+  would have quietly defeated the test that exists to catch it. (Same shape as the substring trap where
+  `"connected"` matches `"disconnected"`.) It now matches the two legitimate outcomes, so a failure
+  prints what the element actually said instead of producing one indistinguishable red for two
+  different causes.
+
+  Unit-testing this is not available: `samples/Rask.Example.Wasm` targets `net10.0-browser` and the
+  sample's test project is `net10.0`, so the demo cannot be referenced from one.
 
 - **Everything Rask puts on the wire now formats and parses invariantly, whatever culture the process
   is in.** Rask has no culture concept yet, so every one of these paths inherited the machine's locale

--- a/samples/Rask.Example.Wasm/Features/OrientationDemo.cs
+++ b/samples/Rask.Example.Wasm/Features/OrientationDemo.cs
@@ -49,6 +49,11 @@ public sealed partial class OrientationDemo(IScreenOrientation orientation) : Co
         }
         catch (Exception ex)
         {
+            // Say so on the line the reader is actually looking at. Leaving _current at its "(read to
+            // see)" placeholder made a thrown read identical to a click that never landed — for the
+            // visitor and for the E2E alike, which asserts on this element. A demo whose button appears
+            // to do nothing when it fails teaches the wrong lesson twice over.
+            _current = "read failed";
             _status = "Failed: " + ex.Message;
         }
     }
@@ -58,8 +63,12 @@ public sealed partial class OrientationDemo(IScreenOrientation orientation) : Co
         try
         {
             await orientation.LockAsync(to);
-            _status = $"Locked to {to}";
+            // Read back AFTER claiming the lock, and claim it last: Read owns _status on its failure
+            // path, so setting the lock's status first let a failed read-back overwrite it with
+            // "Failed: …" — reporting a lock that had in fact succeeded as one that had not. The read
+            // failing is still visible, on the line that belongs to it.
             await Read();
+            _status = $"Locked to {to}";
         }
         catch (Exception ex)
         {

--- a/tests/Rask.Examples.E2E.Tests/WasmExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/WasmExampleTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Playwright;
 using Rask.Examples.E2E.Tests.Infrastructure;
 using static Microsoft.Playwright.Assertions;
@@ -80,10 +81,24 @@ public sealed class WasmExampleTests(WasmExampleAppFixture app, PlaywrightFixtur
             new LocatorAssertionsToContainTextOptions { Timeout = 15_000 });
 
         await Page.Locator("#orientation-read").ClickAsync();
-        // After reading, the current-orientation code shows either "<Type> (<angle>°)" or "not supported"
-        // — both differ from the idle placeholder.
-        await Expect(Page.Locator("#orientation-current")).Not.ToContainTextAsync("read to see",
-            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+        // Assert the OUTCOME, not the absence of the placeholder.
+        //
+        // This used to be Not.ToContainText("read to see"), which passes on anything that is not the
+        // idle text — including the demo's own "read failed". So the moment the demo started reporting
+        // a thrown read (#810), a negative assertion would have started passing on the failure it
+        // exists to catch. Same shape as the substring trap where "connected" matches "disconnected":
+        // a negative assertion is satisfied by outcomes nobody enumerated.
+        //
+        // Matching the two legitimate shapes instead — "<type> (<angle>°)" or "not supported" — means a
+        // failure prints what the element actually said, so "read failed" and a click that never landed
+        // stop producing the same red. That distinction is the whole point of the issue.
+        // The type is the OrientationType enum's name — "LandscapePrimary", not the web platform's
+        // "landscape-primary". The first version of this regex assumed the latter and failed against
+        // 'LandscapePrimary (0°)', which is the assertion earning its keep on its first run: the old
+        // Not.ToContainText("read to see") would have passed on that too, and on anything else.
+        await Expect(Page.Locator("#orientation-current")).ToHaveTextAsync(
+            new Regex(@"^(?:[A-Za-z][A-Za-z-]* \(-?\d+°\)|not supported)$"),
+            new LocatorAssertionsToHaveTextOptions { Timeout = 10_000 });
     });
 
     // The WASM-only Fullscreen page (FullscreenDemo) — verify it routes and renders. Real fullscreen


### PR DESCRIPTION
`OrientationDemo.Read()` reported a thrown read into `_status` and left `_current` untouched — so the "Current:" line the reader is actually looking at still said `(read to see)`, exactly as it does before the button is ever pressed. A failed read and a click that never landed produced identical output, for the visitor and for the E2E alike.

```csharp
catch (Exception ex)
{
    _status = "Failed: " + ex.Message;   // _current is never touched
}
```

It now says `read failed`, with the detail staying in `_status`.

## A second symptom in the same catch

`Lock()` set `"Locked to {to}"` and *then* read back. `Read()` owns `_status` on its failure path, so a failing read-back overwrote it with `"Failed: …"` — reporting a lock that had **succeeded** as one that had not. The read now happens first and the lock claims its status last, so each line reports the thing it belongs to.

## The assertion had to change with it, and that is the interesting part

The E2E asserted `Not.ToContainText("read to see")` — satisfied by *anything* that is not the placeholder, **including the new `read failed`**. So this fix would have quietly defeated the test that exists to catch the bug: the demo would report the failure, the test would go green on it, and the next regression would be invisible again.

Same shape as the substring trap where `"connected"` matches `"disconnected"`: a negative assertion is satisfied by outcomes nobody enumerated.

It now matches the two legitimate outcomes — `<type> (<angle>°)` or `not supported` — so a failure prints what the element actually said. That is what makes "the read threw" distinguishable from "the click never landed", which is the whole point of the issue (and the lesson from #766, where a forced click had to be confirmed rather than assumed).

## Scope

**A one-off, not a pattern.** Every sibling demo avoids the shape structurally, in two different ways: `EyeDropperDemo`, `BluetoothDemo` and `HidDemo` render the result element only on the non-null branch, so a test asserts presence rather than comparing text; `SerialDemo`, `UsbDemo`, `MediaDevicesDemo`, `IdleDetectorDemo`, `PictureInPictureDemo`, `FullscreenDemo`, `WakeLockDemo`, `PwaDemo` and `InstallPromptDemo` use non-nullable status fields with real defaults. `OrientationDemo` was the only one with all three of: a nullable result field, rendered `?? "placeholder"` inside an id'd element, and a catch that writes only the status field. The fix's comment states that rule, since it is the generalisable part.

## Why no unit test

`samples/Rask.Example.Wasm` targets `net10.0-browser`; the sample's test project (`tests/Rask.Example.Wasm.Tests`) targets `net10.0` and therefore cannot reference it. The demo is unreachable from a unit test, so E2E is the only place — the policy's "E2E only when a unit test can't reach the path", applied rather than assumed.

Closes #810
