### PR TITLE
fix(gates): say when a gate is skipped, and name contention when a suite goes red

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -46,6 +46,31 @@ fi
 
 root="$(git rev-parse --show-toplevel)"
 
+# WARNS, never refuses (#850). Every commit runs this hook, and nothing stops one landing in the middle
+# of someone's browser suite — that is the common shape of the contention, and the shape #847's guard
+# does not cover, because a pre-commit gate is not a browser gate. A refusal here would be a worse tax
+# than the flake: a blocked commit costs more than a slow one, and the person committing is usually not
+# the person who can decide to wait. So this only tells you what you are about to walk into.
+if [ -z "${CI:-}" ] && [ -f "$root/scripts/lib/e2e-concurrency.sh" ]; then
+  # shellcheck source=../scripts/lib/e2e-concurrency.sh
+  . "$root/scripts/lib/e2e-concurrency.sh"
+  live_gates="$(rask_other_e2e_runs | tr '\n' ' ')"
+
+  if [ -n "${live_gates// /}" ]; then
+    echo "pre-commit: HEADS UP — a browser E2E gate is running on this machine right now." >&2
+    for pid in $live_gates; do
+      elapsed="$(ps -o etime= -p "$pid" 2>/dev/null | tr -d ' ')"
+      cmd="$(ps -o command= -p "$pid" 2>/dev/null | cut -c1-120)"
+      [ -n "$elapsed" ] && echo "            pid $pid, running for ${elapsed}: $cmd" >&2
+    done
+    echo "            This gate builds and tests the whole solution, so it will compete with that" >&2
+    echo "            suite and may make it fail for reasons that have nothing to do with either" >&2
+    echo "            change. Not refusing — a blocked commit is worse than a slow one — but if that" >&2
+    echo "            run goes red, this is the first thing to suspect." >&2
+    echo >&2
+  fi
+fi
+
 echo "pre-commit: running the local format + unit gate (staged code changes detected)."
 echo "            build -> dotnet format --verify-no-changes -> tests. bypass with"
 echo "            'git commit --no-verify' or RASK_SKIP_UNIT=1."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -94,7 +94,7 @@ elif ! git rev-parse --verify --quiet origin/main >/dev/null; then
     "The code the CLI writes doesn't compile." \
     "A scaffolded project built, but a gate assertion failed — read the failure above."
 elif ! git diff --name-only origin/main...HEAD | grep -E "$generator_paths" >/dev/null; then
-  : # nothing in this push can change what the generators emit
+  echo "pre-push: CLI build gate SKIPPED — nothing in this push matches the generator paths."
 else
   echo "pre-push: this push touches the generators or the packages they emit — running the CLI build gate."
   echo "          bypass with 'git push --no-verify' or RASK_SKIP_CLI_BUILD_E2E=1."
@@ -111,14 +111,18 @@ fi
 # src/Rask.Core/Resources/ is in scope as a whole. The client branch used to live entirely in each
 # host's own file, so naming those two was enough; both hosts now IMPORT the indicator, the morph and
 # the diff codec from there, and an edit to any of them changes what an edit does to a running app.
-watch_paths='^(src/Rask\.Core/(HotReload|ScopedAssets|ScopedCss|Live|Routing|Resources)/|src/Rask\.Server/(LiveSessionStore|RaskEndpointExtensions)\.cs|src/Rask\.Server/Resources/rask\.ts|src/Rask\.Wasm/(HotReload/|Resources/rask\.wasm\.ts|Browser/main\.ts)|src/Rask\.(Generators|Cqrs\.Generators|Generators\.Shared)/|src/Rask\.Cli/(Commands/DevCommand|DevTarget|IBrowserLauncher)\.cs|tests/Rask\.Cli\.Tests/WatchHotReloadE2ETests\.cs|tests/Rask\.Examples\.E2E\.Tests/WasmWatchHotReloadTests\.cs)'
+# src/Rask.Core/build/ is in scope because Rask.Core.targets is where @(Watch) is BUILT: `dotnet watch`
+# collects @(Compile), @(EmbeddedResource), the project file and Razor content and never @(None), so a
+# scoped asset reaches the watcher only through the items that file adds. A change to the watch list
+# itself was the one hot-reload change this filter did not select (found while fixing #862).
+watch_paths='^(src/Rask\.Core/(HotReload|ScopedAssets|ScopedCss|Live|Routing|Resources|build)/|src/Rask\.Server/(LiveSessionStore|RaskEndpointExtensions)\.cs|src/Rask\.Server/Resources/rask\.ts|src/Rask\.Wasm/(HotReload/|Resources/rask\.wasm\.ts|Browser/main\.ts)|src/Rask\.(Generators|Cqrs\.Generators|Generators\.Shared)/|src/Rask\.Cli/(Commands/DevCommand|DevTarget|IBrowserLauncher)\.cs|tests/Rask\.Cli\.Tests/WatchHotReloadE2ETests\.cs|tests/Rask\.Examples\.E2E\.Tests/WasmWatchHotReloadTests\.cs)'
 
 if [ "${RASK_SKIP_WATCH_E2E:-}" = "1" ]; then
   echo "pre-push: RASK_SKIP_WATCH_E2E=1 set — skipping the watch hot-reload gate."
 elif ! git rev-parse --verify --quiet origin/main >/dev/null; then
   echo "pre-push: no origin/main to diff against — skipping the watch hot-reload gate."
 elif ! git diff --name-only origin/main...HEAD | grep -E "$watch_paths" >/dev/null; then
-  : # nothing in this push can change the hot-reload loop
+  echo "pre-push: watch hot-reload gate SKIPPED — nothing in this push matches the hot-reload paths."
 else
   echo "pre-push: this push touches the hot-reload loop — running the watch gate."
   echo "          bypass with 'git push --no-verify' or RASK_SKIP_WATCH_E2E=1."
@@ -146,7 +150,7 @@ if [ "${RASK_SKIP_DEPLOY_E2E:-}" = "1" ]; then
 elif ! git rev-parse --verify --quiet origin/main >/dev/null; then
   echo "pre-push: no origin/main to diff against — skipping the deploy gate."
 elif ! git diff --name-only origin/main...HEAD | grep -E "$deploy_paths" >/dev/null; then
-  : # nothing in this push touches the deploy path
+  echo "pre-push: deploy gate SKIPPED — nothing in this push matches the deploy paths."
 else
   echo "pre-push: this push changes the deploy path — running the deploy gate against a container host."
   echo "          bypass with 'git push --no-verify' or RASK_SKIP_DEPLOY_E2E=1."
@@ -167,7 +171,7 @@ if [ "${RASK_SKIP_INSTALL_E2E:-}" = "1" ]; then
 elif ! git rev-parse --verify --quiet origin/main >/dev/null; then
   echo "pre-push: no origin/main to diff against — skipping the install gate."
 elif ! git diff --name-only origin/main...HEAD | grep -E "$install_paths" >/dev/null; then
-  : # nothing in this push changes the installer
+  echo "pre-push: install gate SKIPPED — nothing in this push matches the installer paths."
 else
   echo "pre-push: this push changes the public installer — running it on a bare container."
   echo "          bypass with 'git push --no-verify' or RASK_SKIP_INSTALL_E2E=1."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,44 @@ them until tagged releases begin.
   work, tracked in [#868](https://github.com/pal-tamas/rask/issues/868).
 
 ### Fixed
+- **A gate that does not run now says so, and a red run under contention says that too.** Two reports
+  about the same failure mode — a gate whose silence is indistinguishable from success
+  ([#845](https://github.com/pal-tamas/rask/issues/845),
+  [#850](https://github.com/pal-tamas/rask/issues/850)).
+
+  The four path-filtered `pre-push` gates — CLI build, watch hot-reload, deploy, install — took a bare
+  `:` branch when nothing in a push matched their paths, printing **nothing at all**. Each now prints
+  one `… SKIPPED — nothing in this push matches the … paths.` line. And one filter was wrong:
+  `src/Rask.Core/build/` was not in `watch_paths`, so a change to `Rask.Core.targets` — the file that
+  *builds* `@(Watch)`, and therefore decides what `dotnet watch` can see at all — did not select the
+  hot-reload gate. The one hot-reload change the hot-reload filter could not catch was a change to the
+  watch list itself.
+
+  **#845's stated mechanism turned out not to be the cause, and is recorded as such.** It reported
+  that a push from a worktree runs the *main checkout's* hooks, because `core.hooksPath` is relative.
+  It does not: git resolves that path against the pushing worktree's own top level. Verified on git
+  2.50.1 in a throwaway repo, pushing from a linked worktree whose `.githooks/pre-push` differed from
+  the main checkout's, from the worktree root and from a subdirectory — the worktree's copy ran both
+  times. So a hook change *is* exercised by the push that introduces it. One real caveat did come out
+  of it: a branch containing no `.githooks/` runs **no hook at all**, with no fallback and no message.
+  `CONTRIBUTING.md` and `docs/development-workflow.md` now state the resolved behaviour instead of
+  leaving it to inference.
+
+  For #850, contention is now *named at the moment of failure* rather than guarded against in advance,
+  which is where the cost actually sits: a timing-sensitive suite that goes red under a competing
+  build reads as a real bug for hours. `run-e2e-local.sh`'s test run was the script's last statement
+  under `set -e`, so a red suite propagated an exit code with no explanation layer — unlike its own
+  build step. Both it and `run-unit-local.sh` now check for a competing heavy build (`dotnet
+  build`/`test`/`publish`/`msbuild`/`pack`, ignoring MSBuild worker nodes so one build is not reported
+  as eight) and add a line asking for a re-run alone before investigating. `pre-commit` warns when a
+  browser gate is live and **never refuses** — every commit runs that hook, and a blocked commit is
+  worse than a slow one.
+
+  Also fixed: the concurrency guard's own refusal was classified as `unknown`, so the hook printed
+  "look for a failing assertion, a timeout, or a host that exited early" — about a suite that never
+  started — directly beneath the guard's correct "wait for the run above to finish". There is now a
+  `busy` kind saying nothing ran. It sits below `code`: a real `error CS` still wins, because if
+  something got far enough to fail compiling then something did run.
 - **The packed `Rask.External` now carries its real `build/Rask.External.props`.** The Static Web
   Assets SDK auto-generates `build/$(PackageId).props` to import its own wiring, so the hand-written
   file of the same name had a second producer: NuGet packed the SDK's copy first and dropped ours

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,11 @@ Most `src/` projects have a sibling `+ Tests` project. Deeper rationale lives in
   `pre-commit` hook that runs the local **format + unit** gate, and the `pre-push` hook that runs the local
   **E2E** gate (see below). Hooks are advisory — bypass any with the git no-verify flag,
   `RASK_SKIP_UNIT=1`, or `RASK_SKIP_E2E=1`.
+
+  `core.hooksPath` is relative, and git resolves it against the **top level of the worktree you are
+  pushing from** — not the main checkout. Most work here happens in `git worktree`s, so this matters:
+  a change to a hook is exercised by its own push, and the copy that runs is the one on the branch
+  under test. If a branch contains no `.githooks/` at all, no hook runs and nothing reports it.
 - **Tests run locally, not in CI.** The unit/integration suite and both E2E suites were moved out of the
   CI pipeline. `.github/workflows/ci.yml` has exactly one job — the deterministic benchmark byte-gates —
   alongside commitlint and GitHub's default CodeQL setup. No workflow in this repo runs `dotnet test`, so

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -111,6 +111,34 @@ Every change passes this gate before a PR (the `rask-ship` skill):
   worktrees, this is the thing that stops you diagnosing a failure that was never in your branch.
   `RASK_E2E_ALLOW_CONCURRENT=1` overrides it; treat anything it then reports as suspect until re-run
   alone.
+
+  **What that guard does not cover.** It detects its own kind — a second browser gate. The commoner
+  collision is everything else competing with a live suite: a `pre-commit` hook, a plain `dotnet
+  build`, a `dotnet publish`, the CLI build gate. None of those is a browser gate, so nothing refuses
+  and nothing warns. Two things soften it now, both hints rather than decisions ([#850]):
+  `pre-commit` says so before it starts when a browser gate is live (it never refuses — a blocked
+  commit is worse than a slow one), and a red suite that finds a heavy build still running names it
+  and asks you to re-run alone before investigating. Neither claims your failure is not real; they
+  say the run was not clean enough to conclude that it is.
+
+- **Every gate says whether it ran.** The path-filtered gates — CLI build, watch hot-reload, deploy,
+  install — used to take a silent branch when nothing in the push matched their paths, printing
+  nothing at all. A gate that does not run then looks exactly like one that passed, which is this
+  repo's most expensive bug class and the thing [#845] was reported over. Each now prints one
+  `… SKIPPED — nothing in this push matches the … paths.` line, so the absence of a gate is visible
+  rather than inferred.
+
+- **Hooks in a worktree run the worktree's own copy.** `core.hooksPath` is the relative path
+  `.githooks`, and git resolves it against the **pushing worktree's** top level, not the main
+  checkout's — so a hook change *is* exercised by the push that introduces it, from a worktree as much
+  as from the main clone. Verified on git 2.50.1 by pushing from a linked worktree whose
+  `.githooks/pre-push` differed from the main checkout's, from the worktree root and from a
+  subdirectory: the worktree's copy ran in both. One caveat worth knowing: if a branch does not
+  contain `.githooks/` at all, **no hook runs and nothing says so** — git does not fall back to the
+  main checkout's copy.
+
+[#845]: https://github.com/pal-tamas/rask/issues/845
+[#850]: https://github.com/pal-tamas/rask/issues/850
 - **The CLI build gate runs locally, enforced before push.** `scripts/run-cli-build-e2e.sh` is the only
   thing proving the code the CLI *writes* actually compiles — every other CLI test asserts on generated
   strings. It packs this commit's Rask packages to a local feed, scaffolds every `rask new` flag

--- a/scripts/lib/build-failure.sh
+++ b/scripts/lib/build-failure.sh
@@ -21,13 +21,21 @@
 
 # Classify a captured build/test log. Echoes exactly one kind:
 #
+#   busy     — the gate REFUSED TO START because another browser gate held the machine. Nothing ran,
+#              so every other kind would be a guess about a run that never happened.
 #   code     — real compile errors (`error CS…`). The gate's own message is correct; the branch is broken.
 #   workload — `error NETSDK1147` and no CS errors. A browser target could not resolve its workload.
 #   sdk      — some other `error NETSDK…` and no CS errors. An SDK/restore problem, still not the branch.
 #   unknown  — neither appears. The gate failed somewhere that is not a compile at all (a failing
 #              assertion, a timeout, a crashed host), so claiming "it doesn't compile" would be wrong too.
 #
-# CS wins when both appear: a NETSDK error alongside genuine compile errors does not excuse them.
+# `busy` is checked FIRST and wins outright. Without it the concurrency guard's refusal fell through to
+# `unknown`, whose advice is "look for a failing assertion, a timeout, or a host that exited early" —
+# advice about a suite that never started, printed directly beneath the guard's own correct explanation
+# and contradicting it. The guard says "wait"; the classifier said "go read your test output".
+#
+# CS wins over the machine kinds when both appear: a NETSDK error alongside genuine compile errors does
+# not excuse them.
 rask_build_failure_kind() {
   local log="${1:-}"
 
@@ -36,13 +44,24 @@ rask_build_failure_kind() {
   # `grep -c`, never `grep -q`. With `set -o pipefail` a `-q` grep exits on the first match, the writer
   # takes SIGPIPE, and the pipeline reports failure — the same trap that let a 421-file commit past the
   # pre-commit hook (see the note in .githooks/pre-commit). `|| true` because grep exits 1 on no match.
-  local cs netsdk workload
+  local cs netsdk workload busy
   cs=$(grep -Ec 'error[[:space:]]+CS[0-9]+' "$log" 2>/dev/null || true)
   netsdk=$(grep -Ec 'error[[:space:]]+NETSDK[0-9]+' "$log" 2>/dev/null || true)
   workload=$(grep -Ec 'error[[:space:]]+NETSDK1147' "$log" 2>/dev/null || true)
 
+  # Matched on the guard's own refusal line, anchored to the script name at the start of a line so a
+  # test log that merely QUOTES the phrase — a case that exists, since the guard's wording is itself
+  # asserted — cannot trip it.
+  busy=$(grep -Ec '^run-e2e-local: another browser E2E gate is already running' "$log" 2>/dev/null || true)
+
+  # `busy` sits BELOW code and above the machine kinds. A refusal means the suite never started, so it
+  # outranks anything inferred from an absence — but it must never outrank a real `error CS`: if
+  # something got far enough to fail compiling then something did run, and hiding that would be #718
+  # in reverse, blaming the machine for a broken branch.
   if [ "${cs:-0}" -gt 0 ]; then
     printf 'code\n'
+  elif [ "${busy:-0}" -gt 0 ]; then
+    printf 'busy\n'
   elif [ "${workload:-0}" -gt 0 ]; then
     printf 'workload\n'
   elif [ "${netsdk:-0}" -gt 0 ]; then
@@ -65,6 +84,15 @@ rask_explain_build_failure() {
   local kind="${1:-unknown}" gate="${2:-gate}" code_message="${3:-}" other_message="${4:-}"
 
   case "$kind" in
+    busy)
+      {
+        echo "$gate: nothing ran — the machine was already busy with another browser gate."
+        echo
+        echo "  The guard above refused to start this suite and named the run that holds the machine."
+        echo "  There is no failure here to investigate: no journey ran, no assertion was evaluated."
+        echo "  Wait for that run to finish and push again."
+      } >&2
+      ;;
     code)
       [ -n "$code_message" ] && echo "$gate: $code_message" >&2
       ;;

--- a/scripts/lib/e2e-concurrency.sh
+++ b/scripts/lib/e2e-concurrency.sh
@@ -118,3 +118,51 @@ rask_e2e_command_of() {
   fi
   ps -o command= -p "$1" 2>/dev/null
 }
+
+# Is some OTHER heavy build competing with this suite? Prints their pids, one per line.
+#
+# This is the collision the guard above does NOT catch, and the one #850 is about. That guard detects
+# its own kind — a second browser gate — and refuses. The expensive case is everything else: a
+# pre-commit hook, a plain `dotnet build`, a `dotnet publish`, the CLI build gate. None of those is a
+# browser gate, so nothing refuses, nothing warns, and the contention is silent. The browser journeys
+# and the WebSocket tests are timing-sensitive; under load they fail in ways that look exactly like
+# real bugs, minutes after the contention, with nothing in the log pointing back at it.
+#
+# Deliberately a HINT and never a decision. `dotnet` runs for dozens of legitimate reasons, most of
+# them cheap, and refusing on any of them would block far more than it protects — so this is consulted
+# only to add a line to a failure that has ALREADY happened. That is why it can afford to be
+# approximate where the refuse-or-proceed guard cannot, and why a false positive costs a sentence
+# rather than a blocked push.
+#
+# Only the verbs that cost minutes and saturate cores: `dotnet run`, `dotnet ef`, `dotnet tool` and a
+# bare `dotnet --version` are not contention worth naming, and a language server certainly is not.
+rask_other_heavy_builds() {
+  self_pid="${1:-$$}"
+
+  candidates="$(
+    if [ -n "${RASK_HEAVY_PGREP_OVERRIDE:-}" ]; then
+      printf '%s\n' $RASK_HEAVY_PGREP_OVERRIDE
+    else
+      pgrep -f 'dotnet' 2>/dev/null || true
+    fi
+  )"
+
+  for pid in $candidates; do
+    [ "$pid" = "$self_pid" ] && continue
+
+    cmd="$(rask_e2e_command_of "$pid")"
+    [ -n "$cmd" ] || continue
+
+    # An MSBuild worker node belongs to a build already counted, so naming every node would report
+    # one build as eight competitors.
+    case "$cmd" in
+      *nodemode*) continue ;;
+    esac
+
+    case "$cmd" in
+      *"dotnet build"*|*"dotnet test"*|*"dotnet publish"*|*"dotnet msbuild"*|*"dotnet pack"*)
+        printf '%s\n' "$pid"
+        ;;
+    esac
+  done
+}

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -51,9 +51,13 @@ cd "$root"
 # Skipped under CI purely so this can never be the thing that breaks an automated run. Nothing in
 # .github/workflows runs the browser E2E today — release.yml only packs, ci.yml runs the benchmark
 # gates — so this is insurance against a future parallel path, not protection of a known one.
+# Sourced unconditionally, though only the REFUSAL below is skipped under CI: the contention hint on a
+# failing suite at the end of this script needs rask_other_heavy_builds either way, and a helper that
+# exists only on one branch of an `if` is a "command not found" waiting for the first CI run.
+# shellcheck source=lib/e2e-concurrency.sh
+. "$root/scripts/lib/e2e-concurrency.sh"
+
 if [ -z "${CI:-}" ]; then
-  # shellcheck source=lib/e2e-concurrency.sh
-  . "$root/scripts/lib/e2e-concurrency.sh"
   others="$(rask_other_e2e_runs | tr '\n' ' ')"
 
   if [ -n "${others// /}" ]; then
@@ -236,9 +240,45 @@ if [ -n "${RASK_E2E_FILTER:-}" ]; then
 else
   echo "==> Browser journey E2E (Rask.Examples.E2E.Tests)"
 fi
+# Not bare, and `set -e` is why this needs saying: this used to be the script's last statement, so a
+# red suite propagated dotnet's exit code with no layer above it — unlike the build step, which is
+# explained. That is where #850's cost actually sits. The suite is timing-sensitive; under a competing
+# build it fails in ways indistinguishable from real bugs, and the hours go on treating a load flake
+# as a defect. Naming the suspicion at the moment of failure is the cheapest thing that attacks that,
+# and it adds a line rather than making a decision, so it has no false-positive cost.
+set +e
 dotnet test tests/Rask.Examples.E2E.Tests/bin/Release/net10.0/Rask.Examples.E2E.Tests.dll \
   --filter "$e2e_filter" \
   --logger "console;verbosity=normal"
+e2e_status=$?
+set -e
+
+if [ "$e2e_status" -ne 0 ]; then
+  # Sampled AFTER the failure rather than during it. A competing build lasts minutes, so it is very
+  # likely still there; a sampler running alongside the suite would be more machinery and would itself
+  # be load the gate does not need.
+  competing="$(rask_other_heavy_builds | tr '\n' ' ')"
+
+  if [ -n "${competing// /}" ]; then
+    {
+      echo
+      echo "run-e2e-local: a heavy build was running on this machine during this suite."
+      for pid in $competing; do
+        elapsed="$(ps -o etime= -p "$pid" 2>/dev/null | tr -d ' ')"
+        cmd="$(ps -o command= -p "$pid" 2>/dev/null | cut -c1-120)"
+        [ -n "$elapsed" ] && echo "               pid $pid, running for ${elapsed}: $cmd"
+      done
+      echo
+      echo "            These journeys and the WebSocket tests are timing-sensitive, and contention"
+      echo "            reads as a plausible failure with nothing in the log pointing back at it."
+      echo "            RE-RUN THIS SUITE ALONE before investigating the failure above — it may be"
+      echo "            real, and this line does not claim otherwise. It only says the run was not"
+      echo "            clean enough to conclude that it is."
+    } >&2
+  fi
+
+  exit "$e2e_status"
+fi
 
 echo
 if [ -n "${RASK_E2E_FILTER:-}" ]; then

--- a/scripts/run-unit-local.sh
+++ b/scripts/run-unit-local.sh
@@ -78,10 +78,40 @@ echo "==> Unit & integration tests (excludes the browser E2E)"
 # crash in an assembly that reported more tests than Rask.Server.Tests has. Blame writes a per-host
 # sequence file naming the test in flight and collects a dump, so the next occurrence is diagnosable
 # instead of merely observed. It costs nothing on a green run.
+set +e
 dotnet test Rask.slnx -c Release --no-build \
   --filter "FullyQualifiedName!~Rask.Examples.E2E$tsc_filter" \
   --blame-crash \
   --results-directory "$root/artifacts/test-blame" \
   --logger "console;verbosity=normal"
+unit_status=$?
+set -e
+
+# The same hint the browser gate prints, for the same reason. This suite has WebSocket and timing
+# tests of its own, and #850 records one being blamed for a change that could not have caused it —
+# the real cause was a browser gate holding the machine while this ran.
+if [ "$unit_status" -ne 0 ]; then
+  # shellcheck source=lib/e2e-concurrency.sh
+  . "$root/scripts/lib/e2e-concurrency.sh"
+  browser_gates="$(rask_other_e2e_runs | tr '\n' ' ')"
+
+  if [ -n "${browser_gates// /}" ]; then
+    {
+      echo
+      echo "run-unit-local: a browser E2E gate was running on this machine during this run."
+      for pid in $browser_gates; do
+        elapsed="$(ps -o etime= -p "$pid" 2>/dev/null | tr -d ' ')"
+        cmd="$(ps -o command= -p "$pid" 2>/dev/null | cut -c1-120)"
+        [ -n "$elapsed" ] && echo "                pid $pid, running for ${elapsed}: $cmd"
+      done
+      echo
+      echo "             Re-run alone before investigating. A timing-sensitive failure here under a"
+      echo "             live browser suite has already cost one investigation into a test the change"
+      echo "             under review could not reach."
+    } >&2
+  fi
+
+  exit "$unit_status"
+fi
 
 echo "==> Format + unit gate passed."

--- a/scripts/tests/build-failure-kind.test.sh
+++ b/scripts/tests/build-failure-kind.test.sh
@@ -41,6 +41,28 @@ assert() {
 
 echo "==> rask_build_failure_kind"
 
+# The refusal, which used to classify as `unknown` — so the hook printed "look for a failing assertion,
+# a timeout, or a host that exited early" directly beneath the guard's own "wait for the run above to
+# finish", about a suite that had not started. Advice pointing at a test output that does not exist.
+assert "the concurrency guard's refusal" busy \
+"pre-push: running the local E2E gate (browser journeys).
+run-e2e-local: another browser E2E gate is already running on this machine.
+               pid 22845, running for 00:07: bash /repo/scripts/run-e2e-local.sh
+"
+
+# It must NOT fire on a log that merely quotes the phrase — a test asserting on the guard's own wording
+# would otherwise make every red run look like contention.
+assert "a test that quotes the refusal is not busy" unknown \
+"  Failed AGuardTest.It_says_another_browser_E2E_gate_is_already_running [12 ms]
+  Assert.Contains() Failure
+"
+
+# A real compile error still wins over a refusal line: if it got far enough to fail compiling, it ran.
+assert "compile errors beat a quoted refusal" code \
+"run-e2e-local: another browser E2E gate is already running on this machine.
+/repo/src/A.cs(1,1): error CS1002: ; expected
+"
+
 # The case the gate always got right, and must keep getting right.
 assert "compile errors alone" code \
   '/src/App/Program.cs(12,9): error CS0246: The type or namespace name '\''Foo'\'' could not be found
@@ -133,6 +155,7 @@ assert_says() {
   fi
 }
 
+assert_says "busy says nothing ran, not that a test failed"  busy no no
 assert_says "code says the branch is broken"          code     yes no
 assert_says "workload blames neither the branch nor the gate" workload no no
 assert_says "sdk blames neither the branch nor the gate"      sdk      no no

--- a/scripts/tests/e2e-concurrency.test.sh
+++ b/scripts/tests/e2e-concurrency.test.sh
@@ -120,6 +120,58 @@ form not  "less /repo/scripts/run-e2e-local.sh"
 form not  ""
 
 echo
+echo "==> rask_other_heavy_builds"
+
+# The #850 half: the competitor that is NOT a browser gate. This one only ever adds a line to a failure
+# that already happened, so the cost of being wrong is asymmetric — a miss loses a hint, a false
+# positive prints a sentence. It still has to tell a real build from `dotnet --version`, or the hint
+# fires on every red run and stops being read.
+heavy() {
+  name="$1"
+  expected="$2"
+  shift 2
+
+  actual="$(rask_other_heavy_builds 100 | tr '\n' ' ' | sed 's/ *$//')"
+  checked=$((checked + 1))
+
+  if [ "$actual" = "$expected" ]; then
+    printf '  ok   %-56s -> [%s]\n' "$name" "$actual"
+  else
+    printf '  FAIL %-56s -> [%s] (expected [%s])\n' "$name" "$actual" "$expected" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+export RASK_HEAVY_PGREP_OVERRIDE="301"
+RASK_E2E_CMD_301="dotnet build Rask.slnx -c Release" heavy "a solution build" "301"
+
+RASK_E2E_CMD_301="dotnet test Rask.slnx --no-build" heavy "a test run" "301"
+RASK_E2E_CMD_301="dotnet publish samples/Rask.Example.Wasm -c Release" heavy "a publish" "301"
+RASK_E2E_CMD_301="dotnet msbuild probe.csproj -getItem:Watch" heavy "an msbuild evaluation" "301"
+RASK_E2E_CMD_301="dotnet pack src/Rask.Core" heavy "a pack" "301"
+
+# The cheap verbs. A dev server, a migration and a version query are not contention worth naming, and
+# reporting them would train people to ignore the line that matters.
+RASK_E2E_CMD_301="dotnet run --project samples/Rask.Example.Server" heavy "a dev server is not contention" ""
+RASK_E2E_CMD_301="dotnet ef migrations add Init" heavy "a migration is not contention" ""
+RASK_E2E_CMD_301="dotnet --version" heavy "a version query is not contention" ""
+RASK_E2E_CMD_301="dotnet tool install -g dotnet-ef" heavy "a tool install is not contention" ""
+
+# One build is ONE competitor. MSBuild spawns a worker node per core, and naming each would report a
+# single `dotnet build` as eight machines fighting for the box.
+RASK_E2E_CMD_301="dotnet /usr/share/dotnet/sdk/10.0.100/MSBuild.dll -nodemode:1 -nologo" \
+  heavy "an MSBuild worker node is not a separate build" ""
+
+# Self is excluded, or the gate reports itself as its own competitor on every failure.
+export RASK_HEAVY_PGREP_OVERRIDE="100"
+RASK_E2E_CMD_100="dotnet test Rask.slnx" heavy "self is excluded" ""
+
+export RASK_HEAVY_PGREP_OVERRIDE="302"
+RASK_E2E_CMD_302="" heavy "a pid that has already exited" ""
+
+unset RASK_HEAVY_PGREP_OVERRIDE
+
+echo
 if [ "$failures" -ne 0 ]; then
   echo "e2e-concurrency: $failures of $checked checks FAILED." >&2
   exit 1


### PR DESCRIPTION
Closes #845. Closes #850.

Two reports about one failure mode: a gate whose silence cannot be told from success.

## The silent skips (#845)

The four path-filtered `pre-push` gates — CLI build, watch hot-reload, deploy, install — took a bare
`:` branch when nothing in a push matched their paths and printed **nothing at all**. Each now prints
one line naming the filter. Visible in this branch's own push:

```
pre-push: CLI build gate SKIPPED — nothing in this push matches the generator paths.
pre-push: watch hot-reload gate SKIPPED — nothing in this push matches the hot-reload paths.
pre-push: deploy gate SKIPPED — nothing in this push matches the deploy paths.
pre-push: install gate SKIPPED — nothing in this push matches the installer paths.
```

One filter was also wrong: `src/Rask.Core/build/` was missing from `watch_paths`, so a change to
`Rask.Core.targets` — the file that *builds* `@(Watch)`, and therefore decides what `dotnet watch` can
see at all — did not select the hot-reload gate. The one hot-reload change that filter could not catch
was a change to the watch list itself.

## #845's stated mechanism is not the cause

The issue reported that a push from a worktree runs the **main checkout's** hooks, because
`core.hooksPath` is relative. **It does not.** Git resolves that path against the pushing worktree's
own top level.

Verified on git 2.50.1 in a throwaway repo — never this one, since other sessions push here — with a
linked worktree whose `.githooks/pre-push` differed from the main checkout's:

| case | hook that ran |
|---|---|
| push from the worktree root | the **worktree's** |
| push from a subdirectory of the worktree | the **worktree's** |
| worktree branch with no `.githooks/` at all | **none, silently** — no fallback to the main checkout |

So a hook change *is* exercised by the push that introduces it, and the shim the issue proposed is not
needed. The third row is a real caveat that came out of the investigation and is now documented.

`CONTRIBUTING.md` and `docs/development-workflow.md` state the resolved behaviour instead of leaving it
to inference.

## Contention, named at the moment of failure (#850)

The existing guard detects its own kind — a second browser gate — and refuses. The expensive collision
is everything else: a `pre-commit` hook, a plain `dotnet build`, a publish. None of those is a browser
gate, so nothing warned.

- `run-e2e-local.sh`'s test run was the script's **last statement** under `set -e`, so a red suite
  propagated an exit code with no explanation layer — unlike its own build step, which is explained.
  It and `run-unit-local.sh` now report a competing heavy build and ask for a re-run alone first.
- MSBuild worker nodes are ignored, so one build is not reported as eight; the cheap verbs (`run`,
  `ef`, `tool`, `--version`) are not named at all, or the hint fires on every red run and stops being
  read.
- `pre-commit` warns when a browser gate is live and **never refuses** — every commit runs that hook,
  and a blocked commit is worse than a slow one.

These are hints, never decisions. They add a line to a failure that has already happened, so a false
positive costs a sentence rather than a blocked push.

## The refusal was being classified as a test failure

The guard's own refusal fell through to `unknown`, so the hook printed *"look for a failing assertion,
a timeout, or a host that exited early"* — about a suite that never started — directly beneath the
guard's correct *"wait for the run above to finish"*. There is now a `busy` kind.

It sits **below** `code`: a real `error CS` still wins, because if something got far enough to fail
compiling then something did run, and blaming the machine there would be #718 inverted. That ordering
was caught by its own test, which failed first.

The fix validated itself on this branch's first push attempt:

```
pre-push: E2E gate (browser journeys): nothing ran — the machine was already busy with another browser gate.

  The guard above refused to start this suite and named the run that holds the machine.
  There is no failure here to investigate: no journey ran, no assertion was evaluated.
```

## Testing

- Full unit gate green: **6933 cases**, plus the bash suites — `build-failure-kind` 17,
  `e2e-concurrency` 33, `install-script` 88.
- Browser E2E gate green on the push that opened this PR.
- New table cases cover `rask_other_heavy_builds` (real verbs vs. cheap ones, MSBuild worker nodes,
  self, already-exited pids) and the `busy` classification — including "a test that merely quotes the
  refusal is not busy", so asserting on the guard's own wording cannot make every red run look like
  contention.
- The `pre-commit` warning block is exercised against the **shipped** hook rather than a copy: it warns
  on a live gate, stays silent when idle, and stays silent on an editor that merely mentions the
  script.

## Not included

Excluding `**/*.md` from `generator_paths` — the other half of #886's report — is left out
deliberately: it was not asked for, and it touches lines adjacent to these changes.
