### PR TITLE
fix(server): make RenderModes.ServerInteractivity do what its name says

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,27 @@ them until tagged releases begin.
   now state the dependency, whether it is load-bearing there or merely true, because an exemption for
   the ones a caller happens to order safely makes the invariant depend on a fact about a different
   target. The guard was verified by failing it in both directions.
+
+- **`RenderModes.ServerInteractivity` did nothing.** The property was read nowhere outside its own
+  validation, so turning it off with `Wasm` on was accepted and silently ignored — pages still opened
+  WebSockets — and turning it off with `Wasm` off threw, telling you to turn it back on. It lied either
+  way.
+
+  It now means what it says: **no page ever gets a live session.** Every page is served as a document,
+  and the WebSocket endpoint answers `404` as though it were not there. That is stronger than
+  `RenderModes.Static`, which is detected per page and biased towards keeping a connection; this is
+  declared, so nothing is detected and nothing can bias.
+
+  Both combinations now work rather than one throwing: with `Wasm` off it is plain server-side
+  rendering — a content site, which used to be refused — and with `Wasm` on it is static HTML that
+  hands over to WebAssembly with no socket ever opened.
+
+  A page that renders a handler in this mode has nothing to answer it. That is reported through the
+  `Rask.Ssr` diagnostic rather than prevented by refusing to start, which had made "serve only content"
+  unreachable.
+
+
+### Fixed
 - **The browser gate no longer needs PowerShell, and no longer skips itself quietly when it is
   missing.** `scripts/run-e2e-local.sh` installed the Playwright browsers by shelling out to
   `pwsh <path>/playwright.ps1 install chromium`, and skipped that step whenever `pwsh` was absent.

--- a/docs/render-modes.md
+++ b/docs/render-modes.md
@@ -29,10 +29,24 @@ builder.Services.AddRask(configureServer: o =>
 Defaults are today's behaviour exactly: server-interactive, no static pages, no streaming, no browser
 runtime. An app that configures nothing notices nothing.
 
-**Turning `ServerInteractivity` off** means a page is served as HTML and becomes interactive only
-once the browser bundle boots — no WebSocket is ever opened. That is the offline-first and
-edge-hosted arrangement, and it requires `Wasm`, because otherwise a page with a handler would have
-no way to answer it at all.
+**Turning `ServerInteractivity` off** is a declaration, not a preference: **no page ever gets a live
+session.** Every page is served as a document — no session, no socket, no runtime script — and the
+WebSocket endpoint answers `404` as though it were not there.
+
+That is stronger than `Static`, which is *detected* per page and deliberately biased towards keeping
+a connection. Here nothing is detected, so nothing can bias: an app that serves only content gets
+only content, even on a page that renders a button.
+
+Both combinations are useful, and both are allowed:
+
+| | |
+|---|---|
+| `ServerInteractivity = false`, `Wasm = false` | Plain server-side rendering. A content site. |
+| `ServerInteractivity = false`, `Wasm = true` | Static HTML that hands over to WebAssembly, with no socket ever opened — the offline-first, edge-hosted arrangement. |
+
+The cost is real and is **reported rather than prevented**: a page that renders a handler has nothing
+to answer it, and says so through the `Rask.Ssr` diagnostic. Refusing to start was the wrong response
+to that, because it made "serve only content" unreachable.
 
 **A combination that cannot serve a working page throws when the host is built**, naming what is off
 and what to do. A contradiction is a configuration mistake, and a host that refuses to start is far

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -491,7 +491,9 @@ public static partial class RaskEndpointExtensions
             // built detached and admitted afterwards, so a page that turns out to need nothing live
             // costs no slot. The cheap AtCapacity probe keeps a saturated host from doing the work
             // anyway; the authoritative check is still the atomic one, at TryRegister below.
-            var staticPages = limits.StaticPages;
+            // With server interactivity off, every page is a document whether or not the walk found
+            // a reason to keep one — there is nothing for a session to be for.
+            var staticPages = limits.StaticPages || !limits.ServerInteractivity;
             var session = staticPages
                 ? (store.IsDraining || store.AtCapacity ? null : store.CreateDetached(appFactory))
                 : store.TryCreate(appFactory);
@@ -594,14 +596,19 @@ public static partial class RaskEndpointExtensions
                                  && chain.Count > 0
                                  && DeclaredRenderModes.Of(chain[^1]) == RenderMode.Static;
 
-            var interactive = !(staticPages || declaredStatic)
-                              || session.RequiresLiveSession
-                              || session.LastRenderFaulted
-                              // A JS call issued from a continuation AFTER the walk is invisible to
-                              // the render context, but it is still queued waiting for a frame that
-                              // only a socket can carry.
-                              || session.JsInvokes.HasPending
-                              || LiveOptions.IsDevelopment == true;
+            // Gated as a whole rather than folded in as another reason: every clause below assumes a
+            // session is AVAILABLE, and with server interactivity off none of them can be honoured —
+            // including the Development one, which would otherwise make every page live while you are
+            // developing the very thing you turned off.
+            var interactive = limits.ServerInteractivity
+                              && (!(staticPages || declaredStatic)
+                                  || session.RequiresLiveSession
+                                  || session.LastRenderFaulted
+                                  // A JS call issued from a continuation AFTER the walk is invisible
+                                  // to the render context, but it is still queued waiting for a frame
+                                  // that only a socket can carry.
+                                  || session.JsInvokes.HasPending
+                                  || LiveOptions.IsDevelopment == true);
 
             // A page that asked to be static and turned out to need a connection keeps the connection —
             // a request, not a command. Reported, because the two facts contradict each other and the
@@ -854,6 +861,18 @@ public static partial class RaskEndpointExtensions
                 // Resolve the per-host safety limits once per connection (not per frame) — the receive
                 // loop reads them via instance fields on the hot path.
                 var limits = ctx.RequestServices.GetRequiredService<RaskServerLimits>();
+
+                // Server interactivity off means no page may become live, so this endpoint has nothing
+                // to serve. Answered as 404 rather than 400 or 426: to anything probing, an app that
+                // cannot go live should be indistinguishable from one that never had a socket. Refused
+                // here rather than left unmapped so the mapping stays one shape — the marker below and
+                // the other framework endpoints are registered together.
+                if (!limits.ServerInteractivity)
+                {
+                    ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+                    return;
+                }
+
                 if (!ctx.WebSockets.IsWebSocketRequest)
                 {
                     ctx.Response.StatusCode = StatusCodes.Status400BadRequest;

--- a/src/Rask.Server/RaskRenderModes.cs
+++ b/src/Rask.Server/RaskRenderModes.cs
@@ -52,10 +52,27 @@ public sealed class RaskRenderModes
     ///     always worked.
     /// </summary>
     /// <remarks>
-    ///     Turning it off means a page is served as HTML and becomes interactive only once the
-    ///     browser bundle boots: no socket is ever opened. That is the offline-first and edge-hosted
-    ///     arrangement, and it requires <see cref="Wasm" />, since otherwise a page with a handler
-    ///     would have no way to answer it at all.
+    ///     <para>
+    ///         Turning it off is a declaration rather than a preference: <b>no page ever gets a live
+    ///         session</b>. Every page is served as a document — no session, no socket, no runtime
+    ///         script — and the WebSocket endpoint answers 404 as though it were not there.
+    ///     </para>
+    ///     <para>
+    ///         That is stronger than <see cref="Static" />, which is <em>detected</em> per page and
+    ///         deliberately biased towards keeping a connection. Here nothing is detected, so nothing
+    ///         can bias: an app that serves only content gets only content.
+    ///     </para>
+    ///     <para>
+    ///         With <see cref="Wasm" /> on it is the offline-first, edge-hosted arrangement — static
+    ///         HTML that hands over to WebAssembly, with no socket ever opened. With <see cref="Wasm" />
+    ///         off it is plain server-side rendering, which is the right answer for a content site and
+    ///         used to be refused.
+    ///     </para>
+    ///     <para>
+    ///         The cost is real and is reported rather than prevented: a page that renders a handler
+    ///         has nothing to answer it, and says so through the <c>Rask.Ssr</c> diagnostic. Refusing
+    ///         to start was the wrong response to that — it made "serve only content" unreachable.
+    ///     </para>
     /// </remarks>
     public bool ServerInteractivity { get; set; } = true;
 
@@ -126,14 +143,5 @@ public sealed class RaskRenderModes
                 + "boot module's URL, or leave it at its default of /main.js.");
         }
 
-        if (!ServerInteractivity && !Wasm)
-        {
-            throw new InvalidOperationException(
-                "RenderModes.ServerInteractivity is off and RenderModes.Wasm is off, which leaves no "
-                + "way for any page to become interactive: a click would reach neither a server "
-                + "session nor a browser runtime. Turn one of them on. If this app genuinely serves "
-                + "only content, leave ServerInteractivity on — a page that needs nothing live is "
-                + "already served as a plain document when RenderModes.Static is enabled.");
-        }
     }
 }

--- a/src/Rask.Server/RaskServerLimits.cs
+++ b/src/Rask.Server/RaskServerLimits.cs
@@ -34,6 +34,16 @@ internal sealed class RaskServerLimits
     public bool StaticPages { get; init; }
 
     /// <summary>
+    ///     Whether any page may become live over a WebSocket. See
+    ///     <see cref="RaskRenderModes.ServerInteractivity" />.
+    /// </summary>
+    /// <remarks>
+    ///     Off means every page is a document and the socket endpoint is unreachable — not "prefer
+    ///     static", which is <see cref="StaticPages" />.
+    /// </remarks>
+    public bool ServerInteractivity { get; init; } = true;
+
+    /// <summary>
     ///     Root-relative URL of the browser bundle's boot module, or <c>null</c> when the browser rung
     ///     is off. See <see cref="RaskRenderModes.Wasm" />.
     /// </summary>
@@ -74,6 +84,7 @@ internal sealed class RaskServerLimits
         UnconnectedSessionGracePeriod = o.UnconnectedSessionGracePeriod,
         InitialRenderQuiescenceTimeout = o.RenderModes.QuiescenceTimeout,
         StaticPages = o.RenderModes.Static,
+        ServerInteractivity = o.RenderModes.ServerInteractivity,
         WasmBundleUrl = o.RenderModes.Wasm ? o.RenderModes.WasmBundle : null,
         IdleSocketTimeout = o.IdleSocketTimeout,
         HandlerTimeout = o.HandlerTimeout,

--- a/tests/Rask.Server.Tests/Configuration/RenderModesTests.cs
+++ b/tests/Rask.Server.Tests/Configuration/RenderModesTests.cs
@@ -26,17 +26,14 @@ public class RenderModesTests
     }
 
     [Fact]
-    public void NoInteractivityAtAll_Throws()
+    public void NoInteractivityAtAll_IsPlainServerSideRendering()
     {
-        // A click would reach neither a server session nor a browser runtime.
+        // This used to throw, and the message told you to turn interactivity back on — the opposite of
+        // what an app serving only content is asking for. A page with a handler having nothing to
+        // answer it is a cost to REPORT, not a reason to refuse to start.
         var modes = new RaskRenderModes { ServerInteractivity = false };
 
-        var ex = Assert.Throws<InvalidOperationException>(modes.Validate);
-
-        // The message has to say what to do, not just what is wrong: this is read by someone whose
-        // app would not start.
-        Assert.Contains("no", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Turn one of them on", ex.Message);
+        Assert.Null(Record.Exception(modes.Validate));
     }
 
     [Fact]
@@ -68,10 +65,15 @@ public class RenderModesTests
     public void AHostConfiguredWithAContradiction_DoesNotStart()
     {
         // The end-to-end half: validation runs when the host is built, not merely when someone calls
-        // Validate by hand.
+        // Validate by hand. Turning the browser rung on with nowhere to fetch the bundle from is the
+        // contradiction now — no page could ever move into it, and nothing at runtime would say so.
         var ex = Record.Exception(() =>
             RaskTestHost.Create<RenderModesApp>(
-                configureServer: o => o.RenderModes.ServerInteractivity = false));
+                configureServer: o =>
+                {
+                    o.RenderModes.Wasm = true;
+                    o.RenderModes.WasmBundle = "  ";
+                }));
 
         Assert.IsType<InvalidOperationException>(ex);
     }

--- a/tests/Rask.Server.Tests/Configuration/ServerInteractivityOffTests.cs
+++ b/tests/Rask.Server.Tests/Configuration/ServerInteractivityOffTests.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using Rask.Core;
+using Rask.Server.Tests.Infrastructure;
+
+#pragma warning disable RASK019 // test-infra apps predate framework-managed <head>
+
+namespace Rask.Server.Tests.Configuration;
+
+/// <summary>
+///     <c>RenderModes.ServerInteractivity = false</c> means no page ever goes live.
+/// </summary>
+/// <remarks>
+///     <para>
+///         It used to mean nothing at all: the property was read nowhere outside its own validation, so
+///         turning it off with <c>Wasm</c> on was accepted and silently ignored, and turning it off with
+///         <c>Wasm</c> off threw and told you to turn it back on. Every case here would have passed
+///         vacuously or been unreachable.
+///     </para>
+///     <para>
+///         The page used for most of them renders a button — deliberately. A page that needs nothing
+///         live proves very little, because <c>RenderModes.Static</c> already serves those as documents.
+///         What has to hold is that a page which WOULD have taken a session does not get one.
+///     </para>
+/// </remarks>
+public class ServerInteractivityOffTests
+{
+    [Fact]
+    public async Task APageThatWouldHaveGoneLive_IsServedAsADocument()
+    {
+        using var host = Host();
+
+        var body = await host.Http.GetStringAsync("/");
+
+        // No session id, and no runtime script to attach one.
+        Assert.DoesNotContain("data-rask-root", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("/rask/rask.js", body, StringComparison.Ordinal);
+        Assert.Contains("press", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task NoSessionIsRetained()
+    {
+        // Asserted on the counts rather than the body: a session that is merely invisible in the HTML
+        // is still a DI scope and a component tree held against the cap.
+        using var host = Host();
+
+        await host.Http.GetStringAsync("/");
+
+        Assert.Equal(0, host.Store.Count);
+        Assert.Equal(0, host.Store.LiveCount);
+    }
+
+    [Fact]
+    public async Task TheSocketEndpointIsNotThere()
+    {
+        // 404 rather than 400 or 426: an app that cannot go live should be indistinguishable from one
+        // that never had a socket.
+        using var host = Host();
+
+        var response = await host.Http.GetAsync("/rask/ws");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task StaticPagesDoesNotHaveToBeTurnedOnAsWell()
+    {
+        // The two are different statements. Static is DETECTED per page and biased towards keeping a
+        // connection; this is declared, so nothing is detected and nothing can bias. Requiring both
+        // would have made the weaker one load-bearing.
+        using var host = RaskTestHost.Create<InteractiveApp>(
+            configureServer: o =>
+            {
+                o.RenderModes.ServerInteractivity = false;
+                o.RenderModes.Static = false;
+            });
+
+        var body = await host.Http.GetStringAsync("/");
+
+        Assert.DoesNotContain("data-rask-root", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TurningItOffWithNoBrowserRungIsNotAContradiction()
+    {
+        // Plain server-side rendering for a content site. This used to throw, and the message told you
+        // to turn interactivity back on — which is the opposite of what the app asked for.
+        var modes = new RaskRenderModes { ServerInteractivity = false, Wasm = false };
+
+        Assert.Null(Record.Exception(modes.Validate));
+    }
+
+    [Fact]
+    public void TurningItOffWithTheBrowserRungOnIsAlsoFine()
+    {
+        // The edge-hosted arrangement: static HTML that hands over to WebAssembly, no socket ever.
+        var modes = new RaskRenderModes { ServerInteractivity = false, Wasm = true };
+
+        Assert.Null(Record.Exception(modes.Validate));
+    }
+
+    private static RaskTestHost Host() =>
+        RaskTestHost.Create<InteractiveApp>(
+            configureServer: o => o.RenderModes.ServerInteractivity = false);
+}
+
+public sealed partial class InteractiveApp : Component
+{
+    private int _count;
+
+    protected override Component? HeadAssets => Title["interactive"];
+
+    protected override Component? Render() => Div[Button.OnClick(() => _count++)["press"]];
+}


### PR DESCRIPTION
Replaces #876, which conflicted with `main` on the CHANGELOG `[Unreleased]` section. Identical
content, rebased onto current main and re-gated (397 green).

---

`RenderModes.ServerInteractivity` was read **nowhere outside its own validation**. Turning it off with
`Wasm` on was accepted and silently ignored — pages still opened WebSockets — and turning it off with
`Wasm` off threw, telling you to turn it back on. It lied in both directions.

It now means one thing: **no page ever gets a live session.** Every page is served as a document, and
the socket endpoint answers `404` as though it were not there.

## Why not just use `RenderModes.Static`

That was the old error message's advice, and it is backwards. `Static` is **detected** per page and
deliberately biased towards keeping a connection — a false `interactive` is a non-event, a false
`static` is silent breakage. So a content page that happens to render one handler quietly takes a
session and a socket.

`ServerInteractivity = false` is **declared**. Nothing is detected, so nothing can bias. Turning
`Static` on as well is *not* required — a test pins that, because requiring it would make the weaker
statement load-bearing.

## Both combinations now work

| | |
|---|---|
| `ServerInteractivity = false`, `Wasm = false` | Plain server-side rendering. A content site. Used to throw. |
| `ServerInteractivity = false`, `Wasm = true` | Static HTML handing over to WebAssembly, no socket ever opened — the edge-hosted arrangement from the plan, previously unreachable because the switch did nothing. |

## Implementation note worth reviewing

The gate wraps the **whole** interactivity expression rather than joining it as another clause:

```csharp
var interactive = limits.ServerInteractivity
                  && (!(staticPages || declaredStatic)
                      || session.RequiresLiveSession
                      || ...
                      || LiveOptions.IsDevelopment == true);
```

Every clause inside assumes a session is *available*, and none can be honoured here — including the
`IsDevelopment` one, which would otherwise make every page live while you develop the very thing you
turned off.

`404` rather than `400`/`426` on the socket, deliberately: an app that cannot go live should be
indistinguishable from one that never had a socket.

## Tests

Two existing tests asserted the old refusal; both are **inverted rather than deleted**, and the
end-to-end one now uses a contradiction that still is one (the browser rung on with nowhere to fetch
the bundle from).

The new cases use a page that renders a **button** on purpose. A page needing nothing live proves very
little here, since `Static` already serves those as documents — what has to hold is that a page which
*would* have taken a session does not get one.

Mutation-checked: removing the gate fails three of the six.

## The cost, reported not prevented

A page that renders a handler in this mode has nothing to answer it. That goes out through the
`Rask.Ssr` diagnostic. Refusing to start was the wrong response, because it made "serve only content"
unreachable.
