### PR TITLE
test(server): serialise the classes that swap the global diagnostics sink

### DIFF
--- a/tests/Rask.Server.Tests/Configuration/RenderModeAttributeTests.cs
+++ b/tests/Rask.Server.Tests/Configuration/RenderModeAttributeTests.cs
@@ -13,6 +13,7 @@ namespace Rask.Server.Tests.Configuration;
 // is biased towards keeping a connection — a page wrongly judged interactive behaves exactly as it
 // always has, while one wrongly judged static loses its interactivity silently. The attribute is for
 // what detection cannot see.
+[Collection("DiagnosticsSink")]
 public class RenderModeAttributeTests
 {
     [Fact]

--- a/tests/Rask.Server.Tests/Diagnostics/RaskServerDiagnosticsBridgeTests.cs
+++ b/tests/Rask.Server.Tests/Diagnostics/RaskServerDiagnosticsBridgeTests.cs
@@ -7,6 +7,7 @@ namespace Rask.Server.Tests.Diagnostics;
 
 // Exercises the bridge's per-event Emit directly rather than installing it as the process-global
 // RaskDiagnostics.Sink, so these tests never race host-based tests that drive the same global seam.
+[Collection("DiagnosticsSink")]
 public class RaskServerDiagnosticsBridgeTests
 {
     // RaskLogLevel is internal, so it can't be a public test-method parameter — pass its numeric

--- a/tests/Rask.Server.Tests/Endpoints/StaticPageAuditTests.cs
+++ b/tests/Rask.Server.Tests/Endpoints/StaticPageAuditTests.cs
@@ -16,7 +16,7 @@ namespace Rask.Server.Tests.Endpoints;
 //
 // Serialised: RaskDiagnostics.Sink is process-global, and two tests swapping it concurrently lose it
 // entirely — an empty collection rather than a slow one.
-[Collection("StaticPageAudit")]
+[Collection("DiagnosticsSink")]
 public class StaticPageAuditTests
 {
     [Fact]
@@ -101,9 +101,6 @@ public class StaticPageAuditTests
         return null;
     }
 }
-
-[CollectionDefinition("StaticPageAudit", DisableParallelization = true)]
-public sealed class StaticPageAuditCollection;
 
 // Renders nothing a walk can see as needing a connection, then pushes anyway — the shape of a polling
 // panel, and of any component driven by a timer or an event subscription.

--- a/tests/Rask.Server.Tests/Infrastructure/DiagnosticsSinkCollection.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/DiagnosticsSinkCollection.cs
@@ -1,0 +1,28 @@
+namespace Rask.Server.Tests.Infrastructure;
+
+// Test classes that swap the process-global RaskDiagnostics.Sink.
+//
+// The swap is a save/restore of shared mutable state with no mutual exclusion:
+//
+//     var previous = RaskDiagnostics.Sink;
+//     RaskDiagnostics.Sink = captured.Enqueue;
+//     try { ... } finally { RaskDiagnostics.Sink = previous; }
+//
+// Run two of those in parallel and the second saves the FIRST one's capturing delegate as its
+// `previous`, so restoring in that order leaves the sink pointing at a queue nobody reads — and the
+// event the first test is waiting for is delivered to a stranger, or to nobody. It shows up as
+// `Assert.Contains() Failure ... Collection: []`: EMPTY, not slow.
+//
+// It fails OPEN, which is why it is worth serialising rather than tolerating. A test asserting "the
+// framework reported X" passes whenever the sink happens not to be stolen — and StaticPageAuditTests
+// exists specifically to prove that under-detection gets reported, so the safety net for the riskiest
+// part of static detection is the thing with the hole in it.
+//
+// Add [Collection("DiagnosticsSink")] to any new test class in this assembly that assigns
+// RaskDiagnostics.Sink. Rask.Core.Tests has the same arrangement under "ConsoleRedirect", which also
+// covers Console.SetOut/SetError; this is the server-side counterpart it never got.
+//
+// What this does NOT buy: xUnit serialises members of a collection against each other. A test in here
+// should still assert on the events IT provoked rather than on the whole capture.
+[CollectionDefinition("DiagnosticsSink", DisableParallelization = true)]
+public sealed class DiagnosticsSinkCollection;


### PR DESCRIPTION
Closes #874.

`RaskDiagnostics.Sink` is process-global, and three classes in this assembly swap it with a plain
save/restore and no mutual exclusion:

```csharp
var previous = RaskDiagnostics.Sink;
RaskDiagnostics.Sink = captured.Enqueue;
try { ... } finally { RaskDiagnostics.Sink = previous; }
```

Run two in parallel and the second saves the **first one's capturing delegate** as its `previous`, so
restoring in that order leaves the sink pointing at a queue nobody reads — and the event a test is
waiting for goes to a stranger, or nowhere. It surfaces as `Collection: []`: **empty, not slow.**

Measured at **1 of 8** on pristine `main`.

## Why serialise rather than tolerate

It fails **open**. A test asserting "the framework reported X" passes whenever the sink happens not to
be stolen — and `StaticPageAuditTests` exists specifically to prove that *under-detection gets
reported*, so the safety net for the riskiest part of static detection was the thing with the hole in
it.

## The pattern already existed

`Rask.Core.Tests` has `ConsoleRedirectCollection`, whose comment describes this exact failure and ends
by telling you to add any new sink-assigning class to it. The server assembly never got the
counterpart — the knowledge existed and did not cross the assembly boundary.

## One thing found on the way

`StaticPageAuditTests` **did** carry a collection — but a private one named after itself, so it
serialised against nothing, because the other two swappers were not in it. **A collection of one is a
comment.** It read as guarded, which is worse than unguarded: it stops anyone looking. Folded into the
shared one.

Core's caveat is carried over rather than dropped, so the fix is not over-trusted: xUnit serialises
members of a collection against each other, so a test in here should still assert on the events *it*
provoked rather than on the whole capture.

## Evidence

Eight full gate runs clean, against a prior rate of roughly one in eight. Eight clean runs at that rate
happen by luck about a third of the time, so the statistics are weak on their own — what carries it is
that the mechanism is exact and this removes it outright: the two classes can no longer run
concurrently, so there is no remaining path to the failure.
