### PR TITLE
fix(external): pack the real build props instead of the SDK-generated shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,27 @@ them until tagged releases begin.
   work, tracked in [#868](https://github.com/pal-tamas/rask/issues/868).
 
 ### Fixed
+- **The packed `Rask.External` now carries its real `build/Rask.External.props`.** The Static Web
+  Assets SDK auto-generates `build/$(PackageId).props` to import its own wiring, so the hand-written
+  file of the same name had a second producer: NuGet packed the SDK's copy first and dropped ours
+  with `NU5118`, and the package shipped a 163-byte import shim in place of the 3.7 KB props. Every
+  `RaskExternal*` property the targets stand on — the output directory, the public base path, the
+  enable switch — was simply absent for anyone consuming the package, while the `.targets` that reads
+  them shipped intact.
+
+  No gate in the repo could see it. In-repo builds import the real file straight off disk via
+  `Directory.Build.props`, so the build, the unit suite and every E2E run pass either way; only
+  `dotnet pack` notices, and only `nightly`/`release` pack. `Rask.External` was added to
+  `nightly.yml` in the same change that introduced it, so its first pack ever was after merge.
+  `Rask.Bootstrap` hit this first and solved it; the fix is the same one-line
+  `StaticWebAssetsDisableProjectBuildPropsFileGeneration`, plus the two guarded `Import`s our file
+  must now carry in the generated one's place — without them a consumer gets no URL for
+  `rask-external.js` and every external component fails to mount.
+
+  Two packaging contracts now pin it: a Razor-SDK project that hand-writes `build/<PackageId>.props`
+  must disable the generated one, and a project that disables it must import the static-web-asset
+  props it replaced. Both were proved by failing them.
+
 - **Targets that invoke a generated MSBuild task now wait for the reference that produces it.**
   `main` went red at #871: `pages` and `nightly` both failed with MSB4062 — the
   `ResolveTypeScriptToolTask` "could not be loaded" from

--- a/src/Rask.External/Rask.External.csproj
+++ b/src/Rask.External/Rask.External.csproj
@@ -27,6 +27,19 @@
          it is what puts wwwroot/rask-external.js on a URL both hosts resolve identically, in-repo and
          from the packed NuGet. Set explicitly so those two agree. -->
     <StaticWebAssetBasePath>_content/Rask.External</StaticWebAssetBasePath>
+
+    <!-- Provide build/Rask.External.props ourselves instead of letting the Static Web Assets SDK
+         auto-generate it, so the same file can carry the RaskExternal* properties the targets stand on
+         AND import the static-web-asset wiring. The SDK still emits
+         build/Microsoft.AspNetCore.StaticWebAssets*.props (which our file imports) plus the
+         buildMultiTargeting/buildTransitive shims that import our build/ file.
+
+         Without this, BOTH files claim build/Rask.External.props: the SDK's is packed first and ours
+         is dropped with NU5118, so the shipped package carries a 163-byte import shim in place of the
+         real props. In-repo everything still works, because Directory.Build.props imports the real
+         file straight off disk — so no build, test or E2E gate can see it. Only `dotnet pack` can.
+         Same reasoning as Rask.Bootstrap, which hit this first. -->
+    <StaticWebAssetsDisableProjectBuildPropsFileGeneration>true</StaticWebAssetsDisableProjectBuildPropsFileGeneration>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Rask.External/build/Rask.External.props
+++ b/src/Rask.External/build/Rask.External.props
@@ -1,5 +1,17 @@
 <Project>
 
+  <!-- The Static Web Assets SDK normally auto-generates this build/$(PackageId).props to import the
+       static-web-asset wiring. We provide it ourselves (StaticWebAssetsDisableProjectBuildPropsFileGeneration
+       in the csproj) so the same file can ALSO carry the RaskExternal* knobs below — the SDK-documented
+       extension point. These imports must stay, or NuGet consumers won't get wwwroot/rask-external.js on
+       a URL and every island fails to mount. They are guarded by Exists() because Directory.Build.props
+       imports THIS file in-repo (for the knobs), where the sibling SDK props live only in the packed
+       layout, not on disk. Same shape as Rask.Bootstrap. -->
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.AspNetCore.StaticWebAssets.props"
+          Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.AspNetCore.StaticWebAssets.props')"/>
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.AspNetCore.StaticWebAssetEndpoints.props"
+          Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.AspNetCore.StaticWebAssetEndpoints.props')"/>
+
   <!--
     Consumer-facing knobs for the island bundle. Override any of these in your project, or with -p:.
 

--- a/tests/Rask.Cli.Tests/PackagingContractTests.cs
+++ b/tests/Rask.Cli.Tests/PackagingContractTests.cs
@@ -536,6 +536,103 @@ public sealed class PackagingContractTests
     }
 
     /// <summary>Every MSBuild file in the repo that is ours, skipping build output and nested worktrees.</summary>
+    [Fact]
+    public void Razor_SDK_packages_that_ship_their_own_build_props_disable_the_generated_one()
+    {
+        // The Static Web Assets SDK auto-generates build/<PackageId>.props to import its wiring. A
+        // project that ALSO hand-writes that file has two producers for one package path: the SDK's
+        // is packed first and the hand-written one is dropped with NU5118, so the package ships a
+        // ~160-byte import shim where the real props should be. Every consumer-facing property the
+        // .targets stands on silently vanishes.
+        //
+        // Nothing else in the repo can see this. In-repo builds import the real file straight off
+        // disk via Directory.Build.props, so build, unit and E2E all pass; only `dotnet pack`
+        // notices, and only the nightly/release workflows pack. Rask.Bootstrap hit it first,
+        // Rask.External repeated it. Hence a contract, not a comment.
+        var offenders = new List<string>();
+
+        foreach (var csproj in Directory.EnumerateFiles(Path.Combine(_repoRoot, "src"), "*.csproj", SearchOption.AllDirectories))
+        {
+            var doc = TryLoad(csproj);
+            if (doc?.Root is null)
+                continue;
+
+            var sdk = doc.Root.Attribute("Sdk")?.Value;
+            if (sdk is null || !sdk.Contains("Razor", StringComparison.Ordinal))
+                continue;
+
+            var dir = Path.GetDirectoryName(csproj)!;
+            var packageId = doc.Root.Descendants("PackageId").FirstOrDefault()?.Value
+                            ?? Path.GetFileNameWithoutExtension(csproj);
+
+            // Only a project that hand-writes the file has a collision to avoid.
+            if (!File.Exists(Path.Combine(dir, "build", $"{packageId}.props")))
+                continue;
+
+            var disabled = doc.Root
+                .Descendants("StaticWebAssetsDisableProjectBuildPropsFileGeneration")
+                .Any(e => string.Equals(e.Value.Trim(), "true", StringComparison.OrdinalIgnoreCase));
+
+            if (!disabled)
+                offenders.Add($"{packageId} hand-writes build/{packageId}.props but does not set "
+                              + "StaticWebAssetsDisableProjectBuildPropsFileGeneration, so pack drops it "
+                              + "for the SDK-generated shim (NU5118).");
+        }
+
+        Assert.True(offenders.Count == 0, string.Join(Environment.NewLine, offenders));
+    }
+
+    [Fact]
+    public void Hand_written_build_props_import_the_static_web_asset_wiring_they_replaced()
+    {
+        // Disabling the generated props means taking over its job. The SDK still packs
+        // build/Microsoft.AspNetCore.StaticWebAssets*.props, but nothing imports them unless our file
+        // does - and without them a consumer gets no URL for the package's wwwroot assets, so every
+        // island fails to mount with a 404 that points nowhere near this file.
+        string[] required =
+        [
+            "Microsoft.AspNetCore.StaticWebAssets.props",
+            "Microsoft.AspNetCore.StaticWebAssetEndpoints.props",
+        ];
+
+        var offenders = new List<string>();
+
+        foreach (var csproj in Directory.EnumerateFiles(Path.Combine(_repoRoot, "src"), "*.csproj", SearchOption.AllDirectories))
+        {
+            var doc = TryLoad(csproj);
+            if (doc?.Root is null)
+                continue;
+
+            var disabled = doc.Root
+                .Descendants("StaticWebAssetsDisableProjectBuildPropsFileGeneration")
+                .Any(e => string.Equals(e.Value.Trim(), "true", StringComparison.OrdinalIgnoreCase));
+
+            if (!disabled)
+                continue;
+
+            var dir = Path.GetDirectoryName(csproj)!;
+            var packageId = doc.Root.Descendants("PackageId").FirstOrDefault()?.Value
+                            ?? Path.GetFileNameWithoutExtension(csproj);
+            var props = Path.Combine(dir, "build", $"{packageId}.props");
+
+            if (!File.Exists(props))
+            {
+                offenders.Add($"{packageId} disables the generated build props but ships no build/{packageId}.props to replace it.");
+                continue;
+            }
+
+            var text = File.ReadAllText(props);
+
+            foreach (var import in required)
+            {
+                if (!text.Contains(import, StringComparison.Ordinal))
+                    offenders.Add($"{packageId}: build/{packageId}.props does not import {import}, so consumers get no static web assets.");
+            }
+        }
+
+        Assert.True(offenders.Count == 0, string.Join(Environment.NewLine, offenders));
+    }
+
     private static IEnumerable<string> EnumerateBuildFiles()
     {
         string[] skip = ["obj", "bin", "node_modules", ".git", ".claude", "artifacts"];


### PR DESCRIPTION
Fixes #891. `nightly`'s `publish-nightly` job is red on `main` (`da90bc77`) and published no
prerelease packages.

## The bug

The Static Web Assets SDK auto-generates `build/$(PackageId).props` to import its own wiring.
`Rask.External` also hand-writes a file of that name, so two producers claim one package path. The
SDK's copy is packed **first**, ours is dropped with `NU5118`, and the package ships this in place of
the real 3.7 KB props:

```xml
<Project>
  <Import Project="Microsoft.AspNetCore.StaticWebAssetEndpoints.props" />
  <Import Project="Microsoft.AspNetCore.StaticWebAssets.props" />
</Project>
```

163 bytes. Every `RaskExternal*` property the targets stand on — `RaskExternalOutputDir`,
`RaskExternalPublicBase`, the enable switch — is absent for a NuGet consumer, while
`build/Rask.External.targets` that reads them ships intact. `-warnaserror` promoting `NU5118` to an
error is the only reason a broken package never reached the feed.

## Why every gate was blind

In-repo builds import the real file straight off disk (`Directory.Build.props:162`), so the build,
the unit suite and every E2E run pass identically whether the packed file is right or wrong. Only
`dotnet pack` can see it, and only `nightly`/`release` pack. `Rask.External` was added to
`nightly.yml` in the same PR that introduced the package (#864), so its first pack ever happened
after merge.

Same shape as #852: in-repo correct, packed artifact wrong, every green gate blind.

## The fix

`Rask.Bootstrap` hit this first and already solved it, comment and all — `Rask.External` simply
missed it. Same one-liner:

```xml
<StaticWebAssetsDisableProjectBuildPropsFileGeneration>true</StaticWebAssetsDisableProjectBuildPropsFileGeneration>
```

Taking over the generated file means taking over its job, so `build/Rask.External.props` now also
carries the two `Exists()`-guarded imports the SDK's copy provided. Without them a consumer gets no
URL for `rask-external.js` and every external component fails to mount — the same class of failure as
#884, one layer further out.

## Guards

Two packaging contracts in `tests/Rask.Cli.Tests/PackagingContractTests.cs`:

- a Razor-SDK project that hand-writes `build/<PackageId>.props` must disable the generated one;
- a project that disables it must import the static-web-asset props it replaced.

**Both proved by failing them**, not by watching them pass — removing the property produced
`Rask.External hand-writes build/Rask.External.props but does not set
StaticWebAssetsDisableProjectBuildPropsFileGeneration…`, and breaking one import produced
`build/Rask.External.props does not import Microsoft.AspNetCore.StaticWebAssetEndpoints.props…`.
Both restored afterwards.

## Testing

- `dotnet pack src/Rask.External/Rask.External.csproj -c Release` — **exit 0, zero `NU5118`**. The
  identical command failed on CI before this change.
- Packed `build/Rask.External.props` is **byte-identical to source** (`diff` clean): 4820 bytes, not
  163.
- Still present in the nupkg: `build/Microsoft.AspNetCore.StaticWebAssets*.props`,
  `buildTransitive/` + `buildMultiTargeting/` shims, `Rask.External.Tasks.dll`,
  `Rask.TypeScript.Tasks.dll`, `staticwebassets/rask-external.js`.
- Local format + unit gate: **50 assemblies, 0 failures, 6993 cases** — the previous 6991 plus the
  two contracts added here.

No runtime code changed, so no benchmark delta applies.
