### PR TITLE
fix(benchmarks): refresh the payload-bytes baseline, and stop the gate lying about what moves it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,21 @@ them until tagged releases begin.
   was inferred from whether a delegate existed. It is now `o.Retry.Enabled`.
 
 ### Fixed
+- **The payload-bytes gate was red for three merges over a CSS class rename.** #914's Bootstrap sweep
+  renamed classes inside the benchmark scenarios themselves — `row` → `line`, one character longer —
+  and `AppendRowToList100`'s diff is an `InsertSubtree` whose value *is* one row's HTML, so it grew by
+  exactly that byte and the gate reported `112→113` as a codec regression. It was not one: all six
+  scenarios' payload deltas reconcile to the renames with no residue (200 rows x +1 minus
+  `container`→`wrap` = the +195 on `CounterOnLargePage`, and so on), and nothing in the render or diff
+  path moved. The baseline is refreshed to what the renamed markup actually costs
+  ([#919](https://github.com/pal-tamas/rask/issues/919)).
+
+  The comment on `CheckAgainstBaseline` claimed the gated metrics "only move when the render/diff path
+  itself changes". That is what made this read as a real regression, and it is now corrected: a
+  scenario's markup reaches a gated number through `InsertSubtree`, so the scenarios are frozen — a
+  rename sweep skips `benchmarks/`, and a wanted edit refreshes the baseline in the same commit.
+  `main` has no required checks, which is why a red gate rode along unnoticed.
+
 - **The "downloads stream, headers-first" claim now rests on something a gate can see.**
   `docs/cqrs.md` promises a `FileDownload` comes back without being buffered, and `RemoteDispatch` asks
   for exactly that with `HttpCompletionOption.ResponseHeadersRead` — but in the browser neither is

--- a/benchmarks/Rask.Benchmarks/Baselines/payload-bytes.csv
+++ b/benchmarks/Rask.Benchmarks/Baselines/payload-bytes.csv
@@ -1,7 +1,7 @@
 Scenario,FullPayloadBytes,DiffPayloadBytes,DiffOpCount
-CounterOnLargePage,66838,45,1
-KeyedList100Reorder,6691,47,1
-TextNodeUpdate,66721,54,1
-AppendRowToList100,6759,112,1
-RawGuidePage,1770,661,1
-HandlerShiftAboveList100,15133,94,1
+CounterOnLargePage,67033,45,1
+KeyedList100Reorder,6791,47,1
+TextNodeUpdate,66921,54,1
+AppendRowToList100,6860,113,1
+RawGuidePage,1782,661,1
+HandlerShiftAboveList100,15228,94,1

--- a/benchmarks/Rask.Benchmarks/PayloadBytesReport.cs
+++ b/benchmarks/Rask.Benchmarks/PayloadBytesReport.cs
@@ -73,12 +73,22 @@ internal static partial class PayloadBytesReport
         return check ? CheckAgainstBaseline(rows) : 0;
     }
 
-    // Compares the deterministic diff-codec metrics (diff wire bytes + op count — the values that only
-    // move when the render/diff path itself changes) against the committed baseline, and fails the CI
-    // gate on a regression. FullPayloadBytes is informational (it moves whenever the scenario markup
-    // changes) and is not gated. An improvement (fewer bytes/ops) passes but asks for a baseline refresh
-    // so the file keeps tracking reality; a scenario missing from the baseline also fails, so a new
-    // scenario can't slip in ungated.
+    // Compares the deterministic diff-codec metrics (diff wire bytes + op count) against the committed
+    // baseline, and fails the CI gate on a regression. FullPayloadBytes is informational (it moves
+    // whenever the scenario markup changes) and is not gated. An improvement (fewer bytes/ops) passes
+    // but asks for a baseline refresh so the file keeps tracking reality; a scenario missing from the
+    // baseline also fails, so a new scenario can't slip in ungated.
+    //
+    // THE GATED METRICS ARE NOT IMMUNE TO A MARKUP EDIT, and this comment used to claim they were —
+    // that they "only move when the render/diff path itself changes". AppendRowToList100's diff is an
+    // InsertSubtree whose op.Value IS the new row's HTML fragment, so anything that changes a row's
+    // markup lands in a gated number. #914 renamed a class on the benchmark rows (`row` → `line`, one
+    // character longer), the diff grew by exactly that byte, and the gate reported a codec regression
+    // that never happened — red across three merges before anyone worked out why (#919).
+    //
+    // So: the scenarios' own markup is FROZEN. A repo-wide rename sweep must skip benchmarks/, and an
+    // edit here that is genuinely wanted has to refresh Baselines/payload-bytes.csv in the same commit
+    // with the reason, exactly as an improvement is asked to.
     private static int CheckAgainstBaseline(List<Row> current)
     {
         var baselinePath = Path.Combine(AppContext.BaseDirectory, "Baselines", "payload-bytes.csv");


### PR DESCRIPTION
Closes #919.

The `benchmarks` job has been red on `main` since #914 with

```
AppendRowToList100 regressed: diff bytes 112→113, ops 1→1.
```

which reads as a diff-codec regression. It is not one.

## The byte

#914's Bootstrap sweep renamed classes **inside the payload-bytes scenarios themselves** — `row` →
`line`, one character longer. `AppendRowToList100`'s diff is an `InsertSubtree` whose `op.Value` *is*
the new row's HTML fragment, so it grew by exactly that byte.

Every scenario reconciles to the renames with no residue:

| Scenario | Arithmetic | Predicted | Observed |
|---|---|---|---|
| CounterOnLargePage | 200 rows ×+1, `container`→`wrap` −5 | +195 | **+195** |
| KeyedList100Reorder | 100 rows ×+1 | +100 | **+100** |
| TextNodeUpdate | 200 rows ×+1 | +200 | **+200** |
| AppendRowToList100 | 101 rows ×+1 | +101 | **+101** |
| RawGuidePage | 12 nav links ×+1 (`nav-link`→`menu-link`) | +12 | **+12** |
| HandlerShiftAboveList100 | 100 rows ×+1, `container`→`wrap` −5 | +95 | **+95** |

Six for six, so nothing else moved. This PR refreshes the baseline to what the renamed markup costs.

## The part worth keeping

`CheckAgainstBaseline`'s comment claimed the gated metrics "only move when the render/diff path itself
changes". That is false — a scenario's own markup reaches a gated number through `InsertSubtree` — and
believing it is what made a class rename look like a codec regression that rode along through three
merges. The comment now says what actually moves those numbers, and states the rule that follows: the
scenarios' markup is frozen, a repo-wide rename sweep skips `benchmarks/`, and an edit that is
genuinely wanted refreshes the baseline in the same commit.

## Testing

- Ran the report at `7a29d76b` (last green) — reproduces the *old* baseline exactly — and at
  `e605703a` — reproduces the failure exactly. So the boundary and the numbers are measured, not
  inferred from CI.
- `payload-bytes --check` now exits 0 with all six scenarios `[ok]`.
- Format + unit gate green (406 tests). No product code changed, so nothing else is at risk.

One trap worth noting for anyone refreshing this file in future: the gate reads the baseline from
`AppContext.BaseDirectory`, so `--check` after `--no-build` compares against the **stale copy in
`bin/`** and still reports the old failure. Rebuild before trusting it.

## One flaky journey seen on the way

The first push attempt was blocked by
`BrowserJobsWasmExampleTests.Pagehide_drains_hosted_services_but_not_for_a_bfcache_suspend`, which is
unrelated to this diff (a CSV and a comment). It failed at **2s** reporting `0 -> 0 over ~6s` — the
snapshot loop produced *zero* ticks, i.e. it had not started yet, which is not the same shape as the
`event.persisted` guard failing. It passed three times in isolation at 15s each, passed in both full
suites earlier today, and passed in the retry of this gate at 15s. Recording it rather than shrugging:
if it recurs, the assertion probably needs to wait for the first tick before it starts counting.
