### PR TITLE
test(docs): pin the Counter sample across its three front doors

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -39,6 +39,28 @@ fi
 #   rask.sh / rask.ps1 are here for the same reason, one level worse: they sit at the repo root, so
 #   they matched none of the prefixes above, and a commit that touched only the public installer was
 #   the one commit that ran neither the formatter nor scripts/tests/install-script.test.sh.
+# The Counter sample is written on three front doors — README.md, NUGET.md and the site hero — and
+# scripts/tests/front-doors.test.sh is the only thing pinning them to each other. Two of those doors
+# sit at the REPO ROOT and match none of the prefixes below, so a commit that fixes a typo in the
+# README is precisely the commit that would skip the guard written to catch README drift. That is the
+# rask.sh shape again, and it is why the sample rotted in the first place.
+#
+# Running the one check here, rather than adding these files to the filter below, is deliberate: the
+# filter decides whether to run the FULL format + unit suite, and making a typo fix pay for that is
+# the cost scripts/tests/install-script.test.sh declined to impose. This costs well under a second.
+# The site hero needs no entry — it lives under samples/, so it already runs the whole gate, which
+# runs this test through scripts/run-unit-local.sh.
+front_doors='^(README\.md|NUGET\.md)$'
+
+if git diff --cached --name-only | grep -E "$front_doors" >/dev/null; then
+  fd_root="$(git rev-parse --show-toplevel)"
+  if [ -x "$fd_root/scripts/tests/front-doors.test.sh" ] \
+     && ! "$fd_root/scripts/tests/front-doors.test.sh"; then
+    echo "pre-commit: the Counter sample differs between its front doors — see above." >&2
+    exit 1
+  fi
+fi
+
 if ! git diff --cached --name-only | grep -E '^(src/|samples/|docs/|tests/|benchmarks/|scripts/|\.githooks/|Rask\.slnx$|rask\.(sh|ps1)$|Directory\.)' >/dev/null; then
   echo "pre-commit: no code changes staged — skipping the format + unit gate."
   exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+
+- **The Counter sample is pinned across its three front doors.** It is written in `README.md`, in
+  `NUGET.md` (packed into every package, so the nuget.org page) and in the landing site's hero, and
+  nothing held them together. They drifted exactly as you would expect: #924 cut the sample to one
+  button and left the other two on the old three-line version, and the hero had been sitting on
+  `Counter : Page` with a `protected override string Route` — an API deleted from the tree long
+  before — so the first Rask code a visitor read could not compile. Both were caught by reading them.
+
+  `scripts/tests/front-doors.test.sh` now asserts the three are the same code, normalising the hero's
+  syntax-highlighted HTML back to plain C# before comparing. It also pins its own extractors, since a
+  regex that silently matches nothing is how this kind of guard becomes a no-op.
+
+  **Wiring is the point.** `README.md` and `NUGET.md` sit at the repo root and match none of the
+  pre-commit filter's directory prefixes, so a README typo fix was precisely the commit that would
+  skip a guard written to catch README drift — the `rask.sh` shape again. `pre-commit` therefore runs
+  this one test on its own path list rather than widening the main filter: the guard takes ~0.08s,
+  where the full format + unit gate takes minutes, and making every typo fix pay for that is the cost
+  [`install-script.test.sh`](scripts/tests/install-script.test.sh) had explicitly declined to impose.
+  The hero needs no entry, living under `samples/`, which already runs the whole gate.
 - **The git hooks reject attribution trailers, at both boundaries.** `Co-authored-by:`,
   `Claude-Session:` and "Generated with …" footers are refused by `.githooks/commit-msg` at commit
   time and again by `.githooks/pre-push` over the commits actually being pushed. The rule was already

--- a/scripts/tests/front-doors.test.sh
+++ b/scripts/tests/front-doors.test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Table test for the Counter sample — the first Rask code almost anyone reads.
+#
+# It is written in three places, and each of them is somebody's front door:
+#   README.md                          the repository landing page
+#   NUGET.md                           packed into every published package, so the nuget.org page
+#   samples/Rask.Example.Site/App.cs   the hero on the published site
+#
+# Nothing pinned them to each other, and they drifted exactly as you would expect. #924 cut the
+# sample to one button and left the other two on the old three-line version; worse, the hero had
+# been sitting on `Counter : Page` with a `protected override string Route`, an API deleted from the
+# tree long before, so the first Rask code a visitor read could not compile. Both were found by
+# reading them, not by a gate.
+#
+# So this asserts the three are the SAME CODE. The hero is syntax-highlighted HTML rather than
+# markdown, so it is normalised — tags stripped, entities decoded, indentation removed — and then
+# compared verbatim against the README. Drift in either direction fails, including a regression to
+# an API that no longer exists, because the README's copy is compiled for real by
+# tests/Rask.Example.Playground.Tests/ChainSnippetTests.cs.
+#
+# NOT included, deliberately, so a future reader does not "fix" them into this list:
+#   samples/Rask.Example.Site/ChainAnimation.cs (and assets/rask-chain.svg baked from it) is a timed
+#     typing animation whose subject is the completion list opening after `Button.` — it needs the
+#     multi-line form to read, and its per-line timings are choreography, not a copy of the sample.
+#   docs/getting-started.md teaches state with a heading and a paragraph, which is what the prose
+#     around it is explaining.
+#
+# Usage:  scripts/tests/front-doors.test.sh   (run by scripts/run-unit-local.sh)
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+failures=0
+checked=0
+
+check() {
+    local name="$1" expected="$2" actual="$3"
+    checked=$((checked + 1))
+    if [ "$actual" = "$expected" ]; then
+        printf '  ok   %-52s\n' "$name"
+    else
+        printf '  FAIL %-52s\n' "$name" >&2
+        printf '       expected:\n%s\n       actual:\n%s\n' "$expected" "$actual" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+# The markdown copies: the fenced block from the [Route] line to the closing brace.
+markdown_counter() {
+    awk '/^\[Route\("\/counter"\)\]$/{f=1} f{print} f&&/^}$/{exit}' "$1"
+}
+
+# The hero: the raw-string body of CounterCodeHtml, normalised back to plain C#. The site stores it
+# pre-highlighted because the page renders it through Raw, so those tags are the only difference
+# that is allowed to exist between it and the README.
+hero_counter() {
+    awk '
+        /private const string CounterCodeHtml =/ { inconst = 1; next }
+        inconst && /^        """$/               { body = 1; next }
+        inconst && body && /^        """;$/      { exit }
+        inconst && body                          { print }
+    ' samples/Rask.Example.Site/App.cs \
+    | sed -e 's/<[^>]*>//g' \
+          -e 's/&lt;/</g' -e 's/&gt;/>/g' -e 's/&quot;/"/g' -e 's/&amp;/\&/g' \
+          -e 's/^        //'
+}
+
+readme="$(markdown_counter README.md)"
+nuget="$(markdown_counter NUGET.md)"
+hero="$(hero_counter)"
+
+echo "==> the Counter sample is the same code on every front door"
+
+# Guard the extractors themselves. A silently empty match would make every comparison below pass,
+# which is the failure mode this whole file exists to prevent.
+check "the README block was found"           yes "$([ -n "$readme" ] && printf yes || printf no)"
+check "the NUGET.md block was found"         yes "$([ -n "$nuget" ]  && printf yes || printf no)"
+check "the site hero block was found"        yes "$([ -n "$hero" ]   && printf yes || printf no)"
+check "the README block is a whole class"    yes \
+    "$(printf '%s' "$readme" | grep -q '^}$' && printf yes || printf no)"
+
+check "NUGET.md matches the README"          "$readme" "$nuget"
+check "the site hero matches the README"     "$readme" "$hero"
+
+# The hero regressed to a deleted API once and nothing said so. These name the two symbols directly,
+# so that failure reads as what it is rather than as a wall of diff.
+check "the hero names no Page base class"    "" \
+    "$(printf '%s' "$hero" | grep -n ': *Page$' || true)"
+check "the hero has no 'override string Route'" "" \
+    "$(printf '%s' "$hero" | grep -n 'override string Route' || true)"
+
+# --- gate wiring ---------------------------------------------------------------------------------
+# A guard nothing invokes is not a guard. README.md and NUGET.md sit at the repo root and match none
+# of the pre-commit filter's directory prefixes, so without its own hook entry this file would never
+# run for the commit most likely to break it: an edit to the README alone. The filter is extracted
+# from the hook and run, rather than grepped for, so it cannot pass against one that has been edited
+# into something that no longer matches.
+echo
+echo "==> gate wiring"
+
+check "pre-commit invokes this test" yes \
+    "$(grep -q 'scripts/tests/front-doors\.test\.sh' .githooks/pre-commit && printf yes || printf no)"
+
+front_door_filter="$(sed -n "s/^front_doors='\(.*\)'$/\1/p" .githooks/pre-commit)"
+check "the front-door filter is still where we think" yes \
+    "$([ -n "$front_door_filter" ] && printf yes || printf no)"
+
+matches_front_doors() {
+    printf '%s\n' "$1" | grep -qE "$front_door_filter" && printf yes || printf no
+}
+check "a README-only commit runs this guard"   yes "$(matches_front_doors README.md)"
+check "a NUGET.md-only commit runs this guard" yes "$(matches_front_doors NUGET.md)"
+
+# The hero needs no entry of its own: it lives under samples/, which the ordinary filter already
+# matches, so its commits run the full gate — and that runs this file via run-unit-local.sh.
+check "the site hero is under samples/" yes \
+    "$([ -f samples/Rask.Example.Site/App.cs ] && printf yes || printf no)"
+
+echo
+if [ "$failures" -gt 0 ]; then
+    echo "front-doors.test.sh: $failures of $checked checks FAILED." >&2
+    echo "The Counter sample differs between the README, NUGET.md and the site hero." >&2
+    echo "They are one sample in three places — update all three, or none." >&2
+    exit 1
+fi
+
+echo "front-doors.test.sh: $checked checks passed."

--- a/scripts/tests/install-script.test.sh
+++ b/scripts/tests/install-script.test.sh
@@ -373,9 +373,14 @@ matches_precommit() { printf '%s\n' "$1" | grep -qE "$precommit_filter" && print
 check "a rask.sh-only commit runs the unit gate"  yes "$(matches_precommit rask.sh)"
 check "a rask.ps1-only commit runs the unit gate" yes "$(matches_precommit rask.ps1)"
 check "a scripts/ change still runs it"           yes "$(matches_precommit scripts/tests/install-script.test.sh)"
-# Documented rather than fixed: a commit touching ONLY the root README/NUGET.md/llms.txt still skips
-# the gate, so the URL checks above would not run for it. Widening the filter makes every typo fix pay
-# for the full unit suite, which is a call for the repo owner, not for this test.
+# Still true, and still deliberate: a commit touching ONLY the root README/NUGET.md/llms.txt skips the
+# full format + unit gate, so the URL checks above do not run for it. Widening this filter would make
+# every typo fix pay for the whole unit suite, which is a call for the repo owner, not for this test.
+#
+# The narrower half of that gap IS now closed: pre-commit runs scripts/tests/front-doors.test.sh on its
+# own path list when README.md or NUGET.md is staged, because the Counter sample had already rotted
+# apart across those files unnoticed. That check costs milliseconds; this gate costs minutes, which is
+# the whole reason one is wired that way and the other is not.
 check "a root README-only commit still skips it"  no  "$(matches_precommit README.md)"
 
 check "pre-push registers the install gate" yes \


### PR DESCRIPTION
## Summary

The first Rask code almost anyone reads is written three times — `README.md`, `NUGET.md` (packed into
every published package, so the nuget.org page) and the landing site's hero — and nothing held them
together. They drifted exactly as you would expect:

- #924 cut the sample to one button and left the other two on the old three-line version.
- The hero had been sitting on `Counter : Page` with a `protected override string Route`. Neither
  symbol exists anywhere in `src/` or `samples/` — the API was deleted long before — so **the first
  Rask code a visitor to the landing page read could not compile.**

Both were found by reading them. `scripts/tests/front-doors.test.sh` now asserts the three are the
same code, normalising the hero's syntax-highlighted HTML back to plain C# before comparing, and
naming the two deleted symbols directly so that regression reads as itself rather than as a diff.

It pins its own extractors as well — a regex that silently matches nothing is precisely how a guard
like this becomes a no-op that reports green forever.

## The wiring is the substance

`README.md` and `NUGET.md` sit at the **repo root** and match none of the pre-commit filter's
directory prefixes. So a README typo fix was exactly the commit that would skip a guard written to
catch README drift — the same shape the hook's own comment already records for `rask.sh`, and the
reason the sample was able to rot in the first place.

The main filter is deliberately **not** widened. `install-script.test.sh` had explicitly left that
call to the repo owner, because widening it "makes every typo fix pay for the full unit suite".
Instead `pre-commit` runs this one test on its own path list:

- guard: **0.083s** measured
- full format + unit gate: **~11 minutes**

The hero needs no entry of its own — it lives under `samples/`, which the ordinary filter already
matches, so its commits run the whole gate, which runs this file through `run-unit-local.sh`.

## Testing

The guard was **proven to fail**, not merely observed to pass. Each input was broken in turn and the
gate confirmed red:

| Break | Caught by |
|---|---|
| NUGET.md drifts (the #928 bug) | `NUGET.md matches the README` |
| Hero drifts back to `"Click me"` | `the site hero matches the README` |
| Hero regresses to `: Page` | equality **and** the named `Page` check |
| Hero constant renamed → extractor matches nothing | `the site hero block was found` |
| README block deleted | 4 checks, including `is a whole class` |

End to end: a README-only change breaking parity was staged and committed for real. **The hook
refused it**, exit 1, with `pre-commit: the Counter sample differs between its front doors`. That is
the exact commit shape that previously ran no gate at all.

Also run:

- `scripts/run-unit-local.sh` — format + warnings-as-errors + **49 test projects**, green. The new
  test is picked up automatically by the `scripts/tests/*.test.sh` glob at `run-unit-local.sh:40`.
- `scripts/run-e2e-local.sh` (via `pre-push`) — **63 browser tests passed**.
- `scripts/tests/install-script.test.sh` — **95 checks**, still green after its stale comment about
  this gap was corrected to say which half is now closed and which is still deliberately open.
- `scripts/tests/front-doors.test.sh` — **13 checks**, including its own gate wiring.

## Benchmarks

n/a — no framework or render-hotpath code is touched.

## CHANGELOG

`[Unreleased]` → `### Added`.
