### PR TITLE
fix(core): let the running flow's quiescence scope beat a live one left on the thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+
+- **A render could hand its async work to a different render, and then serve a placeholder for it.**
+  `QuiescenceScope.Current` consulted the thread-static slot before the flow's `AsyncLocal`. A pool
+  thread keeps whatever scope `Begin` set on it — only a `Dispose` that happens to run on that same
+  thread clears it — so a thread can carry another render's **live** scope. When a render's later wave
+  resumed on such a thread, the work it started was tracked against a stranger, its own wave loop saw
+  nothing pending, and the page went out with a placeholder for data it never waited for.
+
+  It answers `200` while doing it, so nothing reports a fault. In tests it surfaced as an intermittent
+  failure that passed every time in isolation; in production it is the SSR path failing silently.
+
+  The flow now wins over the thread. Nothing needed the other order: the one path that loses the
+  `AsyncLocal` — `LifecycleSyncContext`'s suppressed `Task.Run` — restores the captured scope with
+  `Enter`, which sets both slots. `LiveRenderContext` already resolved this way; `QuiescenceScope` had
+  diverged from it.
+
+  Supersedes the earlier fix for the same symptom, which skipped *disposed* foreign scopes. That was
+  necessary and not sufficient — it covered the dead case, this covers the live one.
+
+
+### Fixed
 - **The browser gate no longer needs PowerShell, and no longer skips itself quietly when it is
   missing.** `scripts/run-e2e-local.sh` installed the Playwright browsers by shelling out to
   `pwsh <path>/playwright.ps1 install chromium`, and skipped that step whenever `pwsh` was absent.

--- a/src/Rask.Core/Live/QuiescenceScope.cs
+++ b/src/Rask.Core/Live/QuiescenceScope.cs
@@ -41,34 +41,62 @@ internal sealed class QuiescenceScope : IDisposable
 
     /// <summary>The scope collecting work for the render currently running, if any.</summary>
     /// <remarks>
-    ///     A disposed scope is never current, and reading past one clears it. <see cref="Dispose" />
-    ///     can only clear the thread-static slot on the thread it happens to run on, and after an
-    ///     <c>await</c> that is routinely not the thread <see cref="Begin" /> ran on — so a finished
-    ///     pass leaves its scope visible to whatever renders on that pool thread next.
     ///     <para>
-    ///         The damage is silent rather than loud: work started by the next render is tracked into
-    ///         the dead scope while that render's own wave loop waits on its own, empty, set. It then
-    ///         serves a placeholder for data it never waited for — intermittently, and only under
-    ///         enough concurrency to recycle threads across renders, which is why it presents as a
-    ///         flaky test rather than as a bug.
+    ///         <b>The flow wins over the thread.</b> The <c>AsyncLocal</c> belongs to the render that is
+    ///         actually running here; the <c>ThreadStatic</c> is a fallback for code that crossed an
+    ///         <see cref="ExecutionContext.SuppressFlow" /> boundary. Consulting the thread first means a
+    ///         pool thread still carrying a DIFFERENT, live render's scope shadows this one — and the
+    ///         work this render started is then tracked against a stranger, while this render's own loop
+    ///         sees nothing pending and serves a placeholder for data it never waited for. It answers
+    ///         200 while doing it, so nothing anywhere reports a fault.
+    ///     </para>
+    ///     <para>
+    ///         Nothing needs the thread to win. The one path that loses the <c>AsyncLocal</c> —
+    ///         <c>LifecycleSyncContext</c>'s suppressed <c>Task.Run</c> — restores the captured scope
+    ///         with <see cref="Enter" />, which sets both slots, so the flow lookup finds it there too.
+    ///     </para>
+    ///     <para>
+    ///         A disposed scope is never current either, and reading past one clears it.
+    ///         <see cref="Dispose" /> can only clear the thread-static slot on the thread it happens to
+    ///         run on, and after an <c>await</c> that is routinely not the thread <see cref="Begin" />
+    ///         ran on — so a finished pass would otherwise stay visible to whatever renders on that pool
+    ///         thread next.
     ///     </para>
     /// </remarks>
     internal static QuiescenceScope? Current
     {
         get
         {
-            if (_syncCurrent is { } sync)
-            {
-                if (!sync._disposed)
-                {
-                    return sync;
-                }
+            var resolved = Resolve(_asyncCurrent.Value, _syncCurrent);
 
+            // Reading past a dead thread slot clears it, so the leak heals on first contact rather
+            // than persisting for the life of the thread.
+            if (_syncCurrent is { _disposed: true })
+            {
                 _syncCurrent = null;
             }
 
-            return _asyncCurrent.Value is { _disposed: false } async ? async : null;
+            return resolved;
         }
+    }
+
+    /// <summary>
+    ///     Which of the two slots a lookup should use, given what each holds.
+    /// </summary>
+    /// <remarks>
+    ///     Named so the rule can be asserted directly. The situation it exists for — this thread holding
+    ///     another render's LIVE scope while the flow carries our own — needs two renders interleaved on
+    ///     one pool thread, which is not something a test can arrange deterministically. The rule is the
+    ///     fix, so the rule is what is pinned.
+    /// </remarks>
+    internal static QuiescenceScope? Resolve(QuiescenceScope? flow, QuiescenceScope? thread)
+    {
+        if (flow is { _disposed: false })
+        {
+            return flow;
+        }
+
+        return thread is { _disposed: false } ? thread : null;
     }
 
     /// <summary>

--- a/tests/Rask.Core.Tests/Live/QuiescenceScopeStaleThreadTests.cs
+++ b/tests/Rask.Core.Tests/Live/QuiescenceScopeStaleThreadTests.cs
@@ -15,6 +15,50 @@ namespace Rask.Core.Tests.Live;
 public class QuiescenceScopeStaleThreadTests
 {
     [Fact]
+    public void TheRunningFlowsScopeBeatsALiveOneLeftOnTheThread()
+    {
+        // The bug this exists for. A pool thread can still hold ANOTHER render's scope — Begin sets the
+        // thread slot, and only a Dispose that happens to run on that same thread clears it. If the
+        // thread won, this render's work would be tracked against a stranger's scope, this render's own
+        // wave loop would see nothing pending, and the page would be served with a placeholder for data
+        // it never waited for — answering 200 while doing it.
+        //
+        // Nothing needs the thread to win: the one path that loses the AsyncLocal (LifecycleSyncContext's
+        // suppressed Task.Run) restores the captured scope with Enter, which sets both slots.
+        QuiescenceScope.ResetSyncForTests();
+        using var mine = QuiescenceScope.Begin();
+        using var stranger = QuiescenceScope.Begin();
+
+        Assert.Same(mine, QuiescenceScope.Resolve(flow: mine, thread: stranger));
+    }
+
+    [Fact]
+    public void TheThreadIsUsedWhenTheFlowCarriesNothing()
+    {
+        // The reason the thread slot exists at all: code that crossed an ExecutionContext.SuppressFlow
+        // boundary has no AsyncLocal to read. Preferring the flow must not mean ignoring the thread.
+        QuiescenceScope.ResetSyncForTests();
+        using var thread = QuiescenceScope.Begin();
+
+        Assert.Same(thread, QuiescenceScope.Resolve(flow: null, thread: thread));
+    }
+
+    [Fact]
+    public void ADeadScopeInEitherSlotIsNeverResolved()
+    {
+        QuiescenceScope.ResetSyncForTests();
+        var deadFlow = QuiescenceScope.Begin();
+        deadFlow.Dispose();
+        var liveThread = QuiescenceScope.Begin();
+
+        // A finished render must not keep collecting, whichever slot still points at it.
+        Assert.Same(liveThread, QuiescenceScope.Resolve(deadFlow, liveThread));
+        Assert.Null(QuiescenceScope.Resolve(deadFlow, deadFlow));
+
+        liveThread.Dispose();
+    }
+
+    [Fact]
     public void ADisposedScopeIsNotCurrent()
     {
         QuiescenceScope.ResetSyncForTests();


### PR DESCRIPTION
Closes #870.

`QuiescenceScope.Current` consulted the thread-static slot before the flow's `AsyncLocal`. A pool
thread keeps whatever scope `Begin` set on it — only a `Dispose` that happens to run on *that same
thread* clears it — so a thread can be carrying **another render's live scope**. When a render's later
wave resumed there, the work it started was tracked against a stranger, its own wave loop saw nothing
pending, and the page went out with a placeholder for data it never waited for.

It answers `200` while doing it, so nothing reports a fault. In the suite it looked like a flaky test;
in production it is the SSR path failing silently.

## The hypothesis in the issue was wrong

Registration is not late. `Track` runs **synchronously inside the render walk**, immediately after the
hook returns. The question was never *when* the work is registered but *which scope receives it*.

## Why flow-first is safe

Nothing needed the thread to win. The one path that loses the `AsyncLocal` —
`LifecycleSyncContext`'s suppressed `Task.Run` — restores the captured scope with `Enter`, which sets
**both** slots, so a flow-first lookup finds it there too.

`LiveRenderContext` already resolves this way: its `Current` is `AsyncLocal`-only, with the
thread-static a separately named accessor guarded by `IsActive`. `QuiescenceScope` had simply diverged
from its sibling.

## Supersedes the earlier fix

#865 fixed the same symptom by skipping *disposed* foreign scopes. That was necessary and not
sufficient: it covered the dead case, this covers the live one.

## Evidence, stated honestly

Eight full-gate runs are clean, against a prior rate of roughly one in six. That is **support, not
proof** — eight clean runs would happen by luck about a quarter of the time at that rate. The weight
sits on the mechanism being named and the rule being pinned by tests, mutation-checked by reversing
the precedence.

Two earlier verification attempts proved nothing, and are recorded in the commit so they are not
repeated:

- **The server suite alone has never reproduced this.** Only the full-solution gate has — the symptom
  needs that parallel load. Runs against the suite alone were measuring nothing.
- **A grep for the test name matches the passing lines too.** The first detector reported 8/8
  "failures" that were all passes.

## Also found, filed separately

`RenderModeAttributeTests.APageDeclaringStaticThatNeedsAConnection_KeepsItAndSaysSo` is a *different*
intermittent in the same assembly — measured at 1 of 8 on pristine `main`, so pre-existing and
unrelated. Seven test classes race on the process-global `RaskDiagnostics.Sink`, and it fails open.
See #874.
