### PR TITLE
fix(build): pack the MSBuild task assembly by name, not via build\**

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- **A package that ships an MSBuild task now packs that task by name, so it cannot pack without it.**
+  `Rask.Spa.Hosting`, `Rask.Wasm` and `Rask.Tailwind` each collect a generated `*.Tasks.dll` with
+  `<None Include="build\**">`, ordered by a build-only `ProjectReference` that produces it. That
+  ordering is real for the *build* and meaningless for the *glob*: a glob is expanded at project
+  **evaluation**, before any target runs. On a tree where the DLL is not already on disk it matches
+  nothing, `dotnet pack` **succeeds**, and the package ships with a `UsingTask` pointing at a file
+  that is not in it — the consumer then fails with `MSB4062`
+  ([#852](https://github.com/pal-tamas/rask/issues/852)).
+
+  Reproduced directly rather than reasoned about: delete the DLL, `dotnet pack` the project alone,
+  and the nupkg contains `build/*.props`, `build/*.targets` and no task assembly, with **pack exit
+  0** — while the DLL sits on disk, written during that very build. Packing again is correct,
+  because the first build left it behind, which is what makes it read as flakiness.
+
+  Each DLL is now a literal `<None Include="build\<Name>.Tasks.dll">`, excluded from the glob beside
+  it. A literal include needs the file only when the item is *copied*, which is after the reference
+  has built. The glob stays for `build/*.props` and `build/*.targets`, which are committed and so
+  can never be missing at evaluation.
+
+  **The repair is that the failure stops being silent.** Verified by pointing a literal at a name
+  nothing produces: `error NU5019: File not found`, pack exit 1. A missing task assembly is now a
+  build error instead of a package that looks fine and is inert.
+
+  **Published packages were never affected** — `release.yml` runs `dotnet build Rask.slnx` before
+  every `dotnet pack --no-build`, so the DLL is always on disk by then. The reachable exposure was
+  `CliBuildE2E.PackLocalFeedAsync`, which packs each `.csproj` with no prior solution build, so a
+  first run in a fresh worktree failed two cases with an error belonging to no branch.
+
+  `Rask.Tailwind` was the third one, and is named in no report: the guard added here finds the set
+  by reading each packed `.targets` for the `UsingTask` that will load a DLL, so a package that
+  grows a task is covered the day it does rather than when someone remembers the list. Hand-kept
+  lists are exactly how the neighbouring gates rotted — `Rask.Tailwind` was missing from
+  `CliBuildE2E.FeedPackages` from the day it shipped.
+
 - **`--tailwind` on a front-end template no longer strips the app's styling and put nothing back.**
   The scaffolded stylesheet replaces the one `create-vite` (or `ng new`) wrote, and until now that
   replacement was a single `@import "tailwindcss";`. Part of the file being replaced does style the

--- a/src/Rask.Spa.Hosting/Rask.Spa.Hosting.csproj
+++ b/src/Rask.Spa.Hosting/Rask.Spa.Hosting.csproj
@@ -49,7 +49,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="build\**" Pack="true" PackagePath="build\"/>
+    <!--
+      The generated task assembly is named EXPLICITLY, and excluded from the glob beside it, because
+      a glob is expanded at project EVALUATION — before any target runs, including the build of the
+      ProjectReference above that produces this DLL. On a tree where it is not already on disk the
+      glob matches nothing, and `dotnet pack` then SUCCEEDS and ships a package whose <UsingTask>
+      points at a file that is not in it; the consumer fails with MSB4062, and a second pack on the
+      same machine is correct because the first build left the DLL behind (#852).
+
+      A literal Include needs the file only when the item is copied, which is after the reference has
+      built — so the DLL is collected, and if it is ever genuinely missing the pack FAILS instead of
+      quietly shipping without it. That is the real repair: the failure mode stops being silent.
+
+      The glob stays for build/*.props and build/*.targets, which are committed and so cannot be
+      missing at evaluation — keeping it means a new committed import still ships without anyone
+      remembering to list it.
+    -->
+    <None Include="build\**" Exclude="build\Rask.Spa.Tasks.dll" Pack="true" PackagePath="build\"/>
+    <None Include="build\Rask.Spa.Tasks.dll" Pack="true" PackagePath="build\"/>
     <!--
       The TypeScript client, shipped as source the way Rask.Wasm ships Browser/main.js. It is written
       into a scaffolded client by `rask new` and refreshed on build while its header line is intact,

--- a/src/Rask.Tailwind/Rask.Tailwind.csproj
+++ b/src/Rask.Tailwind/Rask.Tailwind.csproj
@@ -42,8 +42,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="build\**" Pack="true" PackagePath="build\"/>
+    <!--
+      Rask.Tailwind.Tasks.dll is named explicitly and excluded from the glob: a glob is expanded at
+      project EVALUATION, before the ProjectReference that produces this DLL has built, so on a tree
+      where it is not already on disk the pack SUCCEEDS and ships a package whose <UsingTask> points
+      at a file that is not in it. A literal Include needs the file only when the item is copied, so
+      it is collected — and a genuinely missing one is NU5019 rather than a silent omission (#852).
 
+      This package is build-only (IncludeBuildOutput=false), so the task assembly is very nearly all
+      it ships: without it the package is inert, and nothing about the build says so.
+    -->
+    <None Include="build\**" Exclude="build\Rask.Tailwind.Tasks.dll" Pack="true" PackagePath="build\"/>
+    <None Include="build\Rask.Tailwind.Tasks.dll" Pack="true" PackagePath="build\"/>
   </ItemGroup>
 
 </Project>

--- a/src/Rask.Wasm/Rask.Wasm.csproj
+++ b/src/Rask.Wasm/Rask.Wasm.csproj
@@ -111,7 +111,15 @@
     <None Include="Browser\rask.wasm.js"
           Pack="true" PackagePath="Browser\rask.wasm.js"
           Condition=" '$(Configuration)' != 'Release' "/>
-    <None Include="build\**" Pack="true" PackagePath="build\"/>
+    <!--
+      Rask.Wasm.Tasks.dll is named explicitly and excluded from the glob: a glob is expanded at
+      project EVALUATION, before the ProjectReference that produces this DLL has built, so on a tree
+      where it is not already on disk the pack SUCCEEDS and ships a package whose <UsingTask> points
+      at a file that is not in it. A literal Include needs the file only when the item is copied, so
+      it is collected — and a genuinely missing one is NU5019 rather than a silent omission (#852).
+    -->
+    <None Include="build\**" Exclude="build\Rask.Wasm.Tasks.dll" Pack="true" PackagePath="build\"/>
+    <None Include="build\Rask.Wasm.Tasks.dll" Pack="true" PackagePath="build\"/>
   </ItemGroup>
 
   <Import Project="..\..\build\Rask.MinifyJs.targets"/>

--- a/tests/Rask.Cli.Tests/PackagingContractTests.cs
+++ b/tests/Rask.Cli.Tests/PackagingContractTests.cs
@@ -96,6 +96,104 @@ public sealed class PackagingContractTests
         Assert.Equal(@"build\", item.Attribute("PackagePath")?.Value);
     }
 
+    /// <summary>
+    ///     Every MSBuild task assembly a packed <c>.targets</c> will try to load, paired with the package
+    ///     that has to ship it.
+    /// </summary>
+    /// <remarks>
+    ///     Derived from the <c>UsingTask</c> that loads it rather than hand-listed, so a package that
+    ///     grows a task is covered the day it does. Hand-kept lists are how the neighbouring gates rotted
+    ///     — <c>Rask.Tailwind</c> was absent from <c>CliBuildE2E.FeedPackages</c> from the day it shipped,
+    ///     and it is one of the three packages this finds.
+    /// </remarks>
+    public static TheoryData<string, string> PackedTaskAssemblies()
+    {
+        const string here = "$(MSBuildThisFileDirectory)";
+        var data = new TheoryData<string, string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var dir in Directory.EnumerateDirectories(Path.Combine(_repoRoot, "src"))
+                     .OrderBy(path => path, StringComparer.Ordinal))
+        {
+            var package = Path.GetFileName(dir);
+            var targets = Path.Combine(dir, "build", $"{package}.targets");
+
+            if (!File.Exists(targets) || !File.Exists(Path.Combine(dir, $"{package}.csproj")))
+            {
+                continue;
+            }
+
+            foreach (var task in XDocument.Load(targets).Descendants("UsingTask"))
+            {
+                var assembly = task.Attribute("AssemblyFile")?.Value ?? string.Empty;
+
+                if (assembly.StartsWith(here, StringComparison.Ordinal)
+                    && assembly.EndsWith(".dll", StringComparison.Ordinal)
+                    && seen.Add(package + "/" + assembly))
+                {
+                    data.Add(package, assembly[here.Length..]);
+                }
+            }
+        }
+
+        return data;
+    }
+
+    /// <summary>
+    ///     A task assembly produced during the build is packed by NAME, never left to <c>build\**</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         A glob is expanded at project <b>evaluation</b>, before any target runs — including the
+    ///         build of the <c>ProjectReference</c> that produces the DLL. On a tree where it is not
+    ///         already on disk the glob matches nothing, <c>dotnet pack</c> <b>succeeds</b>, and the
+    ///         package ships with a <c>UsingTask</c> pointing at a file that is not in it. The consumer
+    ///         fails with MSB4062; packing again on the same machine is correct, because the first build
+    ///         left the DLL behind — so it reads as flakiness rather than as a fact about ordering
+    ///         (<see href="https://github.com/pal-tamas/rask/issues/852" />).
+    ///     </para>
+    ///     <para>
+    ///         A literal <c>Include</c> needs the file only when the item is copied, which is after the
+    ///         reference has built. It also turns the failure loud: a genuinely missing file is NU5019
+    ///         and a non-zero pack, verified by pointing one at a name nothing produces.
+    ///     </para>
+    ///     <para>
+    ///         Structural, like the rest of this class, and for the same reason — the defect exists only
+    ///         on the far side of a <c>dotnet pack</c>, and only on a tree that has not built yet, which
+    ///         no in-repo build ever is by the time a suite runs.
+    ///     </para>
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(PackedTaskAssemblies))]
+    public void A_generated_task_assembly_is_packed_by_name_rather_than_left_to_a_glob(string package, string dll)
+    {
+        var csproj = XDocument.Load(Path.Combine(_repoRoot, "src", package, $"{package}.csproj"));
+        var packItems = csproj.Descendants("None")
+            .Where(e => (e.Attribute("Include")?.Value ?? string.Empty)
+                .StartsWith(@"build\", StringComparison.Ordinal))
+            .ToArray();
+
+        var literal = packItems.SingleOrDefault(e => e.Attribute("Include")?.Value == $@"build\{dll}");
+
+        Assert.True(
+            literal is not null,
+            $"{package}.csproj leaves build/{dll} to a glob, but build/{package}.targets loads it with a "
+            + "UsingTask. A glob is expanded at evaluation, before the ProjectReference that produces the "
+            + "DLL has built — so on a tree where it is not already on disk, pack SUCCEEDS and ships a "
+            + $"package whose UsingTask points at a file that is not in it. Add: <None Include=\"build\\{dll}\" "
+            + "Pack=\"true\" PackagePath=\"build\\\"/>.");
+
+        Assert.Equal("true", literal!.Attribute("Pack")?.Value);
+        Assert.Equal(@"build\", literal.Attribute("PackagePath")?.Value);
+
+        // Any glob beside it must exclude the DLL, or once the file IS on disk it is collected twice.
+        foreach (var glob in packItems.Where(e =>
+                     (e.Attribute("Include")?.Value ?? string.Empty).Contains('*', StringComparison.Ordinal)))
+        {
+            Assert.Contains(dll, glob.Attribute("Exclude")?.Value ?? string.Empty, StringComparison.Ordinal);
+        }
+    }
+
     [Fact]
     public void Rask_Core_does_not_pretend_to_pack_its_own_build_integration()
     {


### PR DESCRIPTION
`Rask.Spa.Hosting`, `Rask.Wasm` and `Rask.Tailwind` each collect a **generated** `*.Tasks.dll` with `<None Include="build\**">`, ordered by a build-only `ProjectReference` that produces it. That ordering is real for the *build* and meaningless for the *glob*: a glob is expanded at project **evaluation**, before any target runs.

So on a tree where the DLL is not already on disk, the glob matches nothing, `dotnet pack` **succeeds**, and the package ships with a `UsingTask` pointing at a file that is not in it. The consumer fails with `MSB4062`.

## Reproduced, not reasoned about

Delete the DLL and pack the project alone — which is exactly what `CliBuildE2E.PackLocalFeedAsync` does:

```
build/ before pack   Rask.Spa.Hosting.props, Rask.Spa.Hosting.targets
pack exit            0
nupkg contents       build/*.props, build/*.targets, client/*   ← no task assembly
build/ after pack    ... Rask.Spa.Tasks.dll                     ← written during that very build
```

Packing again is correct, because the first build left the DLL behind. That is why it reads as flakiness, and why nobody sees it on a machine that has built before.

## The fix, and why it is more than a rewrite

Each DLL is now a literal `<None Include="build\<Name>.Tasks.dll">`, excluded from the glob beside it so it is not collected twice once it does exist. A literal include needs the file only when the item is **copied**, which is after the reference has built.

**The repair is that the failure stops being silent.** Verified by pointing a literal at a name nothing produces:

```
error NU5019: File not found: '.../build/Rask.Spa.NeverProduced.dll'
--- pack exit: 1 ---
```

A missing task assembly is now a build error rather than a package that looks fine and is inert.

The glob stays for `build/*.props` and `build/*.targets` — committed, so never missing at evaluation — which keeps a newly committed import shipping without anyone remembering to list it.

## Scope: three packages, and published ones were never affected

| project | generated file |
|---|---|
| `Rask.Spa.Hosting` | `Rask.Spa.Tasks.dll` |
| `Rask.Wasm` | `Rask.Wasm.Tasks.dll` |
| **`Rask.Tailwind`** | **`Rask.Tailwind.Tasks.dll`** |

`Rask.Tailwind` is named in no report. It is also build-only (`IncludeBuildOutput=false`), so the task assembly is very nearly all it ships — without it the package is inert and nothing about the build says so.

**`release.yml` is safe**, as #852 says: it runs `dotnet build Rask.slnx` before every `dotnet pack --no-build`, so the DLL is always on disk by then. The reachable exposure is `PackLocalFeedAsync`, which packs each `.csproj` with no prior solution build — so a first run in a fresh worktree failed two cases with an error belonging to no branch.

## The guard finds the set itself

`PackagingContractTests` now reads each packed `.targets` for the `UsingTask` that will load a DLL, and requires that DLL to be named literally in the csproj. A package that grows a task is covered the day it does.

That matters here specifically: hand-kept lists are how the neighbouring gates rotted — `Rask.Tailwind` was missing from `CliBuildE2E.FeedPackages` from the day it shipped (#848), and `TailwindPublishE2ETests` was invisible to the gate's own `--filter` (#858). Deriving the set from the contract is the only version of this that stays true.

## Verification

| | result |
|---|---|
| all three, packed from clean (DLL + `obj/` + `bin/` removed) | task DLL **is** in the nupkg, 3/3 |
| literal pointed at a file nothing produces | **NU5019**, pack exit 1 |
| guard with one csproj put back on the bare glob | **FAILS**, naming the file and the fix |
| guard as shipped | 3 cases, pass — and it found exactly the three the disk scan did |
| `scripts/run-unit-local.sh` | **6680 passed, 0 failed**, `dotnet format` clean |
| `scripts/run-cli-build-e2e.sh` (pre-push) | **39/39, 0 skipped** |

Closes #852
