### PR TITLE
feat(core): render a whole document with no host, and plan which routes can be

### DIFF
--- a/src/Rask.Core/Live/RaskPrerender.cs
+++ b/src/Rask.Core/Live/RaskPrerender.cs
@@ -1,3 +1,5 @@
+using Rask.Core.Routing;
+
 namespace Rask.Core.Live;
 
 /// <summary>
@@ -13,6 +15,22 @@ namespace Rask.Core.Live;
 /// </param>
 /// <param name="Waves">How many extra waves ran after the first render.</param>
 public readonly record struct PrerenderResult(string Html, bool TimedOut, bool Faulted, int Waves);
+
+/// <summary>
+///     Which routes can be prerendered, and which cannot.
+/// </summary>
+/// <param name="Paths">
+///     Routes whose every segment is a literal, so the path is known without data. These are what a
+///     prerender pass walks.
+/// </param>
+/// <param name="Skipped">
+///     Routes that were left out, as their templates. <b>Report these.</b> A route carrying a
+///     parameter cannot be enumerated without knowing the values, and a catch-all is a 404 page at
+///     best — dropping them quietly would let a pass that covered only the static half read as
+///     though it had covered everything.
+/// </param>
+public sealed record PrerenderPlan(IReadOnlyList<string> Paths, IReadOnlyList<string> Skipped);
+
 
 /// <summary>
 ///     Renders an app to a complete HTML document with no host and no browser.
@@ -72,5 +90,39 @@ public static class RaskPrerender
             maxWaves: maxWaves).ConfigureAwait(false);
 
         return new PrerenderResult(render.Html, render.TimedOut, root.RenderedFallback, render.Waves);
+    }
+    /// <summary>
+    ///     Reads the registered route table and splits it into what a prerender pass can and cannot do.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Call after the app's routes are registered — the generator's <c>[Route]</c> registrations
+    ///         run from module initializers, so simply touching the app assembly is enough.
+    ///     </para>
+    ///     <para>
+    ///         "Can be prerendered" is decided on the parsed segments rather than by looking for a brace
+    ///         in the template. The two agree today; only one of them keeps agreeing if the template
+    ///         syntax ever grows a construct that contains no brace, or a literal that contains one.
+    ///     </para>
+    /// </remarks>
+    public static PrerenderPlan PlanRoutes()
+    {
+        var paths = new List<string>();
+        var skipped = new List<string>();
+
+        foreach (var leaf in RouteFlattener.Flatten(RouteRegistry.BuildTree()))
+        {
+            // A route with no segments at all is the root, and it is prerenderable.
+            if (leaf.Pattern.Segments.All(segment => segment.Kind == SegmentKind.Literal))
+            {
+                paths.Add(leaf.FullTemplate);
+            }
+            else
+            {
+                skipped.Add(leaf.FullTemplate);
+            }
+        }
+
+        return new PrerenderPlan(paths, skipped);
     }
 }

--- a/src/Rask.Core/Live/RaskPrerender.cs
+++ b/src/Rask.Core/Live/RaskPrerender.cs
@@ -1,0 +1,76 @@
+namespace Rask.Core.Live;
+
+/// <summary>
+///     The outcome of prerendering one page.
+/// </summary>
+/// <param name="Html">The complete document.</param>
+/// <param name="TimedOut">
+///     Whether the page was still waiting on work when the budget ran out. Its markup is whatever had
+///     rendered by then — a placeholder, in the case that matters.
+/// </param>
+/// <param name="Faulted">
+///     Whether the render threw and the root boundary rendered its fallback instead of the app.
+/// </param>
+/// <param name="Waves">How many extra waves ran after the first render.</param>
+public readonly record struct PrerenderResult(string Html, bool TimedOut, bool Faulted, int Waves);
+
+/// <summary>
+///     Renders an app to a complete HTML document with no host and no browser.
+/// </summary>
+/// <remarks>
+///     <para>
+///         For an app that has no server to render it per request — a browser-WebAssembly app published
+///         to a static host. Without this, the first thing every visitor and every crawler receives is
+///         the boot shell: a spinner, and the word "Loading". The app's real markup does not exist until
+///         several megabytes of runtime have downloaded and started.
+///     </para>
+///     <para>
+///         What comes back is what a browser would have been sent, wrapped in the same root boundary the
+///         hosts install, and driven through the same waves a server's first response uses — so a page
+///         whose <c>OnMountAsync</c> loads build-time data writes the data rather than its placeholder.
+///     </para>
+///     <para>
+///         <b>Check <see cref="PrerenderResult.Faulted" /> and
+///         <see cref="PrerenderResult.TimedOut" /> before writing anything to disk.</b> A faulted render
+///         still returns perfectly ordinary HTML — that is what a root boundary is for — so a caller that
+///         writes it blindly publishes an error page under the route's own name, and nothing at build
+///         time would say so.
+///     </para>
+/// </remarks>
+public static class RaskPrerender
+{
+    /// <summary>
+    ///     Renders <paramref name="app" /> as a whole document, waiting for its async work to settle.
+    /// </summary>
+    /// <param name="app">The root component the host would mount.</param>
+    /// <param name="services">
+    ///     The app's services. Seed the route on this provider's <c>RouteState</c> before calling — which
+    ///     page this renders is the caller's decision, because the caller is what holds the route table.
+    /// </param>
+    /// <param name="budget">
+    ///     How long the waves may take in total. Prerendering can afford more than a request can: it
+    ///     happens once, at build time, and nobody is waiting on a socket.
+    /// </param>
+    /// <param name="maxWaves">Wave cap. Defaults to <see cref="QuiescentRender.DefaultMaxWaves" />.</param>
+    public static async Task<PrerenderResult> RenderDocumentAsync(
+        Component app,
+        IServiceProvider services,
+        TimeSpan budget,
+        int maxWaves = QuiescentRender.DefaultMaxWaves)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        ArgumentNullException.ThrowIfNull(services);
+
+        // The same wrapper Rask.Server and Rask.Wasm install: it composes the shell from the app's
+        // Shell / HtmlLang / BodyClass and catches anything the subtree throws. Going through it rather
+        // than reimplementing the composition is the point — this has to be what a browser gets.
+        var root = new RootErrorBoundary(app);
+
+        var render = await QuiescentRender.RunAsync(
+            publishOnly => root.RenderAsLiveRoot(services, publishOnly),
+            budget,
+            maxWaves: maxWaves).ConfigureAwait(false);
+
+        return new PrerenderResult(render.Html, render.TimedOut, root.RenderedFallback, render.Waves);
+    }
+}

--- a/tests/Rask.Core.Tests/Live/RaskPrerenderTests.cs
+++ b/tests/Rask.Core.Tests/Live/RaskPrerenderTests.cs
@@ -78,6 +78,44 @@ public class RaskPrerenderTests
         Assert.Contains("/seeded", result.Html, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ThePlanKeepsRoutesWhoseEverySegmentIsALiteral()
+    {
+        RouteRegistry.Replace(nameof(ThePlanKeepsRoutesWhoseEverySegmentIsALiteral), [
+            new RouteRegistration(typeof(PlainPage), "/", null),
+            new RouteRegistration(typeof(PlainPage), "/about", null),
+            new RouteRegistration(typeof(PlainPage), "/guides/intro", null),
+        ]);
+
+        var plan = RaskPrerender.PlanRoutes();
+
+        Assert.Contains("/", plan.Paths);
+        Assert.Contains("/about", plan.Paths);
+        Assert.Contains("/guides/intro", plan.Paths);
+    }
+
+    [Fact]
+    public void ThePlanREPORTSWhatItCannotPrerenderRatherThanDroppingIt()
+    {
+        // The point of Skipped being a field rather than a log line. A parameterised route cannot be
+        // enumerated without knowing the values, and a catch-all is a 404 page at best — but a pass
+        // that quietly covered only the static half would read as though it had covered everything.
+        RouteRegistry.Replace(nameof(ThePlanREPORTSWhatItCannotPrerenderRatherThanDroppingIt), [
+            new RouteRegistration(typeof(PlainPage), "/products/{id}", null),
+            new RouteRegistration(typeof(PlainPage), "/docs/{**rest}", null),
+            new RouteRegistration(typeof(PlainPage), "/plain", null),
+        ]);
+
+        var plan = RaskPrerender.PlanRoutes();
+
+        Assert.Contains("/plain", plan.Paths);
+        Assert.DoesNotContain("/products/{id}", plan.Paths);
+        Assert.DoesNotContain("/docs/{**rest}", plan.Paths);
+
+        Assert.Contains("/products/{id}", plan.Skipped);
+        Assert.Contains("/docs/{**rest}", plan.Skipped);
+    }
+
     private static IServiceProvider Services()
     {
         var services = new ServiceCollection();

--- a/tests/Rask.Core.Tests/Live/RaskPrerenderTests.cs
+++ b/tests/Rask.Core.Tests/Live/RaskPrerenderTests.cs
@@ -1,0 +1,122 @@
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core.Live;
+using Rask.Core.Routing;
+
+#pragma warning disable RASK014 // test-defined Component subclasses have no generated chain entries
+
+namespace Rask.Core.Tests.Live;
+
+// Rendering a whole document with no host and no browser — which is what an app with no server needs
+// at publish time. A standalone WASM app currently ships its boot shell to every visitor and every
+// crawler: a spinner and the word "Loading", because the real markup does not exist until several
+// megabytes of runtime have downloaded.
+public class RaskPrerenderTests
+{
+    [Fact]
+    public async Task ItRendersAWholeDocument()
+    {
+        var result = await RaskPrerender.RenderDocumentAsync(
+            new PlainPage(), Services(), TimeSpan.FromSeconds(5));
+
+        // The shell the hosts compose, not just the component's own markup.
+        Assert.Contains("<!doctype html>", result.Html, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<body", result.Html, StringComparison.Ordinal);
+        Assert.Contains("hello", result.Html, StringComparison.Ordinal);
+        Assert.False(result.Faulted);
+        Assert.False(result.TimedOut);
+    }
+
+    [Fact]
+    public async Task ItWaitsForDataThePageLoadsOnMount()
+    {
+        // The entire reason this goes through the wave loop. Rendering once would write the placeholder
+        // — which is exactly the "Loading…" a crawler sees today, in a different costume.
+        var result = await RaskPrerender.RenderDocumentAsync(
+            new AsyncPage(), Services(), TimeSpan.FromSeconds(5));
+
+        Assert.Contains("loaded", result.Html, StringComparison.Ordinal);
+        Assert.DoesNotContain("loading", result.Html, StringComparison.Ordinal);
+        Assert.False(result.TimedOut);
+    }
+
+    [Fact]
+    public async Task APageThatThrows_IsReportedRatherThanReturnedAsIfItWereThePage()
+    {
+        // The root boundary catches it and renders a perfectly ordinary error document, so a caller
+        // that writes the HTML blindly publishes an error page under the route's own name — and nothing
+        // at build time would say so. Faulted is how it says so.
+        var result = await RaskPrerender.RenderDocumentAsync(
+            new ThrowingPage(), Services(), TimeSpan.FromSeconds(5));
+
+        Assert.True(result.Faulted);
+        Assert.NotEmpty(result.Html);
+    }
+
+    [Fact]
+    public async Task WorkThatNeverSettles_IsReportedRatherThanWaitedForForever()
+    {
+        // Same trap: the markup that comes back is the placeholder. Baking that is worse than not
+        // prerendering the route at all, because it looks prerendered.
+        var result = await RaskPrerender.RenderDocumentAsync(
+            new NeverSettlesPage(), Services(), TimeSpan.FromMilliseconds(150));
+
+        Assert.True(result.TimedOut);
+        Assert.Contains("still-loading", result.Html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TheRouteComesFromTheProvider()
+    {
+        // Which page this renders is the caller's decision: it holds the route table, so it seeds the
+        // route. The prerenderer does not guess how routes are enumerated.
+        var services = Services();
+        services.GetRequiredService<RouteState>().Path = "/seeded";
+
+        var result = await RaskPrerender.RenderDocumentAsync(
+            new RouteEchoPage(services.GetRequiredService<RouteState>()), services, TimeSpan.FromSeconds(5));
+
+        Assert.Contains("/seeded", result.Html, StringComparison.Ordinal);
+    }
+
+    private static IServiceProvider Services()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<RouteState>();
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class PlainPage : Component
+    {
+        protected override Component? Render() => Div["hello"];
+    }
+
+    private sealed class AsyncPage : Component
+    {
+        private string? _value;
+
+        protected override async Task OnMountAsync()
+        {
+            await Task.Delay(20);
+            _value = "loaded";
+        }
+
+        protected override Component? Render() => Div[_value ?? "loading"];
+    }
+
+    private sealed class ThrowingPage : Component
+    {
+        protected override Component? Render() => throw new InvalidOperationException("boom");
+    }
+
+    private sealed class NeverSettlesPage : Component
+    {
+        protected override Task OnMountAsync() => new TaskCompletionSource().Task;
+
+        protected override Component? Render() => Div["still-loading"];
+    }
+
+    private sealed class RouteEchoPage(RouteState route) : Component
+    {
+        protected override Component? Render() => Div[route.Path];
+    }
+}


### PR DESCRIPTION
The first two pieces of build-time prerendering, both in Core and both usable on their own.

A standalone WASM app ships its boot shell to every visitor and every crawler — a spinner and the word
"Loading" — because the real markup does not exist until several megabytes of runtime have downloaded.
That includes this framework's own docs site on GitHub Pages.

## `RaskPrerender.RenderDocumentAsync`

The app's root, wrapped in the same boundary both hosts install, driven through the same waves a
server's first response uses. A page whose `OnMountAsync` loads build-time data writes **the data**,
not its placeholder — which is the whole reason it goes through the wave loop rather than rendering
once.

It is small because #872 moved that loop into Core first.

**`Faulted` and `TimedOut` are on the result for one reason: both still return perfectly ordinary
HTML.** A root boundary renders an error document; a timed-out page renders its placeholder. A caller
that writes either blindly publishes it under the route's own name and nothing at build time says so.
Baking a spinner is worse than not prerendering the route at all, because it *looks* prerendered. The
two negative tests are the ones that matter here.

It deliberately does **not** take a route — the caller seeds `RouteState`, because the caller holds the
route table.

`RenderAsLiveRoot` and `RootErrorBoundary` stay internal. Widening them would expose `publishOnly`,
whose contract is that honouring it is mandatory or every wave re-fires `OnRendered` on everything the
last one rendered. That is not something a caller should have to understand.

## `RaskPrerender.PlanRoutes`

Splits the registered route table into what a pass can and cannot cover.

**`Skipped` is a field on the result rather than a log line**, and that is the decision worth arguing.
A parameterised route cannot be enumerated without the values and a catch-all is a 404 page at best —
so a pass that quietly dropped them would cover a site's static half and report as though it covered
all of it. Making the caller *receive* them means it has to decide what to say. This repo has met that
shape repeatedly: a gate filter that selected no tests, a battery list covering everything except the
newest flag, a collection containing only itself.

Prerenderability is decided on the **parsed segment kinds**, not by looking for a brace in the
template. Both agree today; only one keeps agreeing if the syntax ever grows a construct carrying no
brace, or a literal that contains one.

`RouteFlattener` and `RoutePattern` stay internal — the plan lives beside the renderer and exposes only
its result.

## Not in this PR

The build integration: a companion project compiled from the app's own sources for a desktop TFM, run
at publish, walking the plan and writing `index.html` per route. That is where the MSBuild traps live,
and it is worth landing separately.
