### PR TITLE
docs(site): show the README's counter on the other two front doors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,19 @@ them until tagged releases begin.
   `Rask.Chrome` and `Rask.Client` needed nothing: they were never published.
 ### Changed
 
+- **The other two front doors show the same counter as the README.** #924 cut the front-page sample to
+  one button, but `NUGET.md` — the readme packed into every published package, so the nuget.org landing
+  page — and the landing site's hero still showed the three-line `H1`/`P`/`Button["Click me"]` version.
+  The site hero was further adrift than that: it showed `Counter : Page` with a
+  `protected override string Route => "/counter"`, an API that exists nowhere in the tree any more, so
+  the first code a visitor read could not compile. Both now carry the README's block verbatim, and
+  `NUGET.md`'s intro drops the "no `.razor`, no JSX, no JavaScript" claim the README dropped.
+
+  `ChainAnimation` (and the `assets/rask-chain.svg` baked from it) deliberately keeps the longer sample:
+  it is a timed typing animation whose point is the completion list opening after `Button.`, which needs
+  the multi-line form to read. `docs/getting-started.md` keeps it too, where the heading and paragraph
+  are what the surrounding prose teaches.
+
 - **The README is a front page again, and the front end has three peers.** It was 191 lines that opened
   with a 30-row package table (a NuGet shield per row) and a second collapsed table mapping every package
   to its entry-point API, so a reader met two dozen package names before they met the framework. It now

--- a/NUGET.md
+++ b/NUGET.md
@@ -9,22 +9,18 @@
 
 </div>
 
-Write components as plain C# classes. Return a tree of HTML from `Render()`. **No `.razor`, no JSX,
-no JavaScript to write** — and the *same* component code runs server-rendered with live WebSocket
+Write components as plain C# classes. Return a tree of HTML from `Render()`: state is a field, and an
+event handler is a delegate. The *same* component code runs server-rendered with live WebSocket
 updates or fully client-side on WebAssembly.
 
 ```csharp
 [Route("/counter")]
-public sealed class Counter : Component
+public sealed partial class Counter : Component
 {
     private int _count;
 
     protected override Component? Render() =>
-    [
-        H1["Counter"],
-        P[$"Current count: {_count}"],
-        Button.OnClick(() => _count++)["Click me"]
-    ];
+        Button.OnClick(() => _count++)[$"Current count: {_count}"];
 }
 ```
 

--- a/samples/Rask.Example.Site/App.cs
+++ b/samples/Rask.Example.Site/App.cs
@@ -384,18 +384,13 @@ public partial class App : Component
     // Static, trusted syntax-highlighted markup for the Counter.cs sample (global .t-* classes).
     private const string CounterCodeHtml =
         """
-        <span class="t-key">public sealed partial class</span> <span class="t-type">Counter</span> : <span class="t-type">Page</span>
+        [<span class="t-type">Route</span>(<span class="t-str">"/counter"</span>)]
+        <span class="t-key">public sealed partial class</span> <span class="t-type">Counter</span> : <span class="t-type">Component</span>
         {
-            <span class="t-key">protected override string</span> Route =&gt; <span class="t-str">"/counter"</span>;
-
             <span class="t-key">private int</span> _count;
 
             <span class="t-key">protected override</span> <span class="t-type">Component</span>? <span class="t-fn">Render</span>() =&gt;
-            [
-                <span class="t-type">H1</span>[<span class="t-str">"Counter"</span>],
-                <span class="t-type">P</span>[<span class="t-str">$"Current count: {_count}"</span>],
-                <span class="t-type">Button</span>.<span class="t-fn">OnClick</span>(() =&gt; _count++)[<span class="t-str">"Click me"</span>]
-            ];
+                <span class="t-type">Button</span>.<span class="t-fn">OnClick</span>(() =&gt; _count++)[<span class="t-str">$"Current count: {_count}"</span>];
         }
         """;
 }


### PR DESCRIPTION
## Summary

#924 cut the front-page counter to a single button, but the two other places a newcomer meets Rask
kept the old three-line version: **`NUGET.md`**, which is packed into every published package and so
*is* the nuget.org landing page, and the **landing site's hero**. Both now carry the README's block
verbatim.

The hero was further adrift than the sample. It showed:

```csharp
public sealed partial class Counter : Page
{
    protected override string Route => "/counter";
```

Neither a `Page` base class nor an `override string Route` exists anywhere in `src/` or `samples/` —
both greps return nothing — so the first Rask code a visitor to the landing page read **could not
compile**. It now shows `[Route("/counter")]` on a `Component`, matching the README and the rest of
the docs.

`NUGET.md`'s intro also drops the "no `.razor`, no JSX, no JavaScript to write" claim, which the
README dropped in #924. Since `NUGET.md` is the more public surface, leaving it there would have kept
the removed claim on every package page.

**Deliberately unchanged.** `ChainAnimation` — and the `assets/rask-chain.svg` baked from it — keeps
the longer sample: it is a timed typing animation whose subject is the completion list opening after
`Button.`, so the multi-line form is load-bearing and collapsing it would mean re-choreographing the
timings and re-baking the SVG for a worse result. `docs/getting-started.md` keeps it for a related
reason: the heading and paragraph are what the surrounding prose teaches.

## Testing

- `scripts/run-unit-local.sh` — format + warnings-as-errors build + **49 test projects, all green**.
- `scripts/run-e2e-local.sh` (via `pre-push`) — **63 browser tests passed**. Required because
  `samples/Rask.Example.Site/App.cs` is a `samples/` change.
- `Rask.Example.Site.Tests` — 8 tests, covering the page the hero renders into.
- The `NUGET.md` counter block was diffed against the README's and is **byte-identical**; the README's
  is in turn compiled through the real Roslyn + generator pipeline by `ChainSnippetTests`.

## Benchmarks

n/a — no render-hotpath or framework runtime code is touched.

## CHANGELOG

`[Unreleased]` → `### Changed`, including why `ChainAnimation` and `getting-started.md` keep the
longer sample.

## Follow-up worth considering

Nothing pins these snippets against each other, which is why the hero rotted to a removed API
unnoticed. The repo already gates the *install URL* across eight files in
`scripts/tests/install-script.test.sh`; the same mechanism would catch this class of front-door drift.
Not done here to keep the change to what was asked.
