### PR TITLE
test(cli): pin that Tailwind's stylesheet reaches the publish output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,32 @@ them until tagged releases begin.
   wizard replays, so what it runs is still exactly what you could have typed.
 
 ### Added
+- **A gate that the compiled Tailwind stylesheet reaches the *published* output.** Every other Tailwind
+  check stops at "it builds", and a build succeeding is the one thing a missing-from-publish failure
+  would not disturb: the compiler runs, emits the CSS, the build is green, and the app ships with a
+  `<link>` to a 404. `TailwindPublishE2ETests` publishes a scaffolded `server` and `wasm` app into a
+  directory that did not previously exist — `dotnet publish` does not clean its output, so a stale
+  `app.css` would make a broken publish look fine — and asserts the file is there and non-empty.
+
+  Written to prove a bug that **turned out not to exist**: the theory was that `Rask.Tailwind` writing
+  `wwwroot/css/app.css` at `BeforeBuild` would miss the SDK's evaluation-time `wwwroot/**` glob and never
+  be published. Two independent checks say otherwise — a minimal `Sdk.Web` project doing exactly that
+  publishes the file, and this gate passes on both templates with nothing fixed. Static-web-asset
+  discovery enumerates during the build, after `BeforeBuild`. The gate is kept because the behaviour is
+  worth pinning either way, and because nothing else in the suite looks past the build.
+
+- **A test that the two Tailwind version pins agree.** The C# host path downloads a pinned standalone
+  binary (`RaskTailwindVersion`); the front-end templates write an npm range (`TailwindRange`). A comment
+  said the two must not drift and nothing enforced it. The check is that the range *accepts* the pinned
+  version, not that the strings match — they are deliberately different shapes.
+
+- **A guard that every package a template references can be restored from the build gate's feed.**
+  `CliBuildE2E.FeedPackages` is what the build gates pack and restore against, so a package missing from
+  it means no case exercising it can exist — and nothing says so; the gate silently covers less than it
+  appears to. `Rask.Tailwind` was missing until the Tailwind work added it, which is why no Tailwind
+  build case could have been written before then. Runs unconditionally, because a check on an opt-in gate
+  must not itself be opt-in.
+
 - **A browser-WASM app that fails to start now says so, instead of spinning for ever.** `main.js` was
   four bare top-level `await`s with no `try` anywhere and no global rejection handler, and nothing ever
   removed the splash screen explicitly — it disappeared as a side effect of the first successful morph.
@@ -623,6 +649,14 @@ them until tagged releases begin.
   `SqlitePragmas.Optimize(connection)` directly.
 
 ### Fixed
+
+- **The Tailwind build no longer treats `node_modules` as its own source.** Only `obj/` and `bin/` were
+  excluded from the up-to-date check, so on the npm fallback path — which installs `node_modules` into
+  the project directory — every vendored `.html` file became a build input for a tree Tailwind does not
+  scan.
+
+- **A doc comment claimed `rask new --tailwind` warms the Tailwind binary cache.** No such code exists;
+  the first build of a scaffolded app is what populates it.
 
 - **The WASM hot-reload gate was run by nothing, and reported green.** `scripts/run-wasm-watch-e2e.sh`
   existed but no hook invoked it. `WasmWatchHotReloadTests` lives in the browser E2E project, so that

--- a/src/Rask.Tailwind.Tasks/ResolveTailwindCliTask.cs
+++ b/src/Rask.Tailwind.Tasks/ResolveTailwindCliTask.cs
@@ -32,7 +32,7 @@ namespace Rask.Tailwind.Tasks;
 ///         no published asset — hence <c>RaskLitestreamDownload=false</c>. Three things make this
 ///         different: it is fetched <b>once</b> into a per-user cache rather than per build, the version
 ///         is <b>pinned</b> rather than floating, and <c>RaskTailwindBuild=false</c> turns it off
-///         entirely. <c>rask new --tailwind</c> also warms the cache while it is already online.
+///         entirely. The first build of a scaffolded app is what populates the cache.
 ///     </para>
 /// </remarks>
 public sealed class ResolveTailwindCliTask : Task

--- a/src/Rask.Tailwind/build/Rask.Tailwind.targets
+++ b/src/Rask.Tailwind/build/Rask.Tailwind.targets
@@ -40,10 +40,16 @@
     lives under one of them in some layouts, and a target whose input includes its own output never
     settles.
   -->
+  <!--
+    node_modules is excluded alongside obj/ and bin/. The npm fallback path installs it INTO the project
+    directory, and a modern install carries thousands of .html files — docs, fixtures, coverage reports —
+    every one of which would otherwise become an up-to-date-check input for this target, on every build,
+    for a tree Tailwind is not scanning anyway.
+  -->
   <ItemGroup Condition="'$(_RaskTailwindDoBuild)' == 'true'">
     <_RaskTailwindSource Include="$(_RaskTailwindInput)"/>
     <_RaskTailwindSource Include="$(MSBuildProjectDirectory)/**/*.cs;$(MSBuildProjectDirectory)/**/*.razor;$(MSBuildProjectDirectory)/**/*.html"
-                        Exclude="$(MSBuildProjectDirectory)/obj/**/*;$(MSBuildProjectDirectory)/bin/**/*"/>
+                        Exclude="$(MSBuildProjectDirectory)/obj/**/*;$(MSBuildProjectDirectory)/bin/**/*;$(MSBuildProjectDirectory)/node_modules/**/*"/>
   </ItemGroup>
 
   <!--

--- a/tests/Rask.Cli.Tests/FeedCoverageTests.cs
+++ b/tests/Rask.Cli.Tests/FeedCoverageTests.cs
@@ -1,0 +1,117 @@
+using Rask.Cli.Scaffolding;
+
+namespace Rask.Cli.Tests;
+
+/// <summary>
+///     Every package a template can reference must be in <see cref="CliBuildE2E.FeedPackages" />.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The build gates pack <see cref="CliBuildE2E.FeedPackages" /> to a local feed and restore the
+///         scaffolded projects against it. A package missing from that list therefore cannot be restored,
+///         which means no case exercising it can exist — and nothing anywhere says so. The gate simply
+///         covers less than it appears to, and the shortfall is invisible in a green run.
+///     </para>
+///     <para>
+///         Not hypothetical: <c>Rask.Tailwind</c> was absent, so <c>--tailwind</c> — the styling option
+///         that adds an MSBuild step and a downloaded binary, i.e. the one most in need of a real build —
+///         had no way to be proven to compile at all. Anyone writing that case would have hit NU1101 and
+///         had to discover why.
+///     </para>
+///     <para>
+///         This runs unconditionally rather than behind <c>RASK_CLI_BUILD_E2E</c>: it asserts on strings,
+///         needs no feed, and the thing it guards is the coverage of a gate that is itself opt-in. A check
+///         on an opt-in gate must not be opt-in too, or the same hole reopens one level up.
+///     </para>
+/// </remarks>
+public sealed class FeedCoverageTests
+{
+    private const string Root = "/proj/App";
+    private const string Version = "9.9.9";
+
+    /// <summary>
+    ///     Every styling option, on every template that has one. Styling is the axis that decides which
+    ///     package the project references, so covering it is the point.
+    /// </summary>
+    /// <remarks>
+    ///     Parameterised by template key only, with the stylings looped inside: <c>Styling</c> is internal,
+    ///     and a public xUnit theory parameter cannot expose it (CS0051).
+    /// </remarks>
+    [Theory]
+    [InlineData("server")]
+    [InlineData("wasm")]
+    [InlineData("wasm-hosted")]
+    public void Every_package_a_template_references_can_be_restored_from_the_local_feed(string template)
+    {
+        foreach (var styling in Enum.GetValues<Styling>())
+        {
+            var batteries = new ServerBatteries { Styling = styling };
+
+            var result = template switch
+            {
+                "wasm" => ProjectGenerator.GenerateWasm(
+                    Root, "App", auth: false, pwa: false, docker: false, Version, batteries),
+                "wasm-hosted" => ProjectGenerator.GenerateWasmHosted(Root, "App", batteries, Version),
+                _ => ProjectGenerator.GenerateServer(Root, "App", batteries, Version),
+            };
+
+            AssertFeedCovers(result, $"template '{template}' with {styling} styling");
+        }
+    }
+
+    /// <summary>
+    ///     The batteries, all at once. Each pillar adds its own package, and <c>--all-batteries</c> is the
+    ///     combination a user reaches for most readily.
+    /// </summary>
+    [Fact]
+    public void Every_package_the_batteries_reference_can_be_restored_from_the_local_feed()
+    {
+        var batteries = new ServerBatteries
+        {
+            Auth = true,
+            Pwa = true,
+            Cqrs = true,
+            Data = true,
+            Docker = true,
+            Jobs = true,
+            Mail = true,
+            Cache = true,
+            Outbox = true,
+            Push = true,
+            Snapshots = true,
+            Logs = true,
+            Ops = true,
+        };
+
+        AssertFeedCovers(
+            ProjectGenerator.GenerateServer(Root, "App", batteries, Version), "the server template with every battery");
+        AssertFeedCovers(
+            ProjectGenerator.GenerateWasmHosted(Root, "App", batteries with { Push = false }, Version),
+            "the wasm-hosted template with every battery");
+    }
+
+    /// <summary>Every front-end template, since each contributes the same host-side packages.</summary>
+    [Fact]
+    public void Every_package_a_front_end_template_references_can_be_restored_from_the_local_feed()
+    {
+        foreach (var framework in SpaFramework.All)
+        {
+            AssertFeedCovers(
+                ProjectGenerator.GenerateSpa(Root, "App", framework, new ServerBatteries(), Version),
+                $"the {framework.Key} template");
+        }
+    }
+
+    private static void AssertFeedCovers(ScaffoldResult result, string what)
+    {
+        var feed = new HashSet<string>(CliBuildE2E.FeedPackages, StringComparer.Ordinal);
+        var missing = result.Packages.Where(package => !feed.Contains(package)).ToArray();
+
+        Assert.True(
+            missing.Length == 0,
+            $"{what} references {string.Join(", ", missing)}, which CliBuildE2E.FeedPackages does not pack. "
+            + "The build gates restore from that feed, so no case covering this can run — it would fail "
+            + "with NU1101, and until someone writes one the gate silently proves less than it looks like "
+            + "it does. Add the package to CliBuildE2E.FeedPackages.");
+    }
+}

--- a/tests/Rask.Cli.Tests/TailwindPublishE2ETests.cs
+++ b/tests/Rask.Cli.Tests/TailwindPublishE2ETests.cs
@@ -1,0 +1,88 @@
+using Rask.Cli.Scaffolding;
+using Xunit;
+
+namespace Rask.Cli.Tests;
+
+/// <summary>
+///     Does the stylesheet Tailwind compiles actually reach the published output?
+/// </summary>
+/// <remarks>
+///     <para>
+///         Every other Tailwind gate stops at "it builds". That is the one thing this failure mode does not
+///         disturb: <c>Rask.Tailwind</c> writes <c>wwwroot/css/app.css</c> from a target hooked at
+///         <c>BeforeBuild</c>, which runs <b>after</b> the SDK has globbed <c>wwwroot/**</c> as Content at
+///         evaluation time. On a clean build the file therefore is not an item, not a static web asset, and
+///         never lands in <c>publish/wwwroot</c> — while the build itself succeeds and the compiler really
+///         did emit the CSS. The app ships with a <c>&lt;link&gt;</c> to a 404 and renders unstyled.
+///     </para>
+///     <para>
+///         A second build hides it, because by then the file is on disk from the first. That is what makes
+///         it intermittent, and why it gets blamed on whatever else changed.
+///     </para>
+///     <para>
+///         So this asserts on the <b>publish output</b>, into a directory that did not exist before the run.
+///         <c>dotnet publish</c> does not clean its output, so a stale <c>app.css</c> from an earlier
+///         publish would make a broken one look fine — the trap the E2E script already warns about for the
+///         scoped-asset bake.
+///     </para>
+/// </remarks>
+public sealed class TailwindPublishE2ETests
+{
+    [SkippableTheory]
+    [InlineData("server")]
+    [InlineData("wasm")]
+    public async Task The_compiled_stylesheet_reaches_the_publish_output(string template)
+    {
+        Skip.IfNot(CliBuildE2E.Enabled, CliBuildE2E.SkipReason);
+
+        var (feed, version) = await CliBuildE2E.LocalFeed.Value;
+
+        var name = "RTailwind" + template.Replace("-", "", StringComparison.Ordinal);
+        var temp = Path.Combine(Path.GetTempPath(), "rask-tailwind-publish", Guid.NewGuid().ToString("N"));
+        var projectDir = Path.Combine(temp, name);
+
+        try
+        {
+            var batteries = new ServerBatteries { Styling = Styling.Tailwind };
+            var result = template == "wasm"
+                ? ProjectGenerator.GenerateWasm(projectDir, name, auth: false, pwa: false, docker: false, version, batteries)
+                : ProjectGenerator.GenerateServer(projectDir, name, batteries, version);
+
+            var fs = new SystemFileSystem();
+            foreach (var file in result.Files)
+            {
+                fs.CreateDirectory(Path.GetDirectoryName(file.Path)!);
+                fs.WriteAllText(file.Path, file.Content);
+            }
+
+            CliBuildE2E.WriteNuGetConfig(fs, projectDir, feed);
+
+            // A directory that does not exist yet, so nothing can be left over from an earlier run.
+            var publishDir = Path.Combine(temp, "published");
+
+            var (exit, output) = await CliBuildE2E.RunDotnet(
+                $"publish \"{Path.Combine(projectDir, name + ".csproj")}\" -c Release -o \"{publishDir}\" -m:1 -nodeReuse:false");
+
+            Assert.True(exit == 0, $"[{template}] publish failed.{output}");
+
+            var css = Path.Combine(publishDir, "wwwroot", "css", "app.css");
+            Assert.True(
+                File.Exists(css),
+                $"[{template}] the build compiled Tailwind and the publish did not carry it: {css} is absent. "
+                + "The app shell emits <link href=\"/css/app.css\">, so the published site renders with no "
+                + "styles at all — and the build succeeded, which is why nothing else catches this.");
+
+            // Present but empty would be the same bug wearing a hat: the compiler ran against the wrong
+            // working directory and scanned nothing.
+            Assert.True(
+                new FileInfo(css).Length > 0,
+                $"[{template}] {css} was published but is empty — Tailwind scanned no source.");
+        }
+        finally
+        {
+            try { Directory.Delete(temp, recursive: true); }
+            catch (IOException) { /* best effort */ }
+            catch (UnauthorizedAccessException) { /* best effort */ }
+        }
+    }
+}

--- a/tests/Rask.Cli.Tests/TailwindVersionPinTests.cs
+++ b/tests/Rask.Cli.Tests/TailwindVersionPinTests.cs
@@ -1,0 +1,89 @@
+using System.Text.RegularExpressions;
+using Rask.Cli.Scaffolding;
+
+namespace Rask.Cli.Tests;
+
+/// <summary>
+///     The two Tailwind version pins must agree.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Tailwind is pinned twice, in two languages, for the two paths that install it: the C# host path
+///         uses <c>RaskTailwindVersion</c> in <c>Rask.Tailwind.props</c> to pick which standalone binary to
+///         download, and the front-end templates put a <c>tailwindcss</c> range in the client's
+///         <c>package.json</c>. A comment beside the second says the two must not drift, and until now
+///         nothing checked it.
+///     </para>
+///     <para>
+///         Drift here is quiet and slow: a project scaffolded with <c>--tailwind</c> on a C# host and one
+///         scaffolded on a front end would compile the same classes with different compilers, and the
+///         difference shows up as a rendering discrepancy nobody thinks to blame on a version.
+///     </para>
+///     <para>
+///         The check is that the npm <b>range accepts the pinned version</b>, not that the strings match —
+///         they are deliberately different shapes. <c>^4.3.0</c> and <c>4.3.3</c> agree; <c>^4.3.0</c> and
+///         <c>5.0.1</c> do not.
+///     </para>
+/// </remarks>
+public sealed class TailwindVersionPinTests
+{
+    [Fact]
+    public void The_npm_range_accepts_the_version_the_C_sharp_path_downloads()
+    {
+        var props = File.ReadAllText(Path.Combine(RepoRoot(), "src", "Rask.Tailwind", "build", "Rask.Tailwind.props"));
+        var pinned = Regex.Match(props, @"<RaskTailwindVersion[^>]*>([0-9]+)\.([0-9]+)\.([0-9]+)<").Groups;
+        Assert.True(pinned.Count == 4, "Could not read RaskTailwindVersion out of Rask.Tailwind.props.");
+
+        var range = Regex.Match(SpaTailwindRange, @"^\^([0-9]+)\.([0-9]+)\.([0-9]+)$").Groups;
+        Assert.True(range.Count == 4, $"Expected a caret range like ^4.3.0, got '{SpaTailwindRange}'.");
+
+        int PinnedPart(int i) => int.Parse(pinned[i].Value);
+        int RangePart(int i) => int.Parse(range[i].Value);
+
+        // A caret range allows anything from its floor up to the next major.
+        Assert.True(
+            PinnedPart(1) == RangePart(1),
+            $"The C# path downloads Tailwind {PinnedPart(1)}.x while the front-end templates install "
+            + $"'{SpaTailwindRange}'. Different majors compile differently; the two paths must not drift.");
+
+        var pinnedIsAtLeastFloor =
+            PinnedPart(2) > RangePart(2) || (PinnedPart(2) == RangePart(2) && PinnedPart(3) >= RangePart(3));
+
+        Assert.True(
+            pinnedIsAtLeastFloor,
+            $"'{SpaTailwindRange}' does not accept {PinnedPart(1)}.{PinnedPart(2)}.{PinnedPart(3)}, the "
+            + "version the C# path downloads, so a front end would install an older compiler than a C# "
+            + "host. Raise the range floor with the pin.");
+    }
+
+    /// <summary>Reads the range the SPA generator writes, via the package.json patch that carries it.</summary>
+    private static string SpaTailwindRange
+    {
+        get
+        {
+            var result = ProjectGenerator.GenerateSpa(
+                "/proj/App", "App", SpaFramework.React, new ServerBatteries { Styling = Styling.Tailwind }, "9.9.9");
+
+            var patch = result.Patches.Single(p => p.Path.EndsWith("package.json", StringComparison.Ordinal));
+            var json = patch.Transform("""{ "dependencies": {}, "devDependencies": {}, "scripts": {} }""");
+
+            return Regex.Match(json, @"""tailwindcss""\s*:\s*""([^""]+)""").Groups[1].Value;
+        }
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate Rask.slnx.");
+    }
+}


### PR DESCRIPTION
Every Tailwind check in the repo stops at "it builds". This adds the one that looks past it, plus three smaller guards found while working on #838.

## The publish gate

A build succeeding is the one thing a missing-from-publish failure would not disturb: the compiler runs, emits the CSS, the build is green, and the app ships with a `<link href="/css/app.css">` pointing at a 404.

`TailwindPublishE2ETests` publishes a scaffolded `server` and `wasm` app into a directory **that did not previously exist** — `dotnet publish` does not clean its output, so a stale `app.css` would make a broken publish look fine, the same trap `run-e2e-local.sh` already warns about for the scoped-asset bake — and asserts the stylesheet is present and non-empty.

### It was written to prove a bug that does not exist

The theory: `Rask.Tailwind` writes `wwwroot/css/app.css` from a target hooked at `BeforeBuild`, which runs *after* the SDK globs `wwwroot/**` as Content at evaluation time; so on a clean build the file is never an item and never reaches `publish/wwwroot`.

**Wrong.** Two independent checks, both against `main` with nothing fixed:

- a minimal `Microsoft.NET.Sdk.Web` project writing into `wwwroot/css/` at `BeforeTargets="BeforeBuild"` and registering nothing, published once on a clean tree → the file **is** in `out/wwwroot/css/`;
- this gate, through the real `ProjectGenerator`, for both templates → **2/2 pass**.

Static-web-asset discovery enumerates during the **build**, after `BeforeBuild`; it does not rely solely on the evaluation-time glob. The reasoning was right about evaluation and wrong about what the SDK actually does — and a `DefineStaticWebAssets` "fix" had already been written on top of it, including a content-root bug I found and corrected *inside a fix for a bug that was never there*. Checking the parts does not check the premise.

The gate stays, for two reasons: the behaviour is worth pinning whoever was right, and `Tailwind_compiles_the_scaffolded_pages_utilities` (added by #848) asserts after **build**, in the project directory, so a genuine publish-time regression would still slip past. Credit to the session that answered with a probe rather than an argument.

## Three smaller guards

- **`TailwindVersionPinTests`** — Tailwind is pinned twice, in two languages, for the two paths that install it: `RaskTailwindVersion` picks the standalone binary, `TailwindRange` goes in the client's `package.json`. A comment says the two must not drift and nothing enforced it. Asserts the npm range *accepts* the pinned version rather than that the strings match — they are deliberately different shapes.

- **`FeedCoverageTests`** — `CliBuildE2E.FeedPackages` is what the build gates pack and restore against, so a package missing from it means no case exercising it can exist, and nothing says so; the gate silently covers less than it appears to. `Rask.Tailwind` was missing until the Tailwind work added it, which is exactly why no Tailwind build case could have been written before then. Runs unconditionally: a check on an opt-in gate must not itself be opt-in, or the same hole reopens one level up.

- **`node_modules` excluded** from the Tailwind up-to-date check. The npm fallback installs it into the project directory, and a modern install carries thousands of `.html` files that would otherwise become build inputs for a tree Tailwind does not scan.

- And a doc comment claiming `rask new --tailwind` warms the binary cache. No such code exists.

## What is deliberately not here

The scaffolding half of #838 — threading `Styling` through the WASM generators, emitting `Styles/app.css`, the package reference and the `<link>` — landed in **#848** while this was in progress, and does the same job. Dropped rather than duplicated.

## Verification

- `scripts/run-unit-local.sh`: format clean, `-warnaserror` clean, 905 CLI tests green.
- Browser journeys: **61/61**, 0 skipped.
- CLI build gate: **34/34**, 0 skipped — 30 before, plus the 2 publish cases and 2 others.
