### PR TITLE
ci: reject attribution trailers at commit, push, and PR

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -4,6 +4,31 @@
 # CI also enforces this via .github/workflows/commitlint.yml.
 
 msg_file="$1"
+
+root="$(git rev-parse --show-toplevel)"
+# shellcheck source=../scripts/lib/attribution.sh
+. "$root/scripts/lib/attribution.sh"
+
+# Attribution guard. Checked before the merge/revert early-exit below, so those messages are covered
+# too — a squash or merge footer counts on the contributor list exactly like any other. The rule and
+# the reasoning live in scripts/lib/attribution.sh; .githooks/pre-push re-checks it for commits made
+# in a clone that never set core.hooksPath.
+if rask_message_has_attribution < "$msg_file"; then
+  offenders=$(rask_attribution_offenders < "$msg_file")
+  cat >&2 <<EOF
+✖ Commit message carries an attribution trailer:
+
+$offenders
+
+  This repository credits a single contributor. GitHub counts Co-authored-by
+  trailers toward the contributor list, so this footer adds an account that only
+  a full history rewrite can remove.
+
+  Delete the line and commit again — that is the whole fix. Not --no-verify.
+EOF
+  exit 1
+fi
+
 header=$(head -n1 "$msg_file")
 
 # Allow merge/revert/fixup commits through.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -22,6 +22,63 @@ root="$(git rev-parse --show-toplevel)"
 gate_logs="${TMPDIR:-/tmp}/rask-pre-push-$$"
 mkdir -p "$gate_logs"
 
+# --- Attribution guard (cheap, and first) ------------------------------------
+#
+# .githooks/commit-msg already rejects Co-authored-by / Generated-with footers at
+# commit time — but ONLY when core.hooksPath is set. A fresh clone that never ran
+# that config, or an agent committing in a new worktree, bypasses it in silence.
+# That is exactly how two AI trailers reached main and put two extra accounts on
+# GitHub's contributor list, which counts co-authors and not just authors. Taking
+# them back off cost a rewrite of all 970 commits and a force-push of main plus
+# 18 release tags.
+#
+# So the rule is re-checked here, against the commits actually being pushed. This
+# is the last boundary at which the fix is still free: one line, one amend.
+# shellcheck source=../scripts/lib/attribution.sh
+. "$root/scripts/lib/attribution.sh"
+
+zero="0000000000000000000000000000000000000000"
+offending=""
+
+# git feeds the hook "<local ref> <local sha> <remote ref> <remote sha>" per ref.
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  [ "$local_sha" = "$zero" ] && continue   # branch deletion — nothing to inspect
+
+  if [ "$remote_sha" = "$zero" ]; then
+    # New branch: everything on it that no remote already has.
+    range_args="$local_sha --not --remotes"
+  else
+    range_args="$remote_sha..$local_sha"
+  fi
+
+  # shellcheck disable=SC2086  # range_args is deliberately word-split into rev-list
+  for sha in $(git rev-list $range_args); do
+    if git log -1 --format=%B "$sha" | rask_message_has_attribution; then
+      offending="$offending$(git log -1 --format='  %h %s' "$sha")
+"
+    fi
+  done
+done
+
+if [ -n "$offending" ]; then
+  cat >&2 <<EOF
+✖ pre-push: these commits carry an attribution trailer:
+
+$offending
+  This repository credits a single contributor. GitHub counts Co-authored-by
+  trailers toward the contributor list, so pushing these adds accounts that only
+  a full history rewrite can remove.
+
+  Fix with:  git rebase -i --exec 'git commit --amend --no-edit' <base>
+  or, for the tip commit:  git commit --amend
+
+  Install the commit-time guard so this never reaches push again:
+      git config core.hooksPath .githooks
+EOF
+  exit 1
+fi
+# -----------------------------------------------------------------------------
+
 # Run one gate, keep its full output, and — if it fails — say something TRUE about why.
 #
 # Every gate below builds. When the wasm-tools workload is momentarily unresolvable, every

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -24,3 +24,51 @@ jobs:
           # rename here that misses the workflow leaves a green gate enforcing defaults instead of
           # this repo's rules. CommitlintConfigTests pins the two together.
           configFile: commitlint.config.ts
+
+      # The attribution guard, at the one boundary the local hooks cannot cover.
+      #
+      # .githooks/commit-msg and .githooks/pre-push both check this, but both are hooks: they only run
+      # once someone has set core.hooksPath, and a fresh clone has not. That is how two AI trailers
+      # reached main and put two extra accounts on GitHub's contributor list, which credits
+      # Co-authored-by as well as authors — removing them cost a rewrite of all 970 commits.
+      #
+      # The PR BODY is checked too, and is the more important half here: a squash merge builds the
+      # commit message from the PR title and description, so a trailer pasted into the description
+      # lands on main having passed no hook at all.
+      #
+      # Same predicate as the hooks (scripts/lib/attribution.sh) — one regex, three callers.
+      - name: Reject attribution trailers
+        env:
+          # Via env, not ${{ }} interpolation into the script: the body is attacker-controlled text.
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          . scripts/lib/attribution.sh
+
+          failed=0
+
+          for sha in $(git rev-list "$BASE_SHA..$HEAD_SHA"); do
+            if git log -1 --format=%B "$sha" | rask_message_has_attribution; then
+              echo "::error::commit $(git log -1 --format='%h %s' "$sha") carries an attribution trailer"
+              failed=1
+            fi
+          done
+
+          if printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" | rask_message_has_attribution; then
+            echo "::error::the pull request title/description carries an attribution trailer — a squash merge would copy it onto main"
+            failed=1
+          fi
+
+          if [ "$failed" -ne 0 ]; then
+            echo
+            echo "This repository credits a single contributor. GitHub counts Co-authored-by trailers"
+            echo "toward the contributor list, so these add an account that only a history rewrite removes."
+            echo "Delete the line(s); see CONTRIBUTING.md. Install the local guard with:"
+            echo "    git config core.hooksPath .githooks"
+            exit 1
+          fi
+
+          echo "No attribution trailers in $(git rev-list --count "$BASE_SHA..$HEAD_SHA") commit(s), the title, or the body."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **The git hooks reject attribution trailers, at both boundaries.** `Co-authored-by:`,
+  `Claude-Session:` and "Generated with …" footers are refused by `.githooks/commit-msg` at commit
+  time and again by `.githooks/pre-push` over the commits actually being pushed. The rule was already
+  written down; it is now enforced.
+
+  It earns a gate because the cost is wildly asymmetric across the push. GitHub's contributor list
+  credits `Co-authored-by:` trailers as well as authors, so two footers a coding agent appended out of
+  habit — one Claude, one Copilot Autofix — put two extra accounts in the repository sidebar. Removing
+  them meant rewriting all 970 commits and force-pushing `main` and 18 release tags. Before a push the
+  same fix is one deleted line.
+
+  Both hooks are needed. `commit-msg` only runs once `core.hooksPath` is set, and a fresh clone or a
+  new worktree has not set it — which is precisely how the two trailers got in. The predicate lives
+  once, in `scripts/lib/attribution.sh`, so the two cannot drift apart, and
+  `scripts/tests/attribution-guard.test.sh` states 30 cases in both directions: the trailers that
+  actually reached `main` are rejected, and a human `Signed-off-by:`, a merge commit, and a body that
+  merely *discusses* the trailer all still pass.
+
 ### Removed
 - **The nine package ids left behind by earlier removals are retired from nuget.org.** `Rask.Native`,
   `Rask.Templates`, `Rask.Postgres`, `Rask.SqlServer`, `Rask.ObjectStore`, `Rask.Sync`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,14 @@ Most `src/` projects have a sibling `+ Tests` project. Deeper rationale lives in
   pushing from** — not the main checkout. Most work here happens in `git worktree`s, so this matters:
   a change to a hook is exercised by its own push, and the copy that runs is the one on the branch
   under test. If a branch contains no `.githooks/` at all, no hook runs and nothing reports it.
+- **No attribution trailers.** Commit messages carry no `Co-authored-by:`, no `Claude-Session:`, and no
+  "Generated with …" footer. This is not a style preference: GitHub's contributor list credits
+  co-authors as well as authors, so one such footer puts a second account in the repository sidebar,
+  and the only way back off it is a history rewrite — two of them cost a rewrite of all 970 commits
+  and a force-push of `main` and 18 release tags. `commit-msg` rejects them at commit time and
+  `pre-push` re-checks the commits being pushed, because the commit-time hook only runs once
+  `core.hooksPath` is set and a fresh clone has not set it. A human `Signed-off-by:` is fine; the
+  rule is table tested in `scripts/tests/attribution-guard.test.sh`.
 - **Tests and gates run locally, not in CI.** The unit/integration suite, both E2E suites and the
   deterministic benchmark byte-gates all run from `.githooks/`. GitHub does the bare minimum — the
   things only GitHub can do: `commitlint.yml` (commit messages and the PR title, which is the squash

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -133,6 +133,16 @@ Every change passes this gate before a PR (the `rask-ship` skill):
   the "spurious CS1503" that kept this gate on the whitespace pass alone until #584. The
   `.githooks/pre-commit` hook runs it whenever a commit stages code (enable hooks with
   `git config core.hooksPath .githooks`; bypass with `git commit --no-verify` or `RASK_SKIP_UNIT=1`).
+- **Attribution trailers are rejected, at both boundaries.** Commit messages carry no
+  `Co-authored-by:`, no `Claude-Session:` and no "Generated with …" footer. GitHub's contributor list
+  credits co-authors as well as authors, so one footer adds an account to the sidebar that only a
+  history rewrite removes — two of them (one Claude, one Copilot Autofix) cost a rewrite of all 970
+  commits plus a force-push of `main` and 18 release tags. The rule lives once, in
+  `scripts/lib/attribution.sh`, and is consulted by **both** hooks: `.githooks/commit-msg` at commit
+  time, and `.githooks/pre-push` over the commits actually being pushed. The second is not
+  redundant — the first only runs once `core.hooksPath` is set, and a fresh clone or a new worktree
+  has not set it, which is exactly how the two trailers got in. A human `Signed-off-by:` passes;
+  `scripts/tests/attribution-guard.test.sh` states all 30 cases, both directions.
 - **E2E runs locally, enforced before push.** The browser-journey E2E
   (`tests/Rask.Examples.E2E.Tests`, Playwright) was moved out of the CI pipeline. Run it with
   `scripts/run-e2e-local.sh`; the `.githooks/pre-push` hook runs it on `git push` (enable hooks

--- a/scripts/lib/attribution.sh
+++ b/scripts/lib/attribution.sh
@@ -1,0 +1,34 @@
+# Attribution-trailer predicate, shared by .githooks/commit-msg and .githooks/pre-push.
+#
+# This repository credits a single contributor, and that is a property of the COMMIT MESSAGE rather
+# than of the author field: GitHub's contributor list counts `Co-authored-by:` trailers as well as
+# authors. Two footers a coding agent appended out of habit — one Claude, one Copilot Autofix — put
+# two extra accounts in the sidebar, and taking them back off cost a rewrite of all 970 commits plus
+# a force-push of main and 18 release tags. The cost is entirely on the far side of the push, which
+# is why both hooks check and why the rule lives in one file instead of two.
+#
+# POSIX sh: .githooks/commit-msg is `#!/bin/sh`. Nothing here may be a bashism.
+#
+# Table tested by scripts/tests/attribution-guard.test.sh, which also drives the real hooks — the
+# regex being right and the hooks actually consulting it are two different claims.
+
+# Matched case-insensitively, because these trailers arrive spelled every possible way.
+#
+#   - co-authored-by / claude-session   the two footers agents append; anchored so that prose
+#                                       mentioning the trailer mid-sentence is not a false positive
+#   - generated with <tool>             the "🤖 Generated with [Claude Code]" family
+#   - signed-off-by / assisted-by       only when they name a bot or an AI vendor; a human
+#                                       sign-off is none of this guard's business
+RASK_ATTRIBUTION_RE='^[[:space:]]*(co-authored-by|claude-session):|generated with .*(claude|copilot|chatgpt|cursor|codeium|gemini)|^[[:space:]]*(signed-off-by|assisted-by):.*(\[bot\]|anthropic\.com)'
+
+# rask_message_has_attribution — reads a commit message on stdin.
+# Returns 0 when it carries an attribution trailer, 1 when it is clean.
+rask_message_has_attribution() {
+  grep -qiE "$RASK_ATTRIBUTION_RE"
+}
+
+# rask_attribution_offenders — reads a commit message on stdin, prints the offending lines with
+# their line numbers. Prints nothing, and still succeeds, when the message is clean.
+rask_attribution_offenders() {
+  grep -inE "$RASK_ATTRIBUTION_RE" || true
+}

--- a/scripts/tests/attribution-guard.test.sh
+++ b/scripts/tests/attribution-guard.test.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Table test for the attribution guard (scripts/lib/attribution.sh) and the two hooks that use it.
+#
+# The guard exists because GitHub's contributor list credits `Co-authored-by:` trailers as well as
+# authors, so a footer a coding agent appends out of habit silently adds an account to the sidebar.
+# Two of them (Claude, Copilot Autofix) did reach main, and removing them cost a rewrite of all 970
+# commits plus a force-push of main and 18 release tags. Everything about this guard is cheap before
+# a push and very expensive after one, so it is stated as a table rather than left to the cases
+# someone happened to try — same as build-failure-kind.test.sh and e2e-concurrency.test.sh.
+#
+# Both directions cost something. A miss is the failure above. A false positive blocks a legitimate
+# commit, so the prose rows below are as load-bearing as the trailer rows: a body that *discusses*
+# the trailer, or a human Signed-off-by, must pass.
+#
+# Four sections, because "the regex is right" and "the callers consult it" are different claims:
+#   1. the predicate, over a table
+#   2. the real .githooks/commit-msg, driven end to end
+#   3. the real .githooks/pre-push, driven end to end in an isolated throwaway repository
+#   4. .github/workflows/commitlint.yml — structural only; it needs a pull_request event to run,
+#      so what is pinned is that it still sources the shared predicate and still checks the PR body
+#   5. proof that all of the above left THIS repository untouched — section 3 makes commits, and a
+#      test that commits has to show it committed somewhere else (see the GIT_DIR note below)
+#
+# Usage:  scripts/tests/attribution-guard.test.sh   (run by scripts/run-unit-local.sh)
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+# Scrub the git environment before anything else runs, and do not skip this.
+#
+# git EXPORTS GIT_DIR (and friends) to the hooks it invokes, and this file is run by
+# scripts/run-unit-local.sh, which .githooks/pre-commit runs — so under a commit, every `git` call
+# below inherits a GIT_DIR pointing at the real repository. Section 3 creates a throwaway repository
+# and commits into it; with GIT_DIR still set, `cd`-ing there changes nothing and those commits land
+# on the branch being developed instead. That is not hypothetical: it happened on the first run of
+# this test under the hook, which put two "chore: probe" commits on the branch and left the whole
+# tree looking untracked. Passing standalone and destroying the repo under a hook is exactly the
+# shape of failure this suite exists to catch.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES \
+      GIT_COMMON_DIR GIT_PREFIX GIT_REFLOG_ACTION GIT_INDEX_VERSION GIT_QUARANTINE_PATH
+
+# Pinned so the last assertion can prove this run left the real repository exactly as it found it.
+repo_head_before="$(git rev-parse HEAD)"
+repo_status_before="$(git status --porcelain)"
+
+# shellcheck source=../lib/attribution.sh
+. "$root/scripts/lib/attribution.sh"
+
+failures=0
+checked=0
+
+pass() { printf '  ok   %-58s\n' "$1"; }
+fail() { printf '  FAIL %-58s %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+
+# assert_predicate <name> <dirty|clean> <message>
+assert_predicate() {
+  checked=$((checked + 1))
+  if printf '%b' "$3" | rask_message_has_attribution; then actual="dirty"; else actual="clean"; fi
+  if [ "$actual" = "$2" ]; then pass "$1"; else fail "$1" "-> $actual (expected $2)"; fi
+}
+
+echo "==> rask_message_has_attribution"
+
+# The two footers that actually reached main.
+assert_predicate "the Claude trailer that reached main" dirty \
+  'fix: x\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>\n'
+assert_predicate "the Copilot Autofix trailer" dirty \
+  'fix: x\n\nCo-authored-by: Copilot Autofix powered by AI <62310815+github-advanced-security[bot]@users.noreply.github.com>\n'
+
+# The rest of the family, spelled the ways they arrive.
+assert_predicate "lower-case co-authored-by"        dirty 'fix: x\n\nco-authored-by: a <a@b.c>\n'
+assert_predicate "leading whitespace"               dirty 'fix: x\n\n  Co-authored-by: a <a@b.c>\n'
+assert_predicate "a bot co-author"                  dirty 'build: b\n\nCo-authored-by: dependabot[bot] <1@users.noreply.github.com>\n'
+assert_predicate "the session footer"               dirty 'fix: x\n\nClaude-Session: https://claude.ai/code/session_01\n'
+assert_predicate "generated-with, emoji form"       dirty 'fix: x\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n'
+assert_predicate "generated-with, Copilot"          dirty 'fix: x\n\nGenerated with GitHub Copilot\n'
+assert_predicate "a bot sign-off"                   dirty 'build: b\n\nSigned-off-by: dependabot[bot] <support@github.com>\n'
+assert_predicate "an AI-vendor sign-off"            dirty 'fix: x\n\nSigned-off-by: someone <noreply@anthropic.com>\n'
+
+# Clean messages. These are the false-positive guard rails.
+assert_predicate "an ordinary commit"               clean 'feat(forms): add RadioGroup disabled state\n\nA normal body.\n'
+assert_predicate "a merge commit"                   clean 'Merge branch main into topic\n'
+assert_predicate "a revert"                         clean 'Revert "feat: x"\n'
+assert_predicate "prose naming the trailer"         clean 'docs: explain\n\nThe co-authored-by footer is banned in this repository.\n'
+assert_predicate "a HUMAN sign-off"                 clean 'fix: x\n\nSigned-off-by: Tamas Pal <pal.tamas@pptgateway.hu>\n'
+assert_predicate "a body mentioning Claude Code"    clean 'docs: mention the agent\n\nClaude Code is one of the supported agents.\n'
+assert_predicate "a subject naming a bot file"      clean 'chore: update dependabot.yml\n'
+
+echo "==> .githooks/commit-msg (the real hook)"
+
+msg_tmp="$(mktemp)"
+trap 'rm -f "$msg_tmp"' EXIT
+
+# assert_commit_msg <name> <expected-exit> <message>
+assert_commit_msg() {
+  checked=$((checked + 1))
+  printf '%b' "$3" > "$msg_tmp"
+  set +e
+  sh "$root/.githooks/commit-msg" "$msg_tmp" >/dev/null 2>&1
+  actual=$?
+  set -e
+  if [ "$actual" = "$2" ]; then pass "$1"; else fail "$1" "-> exit $actual (expected $2)"; fi
+}
+
+assert_commit_msg "rejects the trailer"            1 'fix: x\n\nCo-Authored-By: Claude <noreply@anthropic.com>\n'
+assert_commit_msg "rejects it on a MERGE commit"   1 'Merge branch a\n\nCo-authored-by: Claude <noreply@anthropic.com>\n'
+assert_commit_msg "accepts a clean commit"         0 'feat(forms): add RadioGroup disabled state\n'
+assert_commit_msg "accepts a clean merge"          0 'Merge branch main into topic\n'
+assert_commit_msg "still rejects a bad subject"    1 'random text\n'
+
+echo "==> .githooks/pre-push (the real hook, isolated repository)"
+
+# Driven in a throwaway repository rather than this one: the hook makes commits' worth of decisions
+# and the test must not need to create, or clean up, commits in the repository being developed. The
+# hook and the libs it sources are COPIED from this tree, so what runs is the shipped file.
+push_repo="$(mktemp -d)"
+trap 'rm -f "$msg_tmp"; rm -rf "$push_repo"' EXIT
+
+mkdir -p "$push_repo/scripts/lib" "$push_repo/.githooks"
+cp "$root/scripts/lib/attribution.sh" "$root/scripts/lib/build-failure.sh" "$push_repo/scripts/lib/"
+cp "$root/.githooks/pre-push" "$push_repo/.githooks/pre-push"
+
+(
+  cd "$push_repo"
+  git init -q -b main
+  git config user.email "test@example.invalid"
+  git config user.name "Test"
+  echo one > f && git add f && git commit -q -m "chore: base"
+) >/dev/null 2>&1
+
+base="$(git -C "$push_repo" rev-parse HEAD)"
+
+(
+  cd "$push_repo"
+  echo two >> f
+  git commit -qa -m "chore: probe
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+) >/dev/null 2>&1
+dirty="$(git -C "$push_repo" rev-parse HEAD)"
+
+(cd "$push_repo" && git commit -q --amend -m "chore: probe") >/dev/null 2>&1
+clean="$(git -C "$push_repo" rev-parse HEAD)"
+
+# assert_pre_push <name> <sha> <expected-exit>
+assert_pre_push() {
+  checked=$((checked + 1))
+  set +e
+  actual="$(
+    cd "$push_repo" || exit 9
+    printf 'refs/heads/main %s refs/heads/main %s\n' "$2" "$base" \
+      | RASK_SKIP_E2E=1 RASK_SKIP_BENCHMARKS=1 RASK_SKIP_CLI_BUILD_E2E=1 RASK_SKIP_WATCH_E2E=1 \
+        RASK_SKIP_DEPLOY_E2E=1 RASK_SKIP_INSTALL_E2E=1 \
+        bash .githooks/pre-push origin https://example.invalid >/dev/null 2>&1
+    echo $?
+  )"
+  set -e
+  if [ "$actual" = "$3" ]; then pass "$1"; else fail "$1" "-> exit $actual (expected $3)"; fi
+}
+
+assert_pre_push "blocks a push carrying the trailer" "$dirty" 1
+assert_pre_push "lets a clean push through"          "$clean" 0
+
+echo "==> .github/workflows/commitlint.yml (the CI backstop)"
+
+# Structural, and deliberately so: this one cannot be driven here, because it only runs inside a
+# pull_request event with a base and head sha. What it CAN be held to is that it still consults the
+# shared predicate rather than a second copy of the regex that would drift, and that it still checks
+# the PR body — a squash merge builds the commit message from the title and description, so the body
+# is the one path onto main that no local hook sees.
+workflow="$root/.github/workflows/commitlint.yml"
+
+assert_contains() {
+  checked=$((checked + 1))
+  if grep -q "$2" "$workflow"; then pass "$1"; else fail "$1" "-> '$2' is gone from commitlint.yml"; fi
+}
+
+assert_contains "CI sources the shared predicate"  'scripts/lib/attribution.sh'
+assert_contains "CI calls it, not its own regex"   'rask_message_has_attribution'
+assert_contains "CI checks the PR body"            'PR_BODY'
+
+if grep -q 'RASK_ATTRIBUTION_RE=' "$workflow"; then
+  fail "CI does not redefine the regex" "-> commitlint.yml sets RASK_ATTRIBUTION_RE; it must source the lib"
+else
+  pass "CI does not redefine the regex"
+fi
+checked=$((checked + 1))
+
+echo "==> this test left the repository alone"
+
+# The regression pin for the bug above. Section 3 commits, and a test that commits must prove it
+# committed somewhere else — a stale GIT_DIR is invisible until it has already rewritten your branch.
+checked=$((checked + 1))
+if [ "$(git rev-parse HEAD)" = "$repo_head_before" ]; then
+  pass "HEAD is where it was"
+else
+  fail "HEAD is where it was" "-> $(git rev-parse HEAD), was $repo_head_before — a git env var leaked"
+fi
+
+checked=$((checked + 1))
+if [ "$(git status --porcelain)" = "$repo_status_before" ]; then
+  pass "the working tree is where it was"
+else
+  fail "the working tree is where it was" "-> status changed; a git env var leaked into the temp repo"
+fi
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "  $checked cases, all passed"
+else
+  echo "  $checked cases, $failures FAILED" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Enforces the "no attribution footers" rule that `CONTRIBUTING.md` and `CLAUDE.md` already stated, at all three boundaries such a footer can cross.

GitHub's contributor list credits co-author trailers as well as commit authors. Two footers a coding agent appended out of habit — one Claude, one Copilot Autofix, three lines in total — put two extra accounts in this repository's sidebar. Taking them back off meant rewriting all 970 commits and force-pushing `main` and 18 release tags. Before a push, the same fix is one deleted line. That asymmetry is the whole argument for a gate.

## What changed

| Boundary | Where | Catches |
|---|---|---|
| Commit | `.githooks/commit-msg` | the footer as it is written, before the merge/revert early-exit so merge and squash messages are covered too |
| Push | `.githooks/pre-push` | commits made in a clone that never set `core.hooksPath` — which is exactly how the two footers got in |
| Merge | `.github/workflows/commitlint.yml` | the PR title and body: a squash merge builds its commit message from the description, so a footer pasted there reaches `main` having passed no hook at all |

The predicate lives once, in `scripts/lib/attribution.sh`, so three callers cannot drift into three regexes. A human sign-off is explicitly none of the guard's business.

## Testing

`scripts/tests/attribution-guard.test.sh` — 30 cases, picked up automatically by `scripts/run-unit-local.sh`. It drives the **real** hooks rather than a copy:

- the two footers that actually reached `main` are rejected, along with the rest of the family (lower-case, leading whitespace, bot co-authors, the session footer, the "generated with" forms, bot sign-offs)
- a human sign-off, a merge commit, a revert, and a body that merely *discusses* the rule all still pass — the false-positive direction costs a blocked commit, so it is stated too
- `pre-push` is driven end to end in a throwaway repository

Verified as a gate, not a decoration: neuter the regex and 13 of the 30 cases go red (exit 1); restore it and they go green (exit 0).

Full local gate green — `scripts/run-unit-local.sh`: format + analyzers clean, 406 tests passed, all 7 script gates pass.

### One bug worth naming

The first run of this test **under `pre-commit`** put two `chore: probe` commits on the branch. git exports `GIT_DIR` to the hooks it invokes, so the throwaway repository the test creates was `cd`-ed into but still resolved to the real one. It passed standalone and corrupted the branch under a hook — precisely the shape of failure this suite exists to catch.

Fixed by scrubbing the inherited git environment, and pinned: the last two cases assert `HEAD` and the working tree are exactly where the test found them. Re-verified by running the suite with `GIT_DIR` deliberately exported — 30/30 green, `HEAD` unchanged.

## Changelog

`[Unreleased] → Added`.
