### PR TITLE
refactor(core): move the quiescence wave loop out of the server host

### DIFF
--- a/src/Rask.Core/Live/QuiescentRender.cs
+++ b/src/Rask.Core/Live/QuiescentRender.cs
@@ -1,0 +1,107 @@
+namespace Rask.Core.Live;
+
+/// <summary>
+///     The outcome of a render driven to quiescence.
+/// </summary>
+/// <param name="Html">The markup as it stood when the last wave finished.</param>
+/// <param name="TimedOut">
+///     Whether a wave gave up before its work settled — the page is being served incomplete.
+/// </param>
+/// <param name="Waves">How many extra waves ran after the first render. Zero means it settled at once.</param>
+public readonly record struct QuiescentRenderResult(string Html, bool TimedOut, int Waves);
+
+/// <summary>
+///     Renders in waves until the page's async work has settled, or a budget runs out.
+/// </summary>
+/// <remarks>
+///     <para>
+///         A component that loads its data in <c>OnMountAsync</c> renders its placeholder first and its
+///         data only once the hook resolves. Rendering once and serving that is how a page ships
+///         "Loading…" as the whole document a crawler sees. This renders, waits for the work that render
+///         started, renders again, and repeats — because resolved data mounts new components, which start
+///         work of their own that a single wait would miss entirely.
+///     </para>
+///     <para>
+///         <b>Host-agnostic on purpose.</b> What differs between hosts is how a page is rendered and what
+///         makes its work impossible to finish — not the shape of the loop. Both arrive as callbacks, so
+///         the same waves drive a server's first response and a build-time prerender of an app that has
+///         no server at all.
+///     </para>
+/// </remarks>
+public static class QuiescentRender
+{
+    /// <summary>
+    ///     Bounds a pathological render whose every wave starts new work, so the response cannot grow
+    ///     without limit.
+    /// </summary>
+    public const int DefaultMaxWaves = 16;
+
+    /// <summary>
+    ///     Drives <paramref name="renderWave" /> until nothing is pending, the budget expires, or
+    ///     <paramref name="maxWaves" /> is reached.
+    /// </summary>
+    /// <param name="renderWave">
+    ///     Renders the page and returns its markup. The argument is <c>publishOnly</c>: <c>false</c> for
+    ///     the first wave and <c>true</c> for every wave after it.
+    ///     <para>
+    ///         <b>Honouring it is mandatory.</b> A re-render that is not publish-only re-fires
+    ///         <c>OnRendered</c> on every component that already rendered, so each wave multiplies the
+    ///         lifecycle callbacks of the one before it.
+    ///     </para>
+    /// </param>
+    /// <param name="budget">
+    ///     How long the waves may take in total — one deadline for the whole render, not per wave.
+    /// </param>
+    /// <param name="isBlocked">
+    ///     Asked before each wait: does something make the pending work impossible to finish here?
+    ///     Waiting then buys nothing and costs the whole budget. A server answering a <c>GET</c> passes
+    ///     "is a JavaScript call queued", because that call completes only once a socket exists. Omitted,
+    ///     nothing is ever considered blocked.
+    /// </param>
+    /// <param name="maxWaves">Wave cap. Defaults to <see cref="DefaultMaxWaves" />.</param>
+    /// <returns>The final markup, whether it settled, and how many extra waves it took.</returns>
+    public static async Task<QuiescentRenderResult> RunAsync(
+        Func<bool, string> renderWave,
+        TimeSpan budget,
+        Func<bool>? isBlocked = null,
+        int maxWaves = DefaultMaxWaves)
+    {
+        ArgumentNullException.ThrowIfNull(renderWave);
+
+        using var quiescence = QuiescenceScope.Begin();
+        var html = renderWave(false);
+
+        var deadline = DateTime.UtcNow + budget;
+        var waves = 0;
+
+        while (quiescence.TrySnapshotPending(out var batch))
+        {
+            if (isBlocked?.Invoke() == true)
+            {
+                break;
+            }
+
+            var remaining = deadline - DateTime.UtcNow;
+            if (remaining <= TimeSpan.Zero || waves >= maxWaves)
+            {
+                quiescence.MarkTimedOut();
+                break;
+            }
+
+            try
+            {
+                await Task.WhenAll(batch).WaitAsync(remaining).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                quiescence.MarkTimedOut();
+                break;
+            }
+
+            html = renderWave(true);
+            waves++;
+        }
+
+        return new QuiescentRenderResult(html, quiescence.TimedOut, waves);
+    }
+}

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -446,50 +446,26 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
             return RenderInitialRoot();
         }
 
-        using var quiescence = QuiescenceScope.Begin();
-        var html = RenderRootWave(publishOnly: false);
-
-        var deadline = DateTime.UtcNow + budget;
-        var waves = 0;
-        while (quiescence.TrySnapshotPending(out var batch))
-        {
+        // The waves themselves are host-agnostic and live in Core, so a build-time prerender of an app
+        // with no server at all runs the same loop. What is server-specific is the two arguments below.
+        var result = await QuiescentRender.RunAsync(
+            RenderRootWave,
+            budget,
             // Work blocked on JavaScript cannot finish here, so waiting for it only burns the
             // budget. A JS call made during a render queues onto a frame, and during the GET there
             // is no client to send that frame to — the awaiting task completes once the socket is
             // up, never before. A hook that reads browser storage to restore a session is exactly
             // this shape, and it is idiomatic enough to appear in the framework's own auth sample.
             //
-            // Stopping here costs nothing that waiting would have bought: the same page is already
+            // Stopping there costs nothing that waiting would have bought: the same page is already
             // marked interactive by the interop itself, so it keeps its session and finishes over
             // the socket precisely as it did before any of this existed.
-            if (JsInvokes.HasPending)
-            {
-                break;
-            }
+            isBlocked: () => JsInvokes.HasPending).ConfigureAwait(false);
 
-            var remaining = deadline - DateTime.UtcNow;
-            if (remaining <= TimeSpan.Zero || waves >= MaxQuiescenceWaves)
-            {
-                quiescence.MarkTimedOut();
-                break;
-            }
+        var html = result.Html;
 
-            try
-            {
-                await Task.WhenAll(batch).WaitAsync(remaining).ConfigureAwait(false);
-            }
-            catch (TimeoutException)
-            {
-                quiescence.MarkTimedOut();
-                break;
-            }
-
-            html = RenderRootWave(publishOnly: true);
-            waves++;
-        }
-
-        LastRenderTimedOut = quiescence.TimedOut;
-        if (quiescence.TimedOut)
+        LastRenderTimedOut = result.TimedOut;
+        if (result.TimedOut)
         {
             // The page is going out with work still in flight, so it MUST keep a live session:
             // served as a plain document it would sit on its placeholder for ever, with nothing
@@ -534,11 +510,6 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
         _renderCache?.Snapshot(); // promote GET frames to the diff baseline
         SeedInitialHtml(html);
     }
-
-    // Bounds a pathological render whose every wave keeps starting new work. Mirrors the coalescing
-    // loop's budget: past this the page is promoted to interactive and the live session finishes
-    // the job, rather than the response growing without limit.
-    private const int MaxQuiescenceWaves = 16;
 
     /// <summary>
     ///     Whether the last render fell back to the framework's error page rather than the app.

--- a/tests/Rask.Core.Tests/Live/QuiescentRenderTests.cs
+++ b/tests/Rask.Core.Tests/Live/QuiescentRenderTests.cs
@@ -1,0 +1,132 @@
+using Rask.Core.Live;
+
+namespace Rask.Core.Tests.Live;
+
+// The wave loop, driven with no host at all — which is the whole reason it moved into Core. A server
+// answering a GET and a build-time prerender of an app that has no server want identical behaviour, and
+// before this they could not share it.
+public class QuiescentRenderTests
+{
+    [Fact]
+    public async Task WorkStartedByARenderIsAwaitedAndTheNextWaveIsReturned()
+    {
+        QuiescenceScope.ResetSyncForTests();
+        var gate = new TaskCompletionSource();
+        var ready = false;
+
+        var result = await QuiescentRender.RunAsync(
+            _ =>
+            {
+                if (!ready)
+                {
+                    // What OnMountAsync does: start work, render the placeholder meanwhile.
+                    QuiescenceScope.Current!.TrackExternal(Settle(gate, () => ready = true));
+                    return "loading";
+                }
+
+                return "loaded";
+            },
+            TimeSpan.FromSeconds(5));
+
+        Assert.Equal("loaded", result.Html);
+        Assert.False(result.TimedOut);
+        Assert.Equal(1, result.Waves);
+    }
+
+    [Fact]
+    public async Task TheFirstWaveIsNotPublishOnlyAndEveryLaterOneIs()
+    {
+        // Honouring this is what stops each wave re-firing OnRendered on everything the previous wave
+        // already rendered, which multiplies lifecycle callbacks per wave rather than adding to them.
+        QuiescenceScope.ResetSyncForTests();
+        var seen = new List<bool>();
+        var rounds = 0;
+
+        await QuiescentRender.RunAsync(
+            publishOnly =>
+            {
+                seen.Add(publishOnly);
+                if (rounds++ < 2)
+                {
+                    QuiescenceScope.Current!.TrackExternal(Task.Delay(1));
+                }
+
+                return "html";
+            },
+            TimeSpan.FromSeconds(5));
+
+        Assert.Equal([false, true, true], seen);
+    }
+
+    [Fact]
+    public async Task WorkThatNeverSettlesGivesUpOnTheBudgetAndSaysSo()
+    {
+        // The caller has to know: a page served with work still in flight cannot be a static document,
+        // because nothing is left running that would ever replace its placeholder.
+        QuiescenceScope.ResetSyncForTests();
+
+        var result = await QuiescentRender.RunAsync(
+            _ =>
+            {
+                QuiescenceScope.Current!.TrackExternal(new TaskCompletionSource().Task);
+                return "still-loading";
+            },
+            TimeSpan.FromMilliseconds(120));
+
+        Assert.True(result.TimedOut);
+        Assert.Equal("still-loading", result.Html);
+    }
+
+    [Fact]
+    public async Task BlockedWorkIsNotWaitedFor()
+    {
+        // Waiting for work that cannot complete here spends the entire budget to learn nothing. The
+        // server's case is a queued JS call, which completes only once a socket exists — so this must
+        // return promptly rather than after the budget, and must NOT be reported as a timeout.
+        QuiescenceScope.ResetSyncForTests();
+        var started = DateTime.UtcNow;
+
+        var result = await QuiescentRender.RunAsync(
+            _ =>
+            {
+                QuiescenceScope.Current!.TrackExternal(new TaskCompletionSource().Task);
+                return "blocked";
+            },
+            TimeSpan.FromSeconds(30),
+            isBlocked: () => true);
+
+        Assert.True(DateTime.UtcNow - started < TimeSpan.FromSeconds(5), "it waited for work it was told could not finish");
+        Assert.False(result.TimedOut);
+        Assert.Equal("blocked", result.Html);
+    }
+
+    [Fact]
+    public async Task ARenderWhoseEveryWaveStartsMoreWorkIsCapped()
+    {
+        // Otherwise a page that always has something pending renders until the budget, and the response
+        // grows with every wave.
+        QuiescenceScope.ResetSyncForTests();
+        var waves = 0;
+
+        var result = await QuiescentRender.RunAsync(
+            _ =>
+            {
+                waves++;
+                QuiescenceScope.Current!.TrackExternal(Task.Delay(1));
+                return "endless";
+            },
+            TimeSpan.FromSeconds(30),
+            maxWaves: 3);
+
+        Assert.True(result.TimedOut);
+        Assert.Equal(3, result.Waves);
+        Assert.Equal(4, waves); // the first render, then three capped waves
+    }
+
+    private static async Task Settle(TaskCompletionSource gate, Action then)
+    {
+        gate.TrySetResult();
+        await gate.Task.ConfigureAwait(false);
+        then();
+    }
+}


### PR DESCRIPTION
The loop that renders, waits for the work that render started, and renders again lived in
`Rask.Server.LiveSession` — not because it is server-specific, but because the server is where it was
first needed.

It is pure control flow over two questions: **how do I render this**, and **is the pending work
impossible to finish here**. Both are now callbacks on `Rask.Core.Live.QuiescentRender`, so the same
waves can drive a server's first response and a build-time prerender of an app that has no server at
all.

## Why now

The standalone `wasm` template ships a boot shell — a spinner and the word "Loading" — as the first
thing every visitor and every crawler receives, including for this framework's own docs site on GitHub
Pages. Prerendering it at publish time needs exactly these waves: a page whose `OnMountAsync` loads
build-time data has to write the data, not its placeholder. Before this, that behaviour could not be
reached without taking a dependency on the server host.

## Behaviour

Unchanged. The server's reasoning stays at the server's call site — the JS-interop check reads as an
argument rather than as a branch inside a shared loop, with the comment explaining why waiting for a
queued JS call buys nothing during a `GET` still sitting next to it.

## Tests

The new Core tests drive the loop with no host, which is the thing that could not be tested before.
Two of them pin subtleties worth keeping:

- `publishOnly` must be `false` on the first wave and `true` after. A re-render that is not
  publish-only re-fires `OnRendered` on everything the previous wave rendered, so each wave multiplies
  the lifecycle callbacks of the one before it rather than adding to them.
- The wave cap has to be reachable independently of the budget.

One of them also cost a wrong first draft, which is worth recording: **`TrackExternal` dedupes by task
identity**, and `Task.CompletedTask` is a singleton — so registering it twice registers once, and it is
useless as stand-in pending work. The cap test silently exited after one wave until the tasks were made
distinct.

## Not fixed here

`Get_AwaitsWorkStartedByAResolvedWave` still fails intermittently under full-suite load — see #870.
That predates this change and is unaffected by it: the assembly passes 391/391 three runs in a row
after the move.
