### PR TITLE
fix(build): enforce the generated-task ordering at every call site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
-- **The TypeScript task assembly is now built before the targets that invoke it.** `main` went red
-  at #871: `pages` and `nightly` both failed with MSB4062 — the `ResolveTypeScriptToolTask` "could
-  not be loaded" from `src/Rask.Core/build/Rask.TypeScript.Tasks.dll` — and each took a downstream
-  job with it, so the docs site stopped deploying and no nightly prerelease was published
+- **Targets that invoke a generated MSBuild task now wait for the reference that produces it.**
+  `main` went red at #871: `pages` and `nightly` both failed with MSB4062 — the
+  `ResolveTypeScriptToolTask` "could not be loaded" from
+  `src/Rask.Core/build/Rask.TypeScript.Tasks.dll` — and each took a downstream job with it, so the
+  docs site stopped deploying and no nightly prerelease was published
   ([#878](https://github.com/pal-tamas/rask/issues/878)).
 
   The `UsingTask` registration was not the problem; the build-order edge was. `Rask.Wasm ->
@@ -22,11 +23,31 @@ them until tagged releases begin.
   `DependsOnTargets="ResolveProjectReferences"`, which is the dependency they always had.
 
   The DLL is generated and gitignored, so this only ever reproduced on a tree that had never built —
-  and the failed build left the DLL behind, so re-running the identical command passed. That is what
-  kept it invisible: the local gates build the solution, where MSBuild orders the task project ahead
-  of `Rask.Wasm`, and `ci.yml` builds only the two benchmark projects and references no WASM host at
-  all. Only a single-project `dotnet publish` from a clean tree — what `pages` and
-  `nightly/aot-publish` run — could see it.
+  and the failed build left the DLL behind, so re-running the identical command passed. Solution
+  builds order the task project ahead of its consumers, so every local gate was green. `ci.yml` was
+  green too, but *not* because it never reached the bug: it builds `Rask.Benchmarks`, which
+  references `Rask.Server` and so ran a broken call site on every clean-tree run. It won the race —
+  MSBuild happened to schedule `Rask.Core` (and through it the task project) ahead of `Rask.Server`
+  within the same reference batch. That is scheduling luck under a parallel build, not immunity, and
+  it is why the same commit could be green on `ci` and red on `pages`.
+
+  Fixing only the five sites would have left the rest of the pattern standing, so the invariant is
+  now enforced over all of it by
+  `PackagingContractTests.Every_generated_task_call_site_waits_for_the_reference_that_produces_it`.
+  It derives the guarded task names from the `UsingTask` declarations that load a `*.Tasks.dll` from
+  their own directory — the four generated task assemblies (`Rask.TypeScript.Tasks`,
+  `Rask.Tailwind.Tasks`, `Rask.Wasm.Tasks`, `Rask.Spa.Tasks`) — and scans the whole repository, since
+  a hand-written list of either names or directories rots. That widening earned its keep immediately:
+  it found three further call sites outside `src/`, in the `Rask.Core.Tests`, `Rask.Wasm.Tests` and
+  `Rask.Examples.E2E.Tests` fixture bundlers.
+
+  It also found a live one. `_RaskTailwindResolve` invokes `ResolveTailwindCliTask` from the equally
+  generated `Rask.Tailwind.Tasks.dll`, and its only caller runs at `BeforeTargets="BeforeBuild"` —
+  ahead of `CoreBuild`, so ahead of reference resolution. It has never bitten because nothing in-repo
+  imports `Rask.Tailwind.targets`; it would have, the first time anything did. All twelve call sites
+  now state the dependency, whether it is load-bearing there or merely true, because an exemption for
+  the ones a caller happens to order safely makes the invariant depend on a fact about a different
+  target. The guard was verified by failing it in both directions.
 - **The browser gate no longer needs PowerShell, and no longer skips itself quietly when it is
   missing.** `scripts/run-e2e-local.sh` installed the Playwright browsers by shelling out to
   `pwsh <path>/playwright.ps1 install chromium`, and skipped that step whenever `pwsh` was absent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- **The TypeScript task assembly is now built before the targets that invoke it.** `main` went red
+  at #871: `pages` and `nightly` both failed with MSB4062 — the `ResolveTypeScriptToolTask` "could
+  not be loaded" from `src/Rask.Core/build/Rask.TypeScript.Tasks.dll` — and each took a downstream
+  job with it, so the docs site stopped deploying and no nightly prerelease was published
+  ([#878](https://github.com/pal-tamas/rask/issues/878)).
+
+  The `UsingTask` registration was not the problem; the build-order edge was. `Rask.Wasm ->
+  Rask.Core -> Rask.TypeScript.Tasks` is honoured at `ResolveProjectReferences`, but the three
+  bundle targets in `Rask.Wasm.csproj` and the two in `Rask.Server.csproj` run at
+  `BeforeTargets="PrepareForBuild"` — the first target in `CoreBuild`, long before references
+  resolve. So they invoked a task whose assembly the edge had not produced yet. They now state
+  `DependsOnTargets="ResolveProjectReferences"`, which is the dependency they always had.
+
+  The DLL is generated and gitignored, so this only ever reproduced on a tree that had never built —
+  and the failed build left the DLL behind, so re-running the identical command passed. That is what
+  kept it invisible: the local gates build the solution, where MSBuild orders the task project ahead
+  of `Rask.Wasm`, and `ci.yml` builds only the two benchmark projects and references no WASM host at
+  all. Only a single-project `dotnet publish` from a clean tree — what `pages` and
+  `nightly/aot-publish` run — could see it.
 - **The browser gate no longer needs PowerShell, and no longer skips itself quietly when it is
   missing.** `scripts/run-e2e-local.sh` installed the Playwright browsers by shelling out to
   `pwsh <path>/playwright.ps1 install chromium`, and skipped that step whenever `pwsh` was absent.

--- a/src/Rask.Core/build/Rask.Core.targets
+++ b/src/Rask.Core/build/Rask.Core.targets
@@ -211,7 +211,15 @@
   <UsingTask TaskName="Rask.TypeScript.Tasks.ResolveTypeScriptToolTask"
              AssemblyFile="$(MSBuildThisFileDirectory)Rask.TypeScript.Tasks.dll"/>
 
+  <!--
+    DependsOnTargets="ResolveProjectReferences" is inert here today and deliberately kept anyway.
+    _RaskCompileScopedTs, the only caller, hangs off CoreCompile, by which point references have long
+    resolved. But the DLL this task lives in is produced BY that reference edge in-repo, so the day
+    someone moves the scoped-TS compile earlier this would fail with MSB4062 and no hint why (#878).
+    Stating the dependency makes the ordering a fact of the target rather than of its caller.
+  -->
   <Target Name="_RaskResolveTsgo"
+          DependsOnTargets="ResolveProjectReferences"
           Condition=" '$(_RaskScopedTsDoBuild)' == 'true' AND '@(_RaskScopedTs)' != '' ">
     <ResolveTypeScriptToolTask Tool="tsgo"
                                Version="$(RaskTsgoVersion)"

--- a/src/Rask.Server/Rask.Server.csproj
+++ b/src/Rask.Server/Rask.Server.csproj
@@ -74,7 +74,7 @@
     Format is iife, not esm: the runtime is delivered by a plain `<script src>` that Rask writes into
     the shell, and a module script would defer past the first frame.
   -->
-  <Target Name="_RaskBundleClientJs" BeforeTargets="PrepareForBuild"
+  <Target Name="_RaskBundleClientJs" BeforeTargets="PrepareForBuild" DependsOnTargets="ResolveProjectReferences"
           Inputs="@(_RaskServerClientTs)"
           Outputs="$(IntermediateOutputPath)rask.js">
     <ResolveTypeScriptToolTask Tool="esbuild"
@@ -109,7 +109,7 @@
     Format is iife, not esm: the worker is registered classically, and an ES-module worker would need
     `{type:"module"}` at every registration site — including ones in consumers' own code.
   -->
-  <Target Name="_RaskBundleServiceWorker" BeforeTargets="PrepareForBuild"
+  <Target Name="_RaskBundleServiceWorker" BeforeTargets="PrepareForBuild" DependsOnTargets="ResolveProjectReferences"
           Inputs="@(_RaskServerSwTs)"
           Outputs="$(IntermediateOutputPath)rask-sw.js">
     <ResolveTypeScriptToolTask Tool="esbuild"

--- a/src/Rask.Spa.Hosting/build/Rask.Spa.Hosting.targets
+++ b/src/Rask.Spa.Hosting/build/Rask.Spa.Hosting.targets
@@ -189,6 +189,7 @@
   -->
   <Target Name="_RaskSpaEmitTypeScript"
           AfterTargets="CoreCompile"
+          DependsOnTargets="ResolveProjectReferences"
           Condition="'$(RaskEmitTypeScript)' == 'true' AND '$(DesignTimeBuild)' != 'true'">
     <WriteGeneratedTypeScriptTask AssemblyPath="@(IntermediateAssembly)" OutputDirectory="$(_RaskSpaGenerated)"/>
 

--- a/src/Rask.Tailwind/build/Rask.Tailwind.targets
+++ b/src/Rask.Tailwind/build/Rask.Tailwind.targets
@@ -56,7 +56,18 @@
     Resolving the engine is separate from running it so the download happens once per build at most,
     and so a failure to resolve reports as itself rather than as a failed Exec.
   -->
-  <Target Name="_RaskTailwindResolve" Condition="'$(_RaskTailwindDoBuild)' == 'true'">
+  <!--
+    DependsOnTargets="ResolveProjectReferences" for the same reason as _RaskResolveTsgo in
+    Rask.Core.targets, except here it is load-bearing rather than defensive: _RaskTailwindBuild, the
+    only caller, runs at BeforeTargets="BeforeBuild", which is ahead of CoreBuild and so ahead of the
+    reference resolution that produces Rask.Tailwind.Tasks.dll in this folder. Nothing in-repo imports
+    this file today — Directory.Build.targets imports only Rask.Core.targets — so a clean-tree build
+    has never reached it. The day one does, this is #878 again, in a package where the first symptom
+    would be MSB4062 in a consumer's Tailwind build.
+  -->
+  <Target Name="_RaskTailwindResolve"
+          DependsOnTargets="ResolveProjectReferences"
+          Condition="'$(_RaskTailwindDoBuild)' == 'true'">
     <ResolveTailwindCliTask Version="$(RaskTailwindVersion)"
                             CacheRoot="$(RaskTailwindCacheRoot)"
                             Engine="$(RaskTailwindEngine)"

--- a/src/Rask.Wasm/Rask.Wasm.csproj
+++ b/src/Rask.Wasm/Rask.Wasm.csproj
@@ -146,7 +146,7 @@
     Format is esm, not iife: .NET imports this module by name through JSHost.ImportAsync and main.js
     imports it for setExports, so its exports have to survive as real module exports.
   -->
-  <Target Name="_RaskBundleClientJs" BeforeTargets="PrepareForBuild;AssignTargetPaths"
+  <Target Name="_RaskBundleClientJs" BeforeTargets="PrepareForBuild;AssignTargetPaths" DependsOnTargets="ResolveProjectReferences"
           Condition=" '$(_RaskBundleBrowserAssets)' == 'true' "
           Inputs="@(_RaskWasmClientTs)"
           Outputs="$(IntermediateOutputPath)rask-bundles\rask.wasm.stamp">
@@ -173,7 +173,7 @@
     `./rask.wasm.js` is the sibling bundle above, which .NET also imports by that name — inlining it
     would give the page two copies of the runtime, each with its own state.
   -->
-  <Target Name="_RaskBundleMainJs" BeforeTargets="PrepareForBuild;AssignTargetPaths"
+  <Target Name="_RaskBundleMainJs" BeforeTargets="PrepareForBuild;AssignTargetPaths" DependsOnTargets="ResolveProjectReferences"
           Condition=" '$(_RaskBundleBrowserAssets)' == 'true' "
           Inputs="@(_RaskWasmMainTs)"
           Outputs="$(IntermediateOutputPath)rask-bundles\main.stamp">
@@ -199,7 +199,7 @@
 
     Edit Resources/rask-sw.ts, never Browser/rask-sw.js — the latter is build output.
   -->
-  <Target Name="_RaskBundleServiceWorker" BeforeTargets="PrepareForBuild;AssignTargetPaths"
+  <Target Name="_RaskBundleServiceWorker" BeforeTargets="PrepareForBuild;AssignTargetPaths" DependsOnTargets="ResolveProjectReferences"
           Condition=" '$(_RaskBundleBrowserAssets)' == 'true' "
           Inputs="@(_RaskWasmSwTs)"
           Outputs="$(IntermediateOutputPath)rask-bundles\rask-sw.stamp">

--- a/tests/Rask.Cli.Tests/PackagingContractTests.cs
+++ b/tests/Rask.Cli.Tests/PackagingContractTests.cs
@@ -420,4 +420,136 @@ public sealed class PackagingContractTests
                 + "two host packages will load it twice and fail to compile with CS0101.");
         }
     }
+
+    /// <summary>
+    ///     Every target that invokes a task loaded from a generated <c>*.Tasks.dll</c> must first wait for
+    ///     the project references that produce it.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Four packages register an MSBuild task from an assembly sitting next to their own
+    ///         <c>.targets</c>: <c>Rask.TypeScript.Tasks.dll</c>, <c>Rask.Tailwind.Tasks.dll</c>,
+    ///         <c>Rask.Wasm.Tasks.dll</c>, <c>Rask.Spa.Tasks.dll</c>. Every one is gitignored and
+    ///         generated — copied there by a <c>CopyTaskAssemblyTo...</c> target on a
+    ///         <c>ReferenceOutputAssembly="false"</c> project reference, an edge honoured at
+    ///         <c>ResolveProjectReferences</c>. A target that runs before that edge — anything hanging off
+    ///         <c>PrepareForBuild</c> or <c>BeforeBuild</c>, both ahead of <c>CoreBuild</c> — invokes a task
+    ///         whose assembly nothing has produced yet and dies with <c>MSB4062</c> naming a file the author
+    ///         has never heard of.
+    ///     </para>
+    ///     <para>
+    ///         Not hypothetical: it took <c>main</c> red for <c>pages</c> and <c>nightly</c>, and with them
+    ///         the docs deploy and the nightly prerelease (#878). It hid because the DLL is generated — a
+    ///         tree that has already built has it on disk, and the <i>failed</i> build leaves it behind, so
+    ///         re-running the identical command passes. Solution builds order the task project first, so
+    ///         every local gate was green; only a single-project <c>dotnet publish</c> from a clean tree
+    ///         could see it.
+    ///     </para>
+    ///     <para>
+    ///         The guarded task names are <i>derived</i> from the <c>UsingTask</c> declarations rather than
+    ///         listed, and the scan covers the whole repository rather than <c>src/</c>, because both of
+    ///         those shortcuts rot — a fifth task package, or a bundle target added to a sample, would sit
+    ///         outside a hand-written list and the guard would stay green while the build broke. The
+    ///         requirement is satisfied by <c>ResolveProjectReferences</c> or by <c>ResolveReferences</c>,
+    ///         which depends on it; <c>_RaskBakeScopedStaticWebAssets</c> already used the latter.
+    ///     </para>
+    /// </remarks>
+    [Fact]
+    public void Every_generated_task_call_site_waits_for_the_reference_that_produces_it()
+    {
+        var buildFiles = EnumerateBuildFiles().ToList();
+
+        // Task names come from the UsingTask declarations that load an assembly sitting next to the
+        // .targets file — the shape every generated task DLL in this repo uses.
+        var guarded = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var doc in buildFiles.Select(TryLoad).OfType<XDocument>())
+        {
+            foreach (var usingTask in doc.Descendants().Where(e => e.Name.LocalName == "UsingTask"))
+            {
+                var assemblyFile = usingTask.Attribute("AssemblyFile")?.Value ?? string.Empty;
+                var taskName = usingTask.Attribute("TaskName")?.Value ?? string.Empty;
+
+                if (assemblyFile.Contains("MSBuildThisFileDirectory", StringComparison.Ordinal)
+                    && assemblyFile.EndsWith(".Tasks.dll", StringComparison.Ordinal)
+                    && taskName.Length > 0)
+                {
+                    // <UsingTask TaskName="Ns.Sub.TheTask"/> is invoked in a target as <TheTask/>.
+                    guarded.Add(taskName[(taskName.LastIndexOf('.') + 1)..]);
+                }
+            }
+        }
+
+        Assert.True(guarded.Count >= 4, $"expected at least 4 generated task DLLs, found {guarded.Count}");
+
+        var callSites = 0;
+
+        foreach (var file in buildFiles)
+        {
+            if (TryLoad(file) is not { } doc)
+            {
+                continue;
+            }
+
+            foreach (var target in doc.Descendants().Where(e => e.Name.LocalName == "Target"))
+            {
+                var invoked = target.Descendants()
+                    .Select(e => e.Name.LocalName)
+                    .Where(guarded.Contains)
+                    .ToList();
+
+                if (invoked.Count == 0)
+                {
+                    continue;
+                }
+
+                callSites++;
+
+                var name = target.Attribute("Name")?.Value ?? "(unnamed)";
+                var dependsOn = target.Attribute("DependsOnTargets")?.Value ?? string.Empty;
+
+                Assert.True(
+                    dependsOn.Contains("ResolveProjectReferences", StringComparison.Ordinal)
+                    || dependsOn.Contains("ResolveReferences", StringComparison.Ordinal),
+                    $"{Path.GetFileName(file)}: target '{name}' invokes {invoked[0]} without waiting for "
+                    + "ResolveProjectReferences (or ResolveReferences, which depends on it). That task's "
+                    + "assembly is a generated *.Tasks.dll produced by exactly that reference edge, so on a "
+                    + "tree that has not built before the build dies with MSB4062 naming a file nobody "
+                    + "wrote (#878).");
+            }
+        }
+
+        // A rule that matches nothing passes vacuously, so the floor is the count as it stands. If this
+        // trips, ask why the number moved before lowering it — a scan that has stopped finding files
+        // looks exactly like a codebase that has stopped needing the guard.
+        Assert.True(callSites >= 12, $"expected at least 12 generated-task call sites, found {callSites}");
+    }
+
+    /// <summary>Every MSBuild file in the repo that is ours, skipping build output and nested worktrees.</summary>
+    private static IEnumerable<string> EnumerateBuildFiles()
+    {
+        string[] skip = ["obj", "bin", "node_modules", ".git", ".claude", "artifacts"];
+
+        return Directory
+            .EnumerateFiles(_repoRoot, "*", SearchOption.AllDirectories)
+            .Where(f => f.EndsWith(".csproj", StringComparison.Ordinal)
+                        || f.EndsWith(".targets", StringComparison.Ordinal)
+                        || f.EndsWith(".props", StringComparison.Ordinal))
+            .Where(f => !Path.GetRelativePath(_repoRoot, f)
+                .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                .Any(segment => skip.Contains(segment, StringComparer.Ordinal)))
+            .OrderBy(f => f, StringComparer.Ordinal);
+    }
+
+    private static XDocument? TryLoad(string file)
+    {
+        try
+        {
+            return XDocument.Load(file);
+        }
+        catch (System.Xml.XmlException)
+        {
+            return null;   // not every MSBuild-shaped file in the tree is ours to parse
+        }
+    }
 }

--- a/tests/Rask.Core.Tests/Rask.Core.Tests.csproj
+++ b/tests/Rask.Core.Tests/Rask.Core.Tests.csproj
@@ -72,7 +72,10 @@
     <_RaskNodeFixture Include="Live\*Fixture.ts"/>
   </ItemGroup>
 
-  <Target Name="_RaskBundleNodeFixtures" AfterTargets="Build" Inputs="@(_RaskNodeFixture);@(_RaskNodeFixtureDependency)"
+  <!-- DependsOnTargets: see PackagingContractTests.Every_generated_task_call_site_waits_for_the_reference_that_produces_it.
+       Inert at AfterTargets="Build", stated so the invariant holds without an exemption (#878). -->
+  <Target Name="_RaskBundleNodeFixtures" AfterTargets="Build" DependsOnTargets="ResolveProjectReferences"
+          Inputs="@(_RaskNodeFixture);@(_RaskNodeFixtureDependency)"
           Outputs="@(_RaskNodeFixture->'$(OutDir)node-fixtures/%(Filename).mjs')">
     <ResolveTypeScriptToolTask Tool="esbuild"
                                Version="$(RaskEsbuildVersion)"

--- a/tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj
+++ b/tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj
@@ -82,7 +82,9 @@
                                    Exclude="..\..\src\Rask.Core\Resources\*.d.ts"/>
   </ItemGroup>
 
-  <Target Name="_RaskBundleBrowserFixtures" AfterTargets="Build"
+  <!-- DependsOnTargets: inert at AfterTargets="Build", stated so the generated-task ordering
+       invariant holds without an exemption (#878). -->
+  <Target Name="_RaskBundleBrowserFixtures" AfterTargets="Build" DependsOnTargets="ResolveProjectReferences"
           Inputs="@(_RaskBrowserFixture);@(_RaskBrowserFixtureDependency)"
           Outputs="@(_RaskBrowserFixture->'$(OutDir)browser-fixtures/%(Filename).js')">
     <ResolveTypeScriptToolTask Tool="esbuild"

--- a/tests/Rask.Wasm.Tests/Rask.Wasm.Tests.csproj
+++ b/tests/Rask.Wasm.Tests/Rask.Wasm.Tests.csproj
@@ -83,7 +83,10 @@
     <_RaskNodeFixture Include="JSInterop\*Fixture.ts"/>
   </ItemGroup>
 
-  <Target Name="_RaskBundleNodeFixtures" AfterTargets="Build" Inputs="@(_RaskNodeFixture)"
+  <!-- DependsOnTargets: inert at AfterTargets="Build", stated so the generated-task ordering
+       invariant holds without an exemption (#878). -->
+  <Target Name="_RaskBundleNodeFixtures" AfterTargets="Build" DependsOnTargets="ResolveProjectReferences"
+          Inputs="@(_RaskNodeFixture)"
           Outputs="@(_RaskNodeFixture->'$(OutDir)node-fixtures/%(Filename).mjs')">
     <ResolveTypeScriptToolTask Tool="esbuild"
                                Version="$(RaskEsbuildVersion)"


### PR DESCRIPTION
Unblocks `main`. Since #871 the `pages` and `nightly` workflows have both failed with MSB4062, and
each took a downstream job with it — `pages/deploy` and `nightly/publish-nightly` were skipped, so
the docs site has not deployed and no nightly prerelease has been published. Fixes #878.

```
src/Rask.Wasm/Rask.Wasm.csproj(153,5): error MSB4062: The
"Rask.TypeScript.Tasks.ResolveTypeScriptToolTask" task could not be loaded from the assembly
.../src/Rask.Core/build/Rask.TypeScript.Tasks.dll. The system cannot find the file specified.
```

## Cause

The `UsingTask` registration is fine and the comment above it argues correctly for being
unconditional. The gap is on the other side: the edge that *produces* the DLL does not reach the
call sites that need it first.

`Rask.Wasm -> Rask.Core -> Rask.TypeScript.Tasks` (`ReferenceOutputAssembly="false"`) is honoured at
`ResolveProjectReferences`. The three bundle targets in `Rask.Wasm.csproj` and the two in
`Rask.Server.csproj` run at `BeforeTargets="PrepareForBuild"` — the first target in `CoreBuild`, long
before references resolve. They invoked a task whose assembly nothing had produced yet.

They now state `DependsOnTargets="ResolveProjectReferences"`, the dependency they always had.

## Why it hid

The DLL is generated and gitignored, so it only reproduces on a tree that has never built — and the
*failed* build leaves the DLL behind, so re-running the identical command passes. Verified on a clean
worktree at 417adf28: `dotnet publish samples/Rask.Example.Site -c Release` exits 1 with MSB4062, and
the same command again exits 0.

Solution builds order the task project ahead of its consumers, so every local gate was green. Only a
single-project `dotnet publish` from a clean tree — exactly what `pages` and `nightly/aot-publish`
run — could see it.

`ci.yml` was green on the same commit, but **not** because it never reached the bug. It builds
`Rask.Benchmarks`, which references `Rask.Server`, so it ran a broken call site on every clean-tree
run and won the race: MSBuild happened to schedule `Rask.Core` (and through it the task project)
ahead of `Rask.Server` inside the same reference batch. Scheduling luck under a parallel build, not
immunity — which is how one commit was green on `ci` and red on `pages`. (My first write-up of this
issue had it wrong; the review caught it and the experiment settled it.)

## Beyond the five sites

Spot-fixing five targets would have left the pattern standing, so the invariant is enforced instead:
`PackagingContractTests.Every_generated_task_call_site_waits_for_the_reference_that_produces_it`
derives the guarded task names from the `UsingTask` declarations that load a `*.Tasks.dll` from their
own directory — the four generated task assemblies — and scans the whole repository. A hand-written
list of names or of directories rots.

The widening earned its keep on the first run: it found three further call sites outside `src/`, in
the `Rask.Core.Tests`, `Rask.Wasm.Tests` and `Rask.Examples.E2E.Tests` fixture bundlers.

It also found a live one. `_RaskTailwindResolve` invokes `ResolveTailwindCliTask` from the equally
generated `Rask.Tailwind.Tasks.dll`, and its only caller runs at `BeforeTargets="BeforeBuild"` —
ahead of `CoreBuild`, so ahead of reference resolution. It has never bitten because nothing in-repo
imports `Rask.Tailwind.targets`; it would have, the first time anything did.

All twelve call sites now state the dependency, whether it is load-bearing there or merely true. An
exemption for the ones a caller happens to order safely would make the invariant depend on a fact
about a different target.

## Testing

- `dotnet format Rask.slnx --verify-no-changes` — clean.
- `dotnet build Rask.slnx -c Release -warnaserror -p:EnforceCodeStyleInBuild=true` — **0 warnings, 0 errors**.
- `scripts/run-unit-local.sh` — **6,938 tests, 0 failed**, 56 skipped (the usual env-gated CLI/watch/deploy suites). Count went 6,937 -> 6,938, which is the new test actually running in the gate rather than only in isolation.
- **The regression, end to end.** From `git clean -xdf` (no task DLL, no `Browser/rask.wasm.js`, no `main.js`, no `obj/`), both `pages` commands now exit 0 — `dotnet publish samples/Rask.Example.Site` and `dotnet publish samples/Rask.Example.Wasm` — with zero IL trim warnings, and esbuild genuinely runs: `rask.wasm.js` 80,544 bytes and `main.js` 3,419 bytes are produced, so it is not an incremental skip.
- **The guard proven in both directions.** Reverting the `DependsOnTargets` re-flags exactly the three `Rask.Wasm` targets; restoring clears it. It was not staged — during development it flagged the three test-project call sites as real violations and only went green once each was fixed.
- Scoped TypeScript still compiles after the `Rask.Core.targets` change (`CodeSample.js`, `PictureInPictureDemo.js` emitted), and keeps the inline `export function` form `ScopedAssetRegistry` matches — no hoisted `export { }` clause.

No benchmarks: MSBuild ordering only, no runtime or render-hotpath code.

## Note on the gate

Nothing in the repo builds a single project from a clean tree, which is the only shape that catches
this class — the local hooks build the solution and `ci.yml` builds benchmarks. This PR closes the
bug and pins the invariant, but that gap is worth a follow-up; I left it noted on #878 rather than
widening this PR further.
