### PR TITLE
fix(e2e): install Playwright browsers without PowerShell

### DIFF
--- a/.claude/skills/run-rask/SKILL.md
+++ b/.claude/skills/run-rask/SKILL.md
@@ -24,9 +24,10 @@ otherwise.
   pulls `Microsoft.Playwright` via NuGet (version comes from `Directory.Packages.props`, so the
   `#:package` directive is intentionally unversioned — Central Package Management supplies it).
 - **Playwright browsers** — already present in `~/Library/Caches/ms-playwright` (installed for the
-  E2E suite). If missing, the driver errors with a "browser not found" message; install with
-  `dotnet run --project tests/Rask.Examples.E2E.Tests -- ...` build once then run the generated
-  `playwright.ps1 install chromium`, or see `scripts/run-e2e-local.sh`.
+  E2E suite). If missing, the driver errors with a "browser not found" message; build the E2E project
+  once, then `scripts/playwright.sh install chromium`. That wrapper drives the node CLI bundled with
+  `Microsoft.Playwright`, so it needs no PowerShell and always installs the browser revisions the
+  pinned binding expects — unlike `npx playwright install`.
 
 ## Build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- **The browser gate no longer needs PowerShell, and no longer skips itself quietly when it is
+  missing.** `scripts/run-e2e-local.sh` installed the Playwright browsers by shelling out to
+  `pwsh <path>/playwright.ps1 install chromium`, and skipped that step whenever `pwsh` was absent.
+  On Linux that is the ordinary case rather than the edge one — PowerShell is in neither Fedora's nor
+  Debian's repositories — so the notice went into the middle of the thousands of build lines the gate
+  prints from `.githooks/pre-push`, and the suite failed minutes later with a missing-browser error
+  naming the browsers instead of the skipped install
+  ([#867](https://github.com/pal-tamas/rask/issues/867)).
+
+  The dependency was never real: `playwright.ps1` is six lines that load `Microsoft.Playwright.dll` and
+  call its `Main`, and the same package ships `.playwright/node/<rid>/node` alongside
+  `.playwright/package/cli.js` — the driver the binding launches at runtime. `rask_playwright_driver`
+  (`scripts/lib/playwright.sh`) resolves that pair, and `scripts/playwright.sh` wraps it for humans:
+  `scripts/playwright.sh install chromium`, `scripts/playwright.sh show-trace <file>`. That is also the
+  version-correct route rather than a workaround — it installs the browser revisions the pinned
+  `Microsoft.Playwright` asks for, which `npx playwright install` does not guarantee.
+
+  Resolution is table-tested (`scripts/tests/playwright.test.sh`) across the three rid directories this
+  runs on and every way the lookup can come back empty, because a resolver that quietly finds nothing is
+  what produced the original silent skip. The gate now resolves in the `if` condition and installs in the
+  body: `set -e` is suspended inside a condition, so running the install there would have swallowed a
+  failed download into the else branch and continued having installed nothing.
 - **The Node floor is now enforced, not just documented.** `RaskSpaMinimumNode` was described in
   `Rask.Spa.Hosting.props` as the version "the probe reports anything older" against, and `docs/spa.md`
   told you to set it "if you want the build to insist on more than Rask does". Nothing compared against

--- a/scripts/lib/playwright.sh
+++ b/scripts/lib/playwright.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Drive the Playwright CLI that Microsoft.Playwright already ships — without PowerShell.
+#
+# The package drops a `playwright.ps1` next to the test assembly, which makes pwsh look like a hard
+# dependency of running the browser suite. It is not. That file is six lines: it sets
+# PLAYWRIGHT_DRIVER_SEARCH_PATH, loads Microsoft.Playwright.dll, and calls its Main. The same package
+# also lays down `.playwright/node/<rid>/node` and `.playwright/package/cli.js` — the actual driver the
+# binding launches at runtime — so the CLI can be invoked directly with no shell of any kind between.
+#
+# That matters beyond tidiness. pwsh is not in Fedora's repositories, nor in a plain Debian install, so
+# on a Linux dev box the old check fell through to "skipped auto-install" and the suite then failed
+# minutes later with a missing-browser error that named the wrong cause.
+#
+# Going to the bundled driver is also the VERSION-CORRECT route, not merely a workaround: the browser
+# revisions it installs are the ones THIS Microsoft.Playwright asks for. `npx playwright install` is the
+# tempting one-liner and is wrong — npx resolves the newest Playwright, whose browser build numbers can
+# differ from the pinned binding's, and the mismatch surfaces much later, inside a test run, as
+# "Executable doesn't exist at ...". Prefer the driver that shipped with the package.
+#
+# Lives here rather than inline for the same reason as the other two libs: so it is table-tested
+# (scripts/tests/playwright.test.sh). Resolution walks the build output, and a resolver that quietly
+# finds nothing is exactly the kind of thing that becomes a skipped step nobody reads.
+
+# rask_playwright_driver <search-root>
+#
+# Prints two lines — the bundled node binary, then cli.js — and returns 0. Prints nothing and returns 1
+# when either is absent, which is the normal state before the E2E project has been built once.
+rask_playwright_driver() {
+  search_root="$1"
+
+  [ -d "$search_root" ] || return 1
+
+  cli="$(find "$search_root" -path '*/.playwright/package/cli.js' 2>/dev/null | head -1)"
+  [ -n "$cli" ] || return 1
+
+  # .playwright/package/cli.js -> .playwright, then down into node/<rid>/node. The rid directory is
+  # named for the build host, so it is globbed rather than assumed: linux-arm64 in a UTM guest,
+  # darwin-arm64 on an Apple laptop, linux-x64 on a CI box.
+  pw_dir="$(dirname "$(dirname "$cli")")"
+  node="$(find "$pw_dir/node" -type f -name node 2>/dev/null | head -1)"
+  [ -n "$node" ] || return 1
+
+  printf '%s\n%s\n' "$node" "$cli"
+}
+
+# There is deliberately no rask_playwright wrapper that both resolves and runs. Callers need the two
+# steps separated: `set -e` is suspended inside an `if` condition, so a combined helper invoked as
+# `if rask_playwright ... install chromium` would swallow a failed download into the else branch and
+# carry on having installed nothing. Resolve in the condition, run in the body.

--- a/scripts/playwright.sh
+++ b/scripts/playwright.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# The Playwright CLI, driven through the driver Microsoft.Playwright already ships.
+#
+# This is the replacement for `pwsh <path>/playwright.ps1 <args>`. It needs no PowerShell, and it uses
+# the exact driver the binding launches at runtime, so installed browser revisions always match the
+# pinned Microsoft.Playwright. See scripts/lib/playwright.sh for why `npx playwright` is not equivalent.
+#
+#   scripts/playwright.sh install chromium      # what the E2E gate needs
+#   scripts/playwright.sh show-trace <file>     # open a trace from a failed run
+#   scripts/playwright.sh --help
+#
+# Release is preferred over Debug because that is what scripts/run-e2e-local.sh builds; either works.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+# shellcheck source=lib/playwright.sh
+. "$root/scripts/lib/playwright.sh"
+
+for cfg in Release Debug; do
+  if driver="$(rask_playwright_driver "tests/Rask.Examples.E2E.Tests/bin/$cfg")"; then
+    pw_node="$(printf '%s\n' "$driver" | sed -n 1p)"
+    pw_cli="$(printf '%s\n' "$driver" | sed -n 2p)"
+    exec "$pw_node" "$pw_cli" "$@"
+  fi
+done
+
+echo "playwright: no bundled driver under tests/Rask.Examples.E2E.Tests/bin/{Release,Debug}." >&2
+echo "            Build the E2E project once first:" >&2
+echo "              dotnet build tests/Rask.Examples.E2E.Tests -c Release" >&2
+exit 1

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -83,6 +83,9 @@ fi
 # shellcheck source=lib/build-failure.sh
 . "$root/scripts/lib/build-failure.sh"
 
+# shellcheck source=lib/playwright.sh
+. "$root/scripts/lib/playwright.sh"
+
 # The playground publish below needs the native relink (see the note there), which needs the wasm-tools
 # workload + emscripten. Check up front: without it the publish fails several minutes in, with an error
 # about a missing runtime pack rather than about a missing workload.
@@ -197,13 +200,27 @@ dotnet publish samples/Rask.Example.Site -c Release --no-restore -p:WasmBuildNat
 rm -rf samples/Rask.Example.Wasm.Jobs/obj/Release/net10.0-browser
 dotnet publish samples/Rask.Example.Wasm.Jobs -c Release --no-restore --nologo
 
+# This used to shell out to `pwsh <path>/playwright.ps1 install chromium`, and skipped itself whenever
+# pwsh was missing. On Linux that is the common case, not the edge one — PowerShell is in neither
+# Fedora's nor Debian's repositories — so the gate printed a skip notice into thousands of build lines
+# and the suite then failed with a missing-browser error that named the browsers rather than the skip.
+#
+# The ps1 was never doing any work: six lines that load Microsoft.Playwright.dll and call its Main. The
+# package ships the real driver alongside it, so rask_playwright_driver finds that and we run it
+# directly. See scripts/lib/playwright.sh for why `npx playwright install` is not an equivalent shortcut.
 echo "==> Ensure Playwright browsers are installed"
-pw="$(find tests/Rask.Examples.E2E.Tests/bin/Release -name 'playwright.ps1' 2>/dev/null | head -1)"
-if [ -n "$pw" ] && command -v pwsh >/dev/null 2>&1; then
-  pwsh "$pw" install chromium
+# Resolve in the condition, install in the body — deliberately, not stylistically. `set -e` is suspended
+# inside an `if` condition, so running the install there would swallow a failed download into the else
+# branch and let the gate continue having installed nothing. Only the lookup belongs in the condition,
+# where "not found" genuinely is not fatal; the install then runs under `set -e` and stops the gate.
+if pw_driver="$(rask_playwright_driver tests/Rask.Examples.E2E.Tests/bin/Release)"; then
+  pw_node="$(printf '%s\n' "$pw_driver" | sed -n 1p)"
+  pw_cli="$(printf '%s\n' "$pw_driver" | sed -n 2p)"
+  "$pw_node" "$pw_cli" install chromium
 else
-  echo "   (skipped auto-install: pwsh or playwright.ps1 not found — install browsers manually if the run"
-  echo "    fails with a missing-browser error: 'pwsh <path>/playwright.ps1 install chromium')"
+  echo "   (skipped auto-install: no bundled Playwright driver under"
+  echo "    tests/Rask.Examples.E2E.Tests/bin/Release — build the E2E project once, then:"
+  echo "      scripts/playwright.sh install chromium)"
 fi
 
 # RASK_E2E_FILTER narrows the run while you are iterating on ONE journey. The publishes above still

--- a/scripts/tests/playwright.test.sh
+++ b/scripts/tests/playwright.test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Table test for rask_playwright_driver (scripts/lib/playwright.sh).
+#
+# This resolver decides whether the browser gate installs anything at all. Its failure mode is the quiet
+# one: return nothing, the caller prints a skip notice into thousands of build lines, and the suite dies
+# minutes later with a missing-browser error that points at the browsers rather than at the resolver.
+# That is precisely what the pwsh check it replaced used to do on any Linux box without PowerShell.
+#
+# So both directions are stated here rather than left to whatever layout someone happened to build:
+# a find that is too loose would match a stale nested copy, and one that is too strict would miss the
+# rid directory, which is named for the build host and differs on every machine this runs on.
+#
+# Usage:  scripts/tests/playwright.test.sh   (run by scripts/run-unit-local.sh)
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+# shellcheck source=../lib/playwright.sh
+. "$root/scripts/lib/playwright.sh"
+
+failures=0
+checked=0
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# fixture <dir> <rid> — lay down a build output that looks like Microsoft.Playwright's.
+fixture() {
+  mkdir -p "$tmp/$1/.playwright/package" "$tmp/$1/.playwright/node/$2"
+  : > "$tmp/$1/.playwright/package/cli.js"
+  : > "$tmp/$1/.playwright/node/$2/node"
+  chmod +x "$tmp/$1/.playwright/node/$2/node"
+}
+
+# assert_ok <name> <search-root> <expected-node-suffix> <expected-cli-suffix>
+assert_ok() {
+  name="$1"
+  out="$(rask_playwright_driver "$tmp/$2" || true)"
+  got_node="$(printf '%s\n' "$out" | sed -n 1p)"
+  got_cli="$(printf '%s\n' "$out" | sed -n 2p)"
+  checked=$((checked + 1))
+
+  case "$got_node" in *"$3") node_ok=1 ;; *) node_ok=0 ;; esac
+  case "$got_cli"  in *"$4") cli_ok=1  ;; *) cli_ok=0  ;; esac
+
+  if [ "$node_ok" = 1 ] && [ "$cli_ok" = 1 ]; then
+    printf '  ok   %-52s -> %s\n' "$name" "${got_node##*/.playwright/}"
+  else
+    printf '  FAIL %-52s -> node[%s] cli[%s]\n' "$name" "$got_node" "$got_cli" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+# assert_absent <name> <search-root> — resolver must fail, and print nothing.
+assert_absent() {
+  name="$1"
+  checked=$((checked + 1))
+
+  if out="$(rask_playwright_driver "$tmp/$2")"; then
+    printf '  FAIL %-52s -> resolved [%s], expected failure\n' "$name" "$(printf '%s' "$out" | tr '\n' ' ')" >&2
+    failures=$((failures + 1))
+  elif [ -n "$out" ]; then
+    printf '  FAIL %-52s -> failed but printed [%s]\n' "$name" "$out" >&2
+    failures=$((failures + 1))
+  else
+    printf '  ok   %-52s -> not found\n' "$name"
+  fi
+}
+
+echo "==> rask_playwright_driver"
+
+# The three rid directories this actually runs on. The rid is never assumed, so each is stated.
+fixture linux-guest   linux-arm64
+assert_ok "linux-arm64 (the UTM guest)"        linux-guest   "/node/linux-arm64/node"  "/package/cli.js"
+
+fixture mac-laptop    darwin-arm64
+assert_ok "darwin-arm64 (an Apple laptop)"     mac-laptop    "/node/darwin-arm64/node" "/package/cli.js"
+
+fixture ci-box        linux-x64
+assert_ok "linux-x64 (a CI box)"               ci-box        "/node/linux-x64/node"    "/package/cli.js"
+
+# Nested under a TFM directory, which is where it really lives: bin/Release/net10.0/.playwright/...
+mkdir -p "$tmp/nested/bin/Release/net10.0"
+fixture "nested/bin/Release/net10.0" linux-arm64
+assert_ok "nested under bin/Release/net10.0"   nested        "/node/linux-arm64/node"  "/package/cli.js"
+
+# Negative cases. Each one used to be a silent skip.
+assert_absent "search root does not exist"     no-such-dir
+
+mkdir -p "$tmp/empty"
+assert_absent "build output with no .playwright" empty
+
+mkdir -p "$tmp/no-node/.playwright/package"
+: > "$tmp/no-node/.playwright/package/cli.js"
+assert_absent "cli.js present but no node driver" no-node
+
+mkdir -p "$tmp/no-cli/.playwright/node/linux-arm64"
+: > "$tmp/no-cli/.playwright/node/linux-arm64/node"
+assert_absent "node driver present but no cli.js" no-cli
+
+echo "==> the resolved driver is runnable"
+
+# The two lines are a node binary and a cli.js in that order, and callers invoke them as `$node $cli`.
+# A shell script standing in for the node binary proves the pair comes back the right way round — a
+# resolver that swapped them would still pass every assertion above.
+mkdir -p "$tmp/runnable/.playwright/package" "$tmp/runnable/.playwright/node/linux-arm64"
+: > "$tmp/runnable/.playwright/package/cli.js"
+printf '#!/bin/sh\necho "ARGS:$*"\n' > "$tmp/runnable/.playwright/node/linux-arm64/node"
+chmod +x "$tmp/runnable/.playwright/node/linux-arm64/node"
+
+checked=$((checked + 1))
+driver="$(rask_playwright_driver "$tmp/runnable")"
+got="$("$(printf '%s\n' "$driver" | sed -n 1p)" "$(printf '%s\n' "$driver" | sed -n 2p)" install chromium)"
+case "$got" in
+  *"cli.js install chromium")
+    printf '  ok   %-52s -> %s\n' "node first, cli.js second, args appended" "ARGS:...${got##*/}" ;;
+  *)
+    printf '  FAIL %-52s -> [%s]\n' "node first, cli.js second, args appended" "$got" >&2
+    failures=$((failures + 1)) ;;
+esac
+
+if [ "$failures" -ne 0 ]; then
+  printf '\n%d of %d checks failed\n' "$failures" "$checked" >&2
+  exit 1
+fi
+printf '\n%d checks passed\n' "$checked"

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.cs
@@ -238,7 +238,7 @@ public abstract partial class SharedSmokeTests : IAsyncLifetime
             var path = Path.Combine(TestArtifacts.DirectoryFor(FixtureName, testName), "trace.zip");
             await _ctx.Tracing.StopAsync(new TracingStopOptions { Path = path });
             Console.WriteLine($"  trace: {path}");
-            Console.WriteLine($"    open with: pwsh <playwright.ps1> show-trace {path}");
+            Console.WriteLine($"    open with: scripts/playwright.sh show-trace {path}");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Closes #867.

## Summary

`scripts/run-e2e-local.sh` installed the Playwright browsers by shelling out to
`pwsh <path>/playwright.ps1 install chromium`, and skipped that step whenever `pwsh` was absent.

PowerShell is in neither Fedora's nor Debian's repositories, so on a Linux dev box the skip was the
ordinary path rather than the edge case. The notice it printed landed in the middle of the thousands
of build lines the gate emits from `.githooks/pre-push`, and the suite then failed minutes later with
a missing-browser error — naming the browsers rather than the install that never ran. One indirection
between symptom and cause, in the part of the output nobody rereads.

The dependency was never real. `playwright.ps1` is six lines that set a search path, load
`Microsoft.Playwright.dll` and call its `Main`. The same package lays down
`.playwright/node/<rid>/node` beside `.playwright/package/cli.js` — the driver the binding itself
launches at runtime — so the CLI can be invoked directly with no shell in between.

Going to the bundled driver is the **version-correct** route rather than a workaround: it installs the
browser revisions the pinned `Microsoft.Playwright` asks for. `npx playwright install` is the tempting
substitute and is not equivalent — npx resolves the newest Playwright, whose browser build numbers can
differ, and the mismatch surfaces inside a test run as `Executable doesn't exist`.

## Changes

- **`scripts/lib/playwright.sh`** — `rask_playwright_driver <search-root>` prints the bundled node
  binary and `cli.js`, or fails cleanly. The rid directory is globbed, never assumed: `linux-arm64` in
  a Linux VM, `darwin-arm64` on an Apple laptop, `linux-x64` on CI.
- **`scripts/playwright.sh`** — the human-facing wrapper, and the direct replacement for
  `pwsh playwright.ps1 <args>`: `scripts/playwright.sh install chromium`,
  `scripts/playwright.sh show-trace <file>`.
- **`scripts/run-e2e-local.sh`** — uses the resolver. It resolves in the `if` condition and installs in
  the body, deliberately: `set -e` is suspended inside a condition, so running the install there would
  have swallowed a failed download into the `else` branch and let the gate continue having installed
  nothing. The old code had the same shape and the same latent hole.
- **`SharedSmokeTests.cs`** — the post-failure hint now points at `scripts/playwright.sh show-trace`,
  so the recovery path from a red run does not ask for PowerShell either.
- **`.claude/skills/run-rask/SKILL.md`** — same correction.

There is deliberately no combined `rask_playwright` helper that resolves *and* runs. Both real call
sites need the steps separated — one `exec`s, the other needs `set -e` to apply to the install — and a
combined helper invoked from an `if` condition would reintroduce exactly the hole described above.

## Testing

- `scripts/tests/playwright.test.sh` — new table test, 9 checks: the three rid directories, the real
  nested `bin/Release/net10.0` layout, all four ways the lookup can come back empty, and that the two
  resolved lines come back in the order callers invoke them (a resolver that swapped node and cli.js
  would otherwise pass every other assertion). Picked up automatically by `run-unit-local.sh`, which
  globs `scripts/tests/*.test.sh`.
- `scripts/run-unit-local.sh` — **391/391 passed**, format clean (0 of 47 files in the changed project).
- End-to-end against real build output, no PowerShell present: `scripts/playwright.sh --version` →
  `Version 1.62.0`, and `scripts/playwright.sh install chromium` → exit 0, which is the exact command
  the gate now runs.
- The not-yet-built path was checked too: it exits 1 and names the build command, rather than
  succeeding silently.

No benchmarks: this is gate tooling, nothing on the render or live-runtime hot path.

## Changelog

`[Unreleased] → Fixed`.
