### PR TITLE
test(hooks): stop the attribution suite writing git config into the real repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,18 @@ them until tagged releases begin.
   Both hooks are needed. `commit-msg` only runs once `core.hooksPath` is set, and a fresh clone or a
   new worktree has not set it — which is precisely how the two trailers got in. The predicate lives
   once, in `scripts/lib/attribution.sh`, so the two cannot drift apart, and
-  `scripts/tests/attribution-guard.test.sh` states 30 cases in both directions: the trailers that
+  `scripts/tests/attribution-guard.test.sh` states 32 cases in both directions: the trailers that
   actually reached `main` are rejected, and a human `Signed-off-by:`, a merge commit, and a body that
   merely *discusses* the trailer all still pass.
+
+  The suite makes commits, so it also proves it made them somewhere else. git exports `GIT_DIR` to
+  the hooks it invokes, and this file runs under `pre-commit`: on its first run the throwaway
+  repository it creates resolved to the real one, its `git config user.*` writes landed in the shared
+  `.git/config`, every worktree inherited that identity, and the next real commit was authored by it —
+  which GitHub turned into a `Co-authored-by:` trailer on the squash commit. The guard, defeated by
+  its own test. The identity now travels in `GIT_AUTHOR_*`/`GIT_COMMITTER_*`, which cannot leak into a
+  config file, and four assertions pin `HEAD`, the working tree, the committing identity and the
+  absence of any `git config user.*` write.
 
 ### Removed
 - **The nine package ids left behind by earlier removals are retired from nuget.org.** `Rask.Native`,

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -142,7 +142,7 @@ Every change passes this gate before a PR (the `rask-ship` skill):
   time, and `.githooks/pre-push` over the commits actually being pushed. The second is not
   redundant — the first only runs once `core.hooksPath` is set, and a fresh clone or a new worktree
   has not set it, which is exactly how the two trailers got in. A human `Signed-off-by:` passes;
-  `scripts/tests/attribution-guard.test.sh` states all 30 cases, both directions.
+  `scripts/tests/attribution-guard.test.sh` states all 32 cases, both directions.
 - **E2E runs locally, enforced before push.** The browser-journey E2E
   (`tests/Rask.Examples.E2E.Tests`, Playwright) was moved out of the CI pipeline. Run it with
   `scripts/run-e2e-local.sh`; the `.githooks/pre-push` hook runs it on `git push` (enable hooks

--- a/scripts/tests/attribution-guard.test.sh
+++ b/scripts/tests/attribution-guard.test.sh
@@ -44,6 +44,13 @@ unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OB
 repo_head_before="$(git rev-parse HEAD)"
 repo_status_before="$(git status --porcelain)"
 
+# And the committing identity, which is the half that got away the first time. HEAD and the working
+# tree were both checked and both looked clean, because the damage was in .git/config: this suite
+# had written "Test <test@example.invalid>" there, so the NEXT commit — a real one, made later, by
+# something else entirely — carried it. A test that sets an identity has to prove it did not set
+# yours. Empty when unset, which is itself the value to preserve.
+repo_ident_before="$(git config --get user.name || true)|$(git config --get user.email || true)"
+
 # shellcheck source=../lib/attribution.sh
 . "$root/scripts/lib/attribution.sh"
 
@@ -121,11 +128,26 @@ mkdir -p "$push_repo/scripts/lib" "$push_repo/.githooks"
 cp "$root/scripts/lib/attribution.sh" "$root/scripts/lib/build-failure.sh" "$push_repo/scripts/lib/"
 cp "$root/.githooks/pre-push" "$push_repo/.githooks/pre-push"
 
+# The throwaway repository's identity, passed through the ENVIRONMENT rather than written with
+# `git config`. A config write is a write, and it lands wherever git thinks the repository is.
+#
+# This file used to run `git config user.email ...` here. The first time it ran under pre-commit, a
+# leaked GIT_DIR (see the scrub above) sent those two lines into the REAL repository's .git/config —
+# which is shared by every worktree. The next real commit was therefore authored by
+# "Test <test@example.invalid>", GitHub turned that into a Co-authored-by trailer on the squash
+# commit, and the pull request adding this guard put an attribution trailer on main. Removing it
+# cost another force-push. The guard, defeated by its own test.
+#
+# Environment variables cannot leak into a config file, so this failure mode is closed by
+# construction rather than by remembering to scrub. The assertions at the end of this file prove it.
+export GIT_AUTHOR_NAME="Rask attribution test"
+export GIT_AUTHOR_EMAIL="attribution-test@rask.invalid"
+export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+
 (
   cd "$push_repo"
   git init -q -b main
-  git config user.email "test@example.invalid"
-  git config user.name "Test"
   echo one > f && git add f && git commit -q -m "chore: base"
 ) >/dev/null 2>&1
 
@@ -203,6 +225,25 @@ if [ "$(git status --porcelain)" = "$repo_status_before" ]; then
   pass "the working tree is where it was"
 else
   fail "the working tree is where it was" "-> status changed; a git env var leaked into the temp repo"
+fi
+
+# The one that was missing. HEAD and the tree both looked clean while .git/config had already been
+# rewritten, and the cost landed on a later commit made by something else.
+checked=$((checked + 1))
+repo_ident_after="$(git config --get user.name || true)|$(git config --get user.email || true)"
+if [ "$repo_ident_after" = "$repo_ident_before" ]; then
+  pass "the committing identity is untouched"
+else
+  fail "the committing identity is untouched" \
+    "-> '$repo_ident_after', was '$repo_ident_before' — this suite wrote git config into a real repo"
+fi
+
+# Belt and braces: nothing in this file may write an identity into any repository at all.
+checked=$((checked + 1))
+if grep -qE '^[[:space:]]*git config user\.' "$0"; then
+  fail "no 'git config user.*' writes in this file" "-> use GIT_AUTHOR_*/GIT_COMMITTER_* instead"
+else
+  pass "no 'git config user.*' writes in this file"
 fi
 
 echo


### PR DESCRIPTION
## Summary

Follow-up to #925. That PR's own test wrote `git config user.*` into the **real** repository, and the resulting bad author became an attribution trailer on `main` — from the pull request that banned attribution trailers. This closes the write, and adds the two assertions that would have caught it.

## What happened

git exports `GIT_DIR` to the hooks it invokes, and `scripts/tests/attribution-guard.test.sh` runs under `pre-commit` via `scripts/run-unit-local.sh`. With `GIT_DIR` set, `cd` into another repository changes nothing — every `git` call still targets the real one. So the "throwaway" repository the test creates was not throwaway:

1. its `chore: base` / `chore: probe` commits landed on the branch being developed;
2. `git config user.email test@example.invalid` landed in the **shared** `.git/config`, which every worktree reads;
3. the next real commit was authored by `Test <test@example.invalid>`, and GitHub's squash merge turned that author into a co-author trailer on `main`.

#925 already added the `GIT_DIR` scrub, which closes (1). This closes (2).

## What changed

- **Identity travels in the environment.** `GIT_AUTHOR_*` / `GIT_COMMITTER_*` instead of `git config` writes. An environment variable cannot leak into a config file regardless of what git exported, so the failure is closed by construction rather than by remembering to scrub.
- **Two new pins.** The suite already proved `HEAD` and the working tree were untouched — and both *were*. The damage sat in `.git/config` and surfaced on a later commit made by something else, which is exactly why those two assertions missed it. It now also pins the committing identity, and greps itself for any `git config user.*` write.

32 cases.

## Testing

Full local gate green — `scripts/run-unit-local.sh`: format + analyzers clean, 406 tests, all 7 script gates.

Proven by reproducing the original break inside a throwaway **clone** (so the damage was contained): with the scrub removed and the config writes restored, run with `GIT_DIR` exported —

```
FAIL HEAD is where it was                    -> 2f922c25, was 68f1acc2
FAIL the working tree is where it was        -> status changed
FAIL the committing identity is untouched    -> 'Test|test@example.invalid', was 'pt|pal.tamas@...'
FAIL no 'git config user.*' writes in this file
32 cases, 4 FAILED
```

Restore them and it is 32 green. The clone's identity was rewritten by the broken version, confirming the reproduction was faithful.

Verified on this very commit: it is authored `pt <pal.tamas@pptgateway.hu>`, the repository has no local `user.*` override, and no probe commits reached the branch.

## Changelog

Folded into the existing `[Unreleased] → Added` entry, since #925 is unreleased.
