### PR TITLE
fix(dashboard): embed the console stylesheet on the first build, not the second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,16 @@ them until tagged releases begin.
   was inferred from whether a delegate existed. It is now `o.Retry.Enabled`.
 
 ### Fixed
+- **The ops console shipped with no stylesheet on the first build in a fresh clone.** `Rask.Dashboard`
+  compiles its Tailwind stylesheet into `obj/` and embeds it, but the `EmbeddedResource` item was
+  declared in a static `ItemGroup` guarded by `Condition="Exists(...)"` — and a static item's condition
+  is evaluated when the project is *evaluated*, before any target runs. On a tree that had never built
+  the package the file did not exist yet, the item was silently absent, and the console rendered as
+  unstyled HTML with nothing failing. A second build embedded it, which is why every incremental tree
+  looked fine and the eight `DashboardStylesheetTests` only failed on a clean checkout — the shape
+  `nightly.yml` and `release.yml` both build. The item is now gathered in a target between
+  `_RaskTailwindBuild` and `PrepareResourceNames`, and a missing output is an error rather than a
+  silent omission. Proved by negative control: 8/8 fail on a first build without the fix, 8/8 pass with it.
 
 - **A batteries-included app registered four browser APIs and then could not reach them.** `AddRask()`
   registers `IWebPush`, `INotifications`, `IBadge` and `IWakeLock` unconditionally, but on a Server host

--- a/src/Rask.Dashboard/Rask.Dashboard.csproj
+++ b/src/Rask.Dashboard/Rask.Dashboard.csproj
@@ -87,10 +87,23 @@
     <RaskTailwindMinify>true</RaskTailwindMinify>
   </PropertyGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="obj/dashboard.generated.css"
-                      LogicalName="Rask.Dashboard.dashboard.css"
-                      Condition="Exists('obj/dashboard.generated.css')"/>
-  </ItemGroup>
+  <!--
+    Added from a TARGET rather than a static ItemGroup. A static item's Condition is evaluated when the
+    project is EVALUATED, which is before any target runs — so on the first build in a fresh clone the
+    generated stylesheet does not exist yet, the item is silently absent, and the package ships with no
+    stylesheet at all. Nothing fails the build; the console just renders unstyled, and a SECOND build
+    embeds it, which is why every incremental tree looked fine. _RaskTailwindBuild runs at BeforeBuild,
+    so gathering the item between it and PrepareResourceNames sees the file on every build, first included.
+  -->
+  <Target Name="EmbedRaskDashboardStylesheet"
+          AfterTargets="_RaskTailwindBuild"
+          BeforeTargets="PrepareResourceNames">
+    <Error Condition="!Exists('$(RaskTailwindOutput)')"
+           Text="Rask.Dashboard: $(RaskTailwindOutput) was not produced. The console's stylesheet is compiled by _RaskTailwindBuild from $(RaskTailwindInput) and embedded here; shipping without it renders the console unstyled."/>
+    <ItemGroup>
+      <EmbeddedResource Include="$(RaskTailwindOutput)"
+                        LogicalName="Rask.Dashboard.dashboard.css"/>
+    </ItemGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
## The bug

`Rask.Dashboard` compiles its Tailwind stylesheet to `obj/dashboard.generated.css` and embeds it so
`DashboardLayout` can inline it into the console's document — no static web assets, nothing for a host
to serve. The `EmbeddedResource` item was declared like this:

```xml
<EmbeddedResource Include="obj/dashboard.generated.css"
                  LogicalName="Rask.Dashboard.dashboard.css"
                  Condition="Exists('obj/dashboard.generated.css')"/>
```

A static item's `Condition` is evaluated when the project is **evaluated**, which is before any target
runs. On a tree that has never built the package the file does not exist yet, so the item is silently
absent and the assembly ships with **no stylesheet at all**. Nothing fails the build. The console just
renders as unstyled HTML.

A *second* build embeds it, because by then `_RaskTailwindBuild` has written the file. That is why every
incremental tree looked green — and why the eight `DashboardStylesheetTests` only fail on a clean
checkout, which is exactly the shape `nightly.yml` and `release.yml` build, and the shape a
contributor's first `dotnet test` takes.

## The fix

The item is gathered in a target ordered after `_RaskTailwindBuild` (which runs at `BeforeBuild`) and
before `PrepareResourceNames`, so the file exists every time the item is collected — first build
included. A missing output is now an `Error` rather than an omission: the failure this replaces was
silent, and shipping the console without its stylesheet should stop the build rather than reach a user.

## Testing

Negative control on a genuine first build (`src/Rask.Dashboard/{obj,bin}` and the test project's
deleted):

- fix reverted → **8/8 `DashboardStylesheetTests` fail** (`Assert.NotNull() Failure: Value is null` —
  `GetManifestResourceStream` returns nothing)
- fix applied → **8/8 pass**

Full local unit gate on this branch: **6,611 cases, 0 failed, 49 skipped**; format + warnings-as-errors
clean.

Browser E2E was not re-run. This makes an existing behaviour reliable rather than changing it — the
embedded resource is identical once present, and the 63/63 E2E run on `main` exercised the console
through a warm tree where the resource was already there. The eight targeted tests plus the negative
control are what actually distinguish the two states.

## How it got in

#914 introduced the compile-and-embed arrangement, and it was gated in a worktree that had already
built the package, so the resource was present at evaluation time on every run. The bug surfaced only
when the next gate ran in a worktree whose `obj/` predated the package's Tailwind output.
