### PR TITLE
fix(live): stop every served page retaining its whole live session, and un-break the capacity reports

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -132,7 +132,8 @@ else
     "Fix the failing journey, or bypass with --no-verify."
 fi
 
-# The payload-bytes gates, both baselines. This is the ONLY place they run: the CI job that used to
+# The benchmark gates: both payload-bytes baselines, plus the live-session capacity smokes. This is
+# the ONLY place they run: the CI job that used to
 # duplicate them was nothing but a second opinion nobody was required to listen to, and it rode red
 # through three merges before anyone noticed (#919). Here is where it bites.
 #
@@ -140,14 +141,14 @@ fi
 # say something about; this costs about one, and a hand-listed filter is itself a way for a gate to
 # stop running silently — see the `generator_paths` note below, where exactly that happened.
 if [ "${RASK_SKIP_BENCHMARKS:-}" = "1" ]; then
-  echo "pre-push: RASK_SKIP_BENCHMARKS=1 set — skipping the payload-bytes gates."
+  echo "pre-push: RASK_SKIP_BENCHMARKS=1 set — skipping the benchmark gates."
 else
-  echo "pre-push: running the payload-bytes gates (standalone codec + vs Blazor)."
+  echo "pre-push: running the benchmark gates (payload-bytes x2 + the live-session capacity smokes)."
   echo "          bypass with 'git push --no-verify' or RASK_SKIP_BENCHMARKS=1."
 
-  run_gate "Payload-bytes gates" scripts/run-benchmarks-local.sh \
+  run_gate "Benchmark gates" scripts/run-benchmarks-local.sh \
     "The benchmark projects don't compile." \
-    "The wire got heavier, or a scenario's markup changed and its baseline needs refreshing — the gate's own output says how to tell those apart."
+    "The wire got heavier, a scenario's markup changed and its baseline needs refreshing, or a disposed session is being retained — the gate's own output says which."
 fi
 
 # Like the deploy gate below, this one is scoped to the pushes it can actually say something about:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,12 +224,62 @@ them until tagged releases begin.
   could never engage.
 
 ### Fixed
-
 - **The `Rask.External` package description told users to write an attribute that does not exist.** It
   said to "Mark a component `[Island]`" — there has never been an `IslandAttribute`; the base class *is*
   the declaration. Its `<Title>` also read "Rask — Foreign Components", a third name for the feature
   matching neither the docs nor the README. Both now describe deriving from `ReactComponent` or
   `LitComponent`. This is package metadata, so it was visible on nuget.org rather than in any build.
+- **Every page served leaked its whole live session — ~1.1 MB apiece, for the life of the process.**
+  Rask injects two things into a page during **serialization**: the live runtime `<script>` at the close
+  of `<body>`, and the host's `<head>` contribution. Both build through the chain, and a chain built
+  inside a live render pushes an *entry slot* — the record of which props it did not name, so they can
+  be reset when the enclosing `Render()` returns. These two have no enclosing `Render()`. The slot is
+  attributed to whichever component is on the parent stack, whose `Render()` returned long ago and
+  took its drain with it, so nothing ever popped it. It stayed on a `[ThreadStatic]` list holding a
+  `Component` from a finished page — and through that component's `LiveState`, the entire live session:
+  DI scope, component tree, buffers and all.
+
+  The thread is a long-lived request worker, so this had no ceiling and no symptom. Measured on a
+  200-row page: a 500-cycle create→dispose run left **563 MB** behind where it should leave zero
+  (`session-churn`), every disposed session still fully reachable. Both injection sites are now
+  bracketed by the slot depth, so whatever a host build leaves behind is drained the way the end of a
+  `Render()` would have drained it. Residue is back to **0 bytes at 500 cycles**, and allocation per
+  update is byte-for-byte unchanged (140,648 / 644,377 B on 200 / 1,000 rows), as are both
+  payload-bytes baselines.
+
+  Pinned four ways, each of which fails without the fix: the slot stack is empty after a render
+  (mechanism), the rendered page is collectible once its render returns (symptom), the drain still runs
+  when a host contribution **throws** mid-serialize (the error path — host-supplied code runs inside the
+  serializer, so the bracket is a `try`/`finally`, as `Component`'s own drain already is), and the
+  `session-churn` smoke asserts the retained bytes (the number a host actually pays). Note the existing
+  injection tests could not have caught it — their stub returns a *pre-built* component, which pushes
+  no slot; only a stub that builds through the chain, as the real `ServerRuntimeScript` does,
+  reproduces it.
+- **`AddRask()` no longer demands host services from a container that is not a host — and the capacity
+  reports run again.** `RaskDataProtectionSetup` (#888) took `IConfiguration`, `IHostEnvironment` and
+  `ILoggerFactory` as constructor dependencies. Every host builder registers them, so no app was
+  affected; a `ServiceCollection` composed by hand — a test fixture, a benchmark harness — was. And it
+  did not fail at `AddRask`: the throw came the first time anything materialised the Data Protection
+  options, which for `session-footprint` and `session-churn` was four frames deep inside a session
+  render, as `Unable to resolve service for type 'IConfiguration'`. Both reports died on startup and
+  had done since 2026-08-28 (#922).
+
+  It also defeated a deliberate decision one line above it, where `AddRask` *asks* for the Data
+  Protection provider with `GetService` rather than assuming it, so a host without one degrades instead
+  of failing: the provider was registered, so the ask succeeded, and then building it threw. The setup
+  now resolves all three optionally and falls back to the framework's own key ring — the same ring a
+  plain `dotnet run` already gets — warning if it has a durable ring but no application name to pin the
+  discriminator to.
+- **The live-session capacity reports are gated instead of hand-run.** They are what
+  [`docs/scaling.md`](docs/scaling.md) and [`docs/configuration.md`](docs/configuration.md) tell you to
+  run to size a host, and nothing had run them since the nightly `benchmarks-full` job was deleted with
+  the rest of CI. Four days later two of the three were dead on startup, and that outage is what hid
+  the session leak above. `scripts/run-benchmarks-local.sh` now runs all three smoke-sized on every
+  push (~4s in total, alongside the payload-bytes gates): `session-footprint` and `session-load` have only
+  to run, while `session-churn --smoke` **asserts** that 100 create→dispose cycles leave nothing
+  behind. The full reports stay hand-run. Each runs as its own step with its own status bookkeeping —
+  ganged into one block, the first to abort left the rest unrun, which is exactly how `session-churn`'s
+  identical failure stayed invisible while `session-footprint`'s was being looked at.
 - **The payload-bytes gate was red for three merges over a CSS class rename.** #914's Bootstrap sweep
   renamed classes inside the benchmark scenarios themselves — `row` → `line`, one character longer —
   and `AppendRowToList100`'s diff is an `InsertSubtree` whose value *is* one row's HTML, so it grew by

--- a/benchmarks/Rask.Benchmarks/SessionChurnReport.cs
+++ b/benchmarks/Rask.Benchmarks/SessionChurnReport.cs
@@ -61,10 +61,29 @@ internal static class SessionChurnReport
     // small enough to soak quickly.
     private const int Rows = 200;
 
+    // What a create→dispose cycle may leave behind across the whole smoke run before it is called a
+    // leak. The honest value is zero and that is what the fixed framework reports; the tolerance is
+    // there so a stray pooled buffer or a cached reflection entry cannot fail a push. A REAL leak here
+    // is the whole session — ~1.1 MB per cycle on this page — so nothing about this is a close call.
+    private const long SmokeResidueBudgetBytes = 64 * 1024;
+
+    private const int SmokeChurnCycles = 100;
+
     public static int Run(string[] args)
     {
-        _ = args;
         SessionHarness.VerifySelfMeasurement();
+
+        // --smoke: the churn pass only, at a fifth of the cycles, ASSERTED rather than printed. Two
+        // things it catches that nothing else does. One, that these reports still run at all — this one
+        // and session-footprint both died on startup for four days and nothing said so, because nothing
+        // ran them (#922). Two, the leak that outage hid: every page served retained its whole live
+        // session, ~1.1 MB a time, growing without bound. The unit suite pins the mechanism; this pins
+        // the number a host actually pays. See scripts/run-benchmarks-local.sh.
+        if (Array.IndexOf(args, "--smoke") >= 0)
+        {
+            return Smoke();
+        }
+
         Soak();
         Console.WriteLine();
         UpdateCost();
@@ -73,6 +92,39 @@ internal static class SessionChurnReport
         Console.WriteLine();
         Churn();
         return 0;
+    }
+
+    private static int Smoke()
+    {
+        var services = SessionHarness.NewHost();
+        var store = services.GetRequiredService<LiveSessionStore>();
+
+        // Warm up first, so JIT, statics and the pool's buckets are settled before the baseline — they
+        // are one-off costs, and counting them as residue is how a gate like this cries wolf.
+        RunChurnBatch(store, ChurnBatch);
+
+        var baseline = SessionHarness.StableHeap();
+        RunChurnBatch(store, SmokeChurnCycles);
+        var residue = SessionHarness.StableHeap() - baseline;
+
+        GC.KeepAlive(store);
+        GC.KeepAlive(services);
+
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture,
+            "session-churn --smoke: {0} create→dispose cycles ({1}-row page) left {2} bytes behind "
+            + "(budget {3}).", SmokeChurnCycles, Rows, residue, SmokeResidueBudgetBytes));
+
+        if (residue <= SmokeResidueBudgetBytes)
+        {
+            return 0;
+        }
+
+        Console.Error.WriteLine(string.Format(CultureInfo.InvariantCulture,
+            "session-churn --smoke FAILED: {0} bytes retained across {1} disposed sessions "
+            + "({2} bytes each). A disposed session is not being released — run the full report "
+            + "(`-- session-churn`) for the per-batch curve.",
+            residue, SmokeChurnCycles, residue / SmokeChurnCycles));
+        return 1;
     }
 
     // ---- Soak: does per-session cost converge? ---------------------------------------

--- a/benchmarks/Rask.Benchmarks/SessionFootprintReport.cs
+++ b/benchmarks/Rask.Benchmarks/SessionFootprintReport.cs
@@ -60,7 +60,13 @@ internal static class SessionFootprintReport
 
     public static int Run(string[] args)
     {
-        var sessions = ParseSessions(args);
+        // --smoke: prove the report still RUNS, in seconds rather than minutes. It is not a measurement
+        // — the two cheap pages and a handful of sessions say nothing about capacity — it is the gate
+        // that would have caught #922, where this report died on startup for four days and nobody knew,
+        // because nothing ran it. See scripts/run-benchmarks-local.sh.
+        var smoke = Array.IndexOf(args, "--smoke") >= 0;
+        var sessions = smoke ? 10 : ParseSessions(args);
+        var pages = smoke ? Pages[..2] : Pages;
         SessionHarness.VerifySelfMeasurement();
 
         Console.WriteLine("# Live-session retained footprint. Framework floor only — excludes the transport");
@@ -73,7 +79,7 @@ internal static class SessionFootprintReport
         Console.WriteLine("#        Connected = socket attached + updates driven (buffers at high-water).");
         Console.WriteLine("Page,PageHtmlBytes,State,BytesPerSession,SessionsPer1GiB");
 
-        foreach (var (name, rows) in Pages)
+        foreach (var (name, rows) in pages)
         {
             // A zero-row page has no rows to make interactive, so the shape axis is meaningless there —
             // emitting it twice would imply a comparison that isn't being made.

--- a/benchmarks/Rask.Benchmarks/SessionLoadReport.cs
+++ b/benchmarks/Rask.Benchmarks/SessionLoadReport.cs
@@ -47,8 +47,15 @@ internal static class SessionLoadReport
 
     public static int Run(string[] args)
     {
-        var sessions = IntArg(args, "--sessions=") ?? DefaultSessions;
-        var seconds = IntArg(args, "--seconds=") ?? DefaultSeconds;
+        // --smoke: prove the report still RUNS, on the gate's budget. ONE page, no sweep, and none of
+        // the JIT throwaway below — a smoke is not a measurement, and the numbers it prints are not
+        // comparable with a real run's. Left as a sweep it costs ~13s of every push (3 pages x warmup +
+        // measure, plus 4 Kestrel starts) for an answer the gate never reads. See
+        // scripts/run-benchmarks-local.sh, and session-churn --smoke for the one smoke that ASSERTS.
+        var smoke = Array.IndexOf(args, "--smoke") >= 0;
+        var sessions = IntArg(args, "--sessions=") ?? (smoke ? 2 : DefaultSessions);
+        var seconds = IntArg(args, "--seconds=") ?? (smoke ? 1 : DefaultSeconds);
+        var pages = smoke ? [5] : Pages;
 
         SessionHarness.VerifySelfMeasurement();
 
@@ -67,9 +74,12 @@ internal static class SessionLoadReport
         // pays the process-wide costs — JIT across Kestrel, the WebSocket stack and the render path — and
         // reported them as if they were the page's. It showed: the empty page came out slower than the
         // 5-row one, which is not a thing that can be true.
-        RunOneAsync(rows: 5, sessions: Math.Min(4, sessions), seconds: 1).GetAwaiter().GetResult();
+        if (!smoke)
+        {
+            RunOneAsync(rows: 5, sessions: Math.Min(4, sessions), seconds: 1).GetAwaiter().GetResult();
+        }
 
-        foreach (var rows in Pages)
+        foreach (var rows in pages)
         {
             var result = RunOneAsync(rows, sessions, seconds).GetAwaiter().GetResult();
             Console.WriteLine(string.Join(',',

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -186,7 +186,7 @@ Every change passes this gate before a PR (the `rask-ship` skill):
 
 [#845]: https://github.com/pal-tamas/rask/issues/845
 [#850]: https://github.com/pal-tamas/rask/issues/850
-- **The payload-bytes gates run locally, enforced before push.** `scripts/run-benchmarks-local.sh`
+- **The benchmark gates run locally, enforced before push.** `scripts/run-benchmarks-local.sh`
   checks both wire-byte baselines — the standalone codec numbers and the head-to-head against Blazor —
   byte-for-byte. The numbers are noise-free (no timing: every render emits the same payload shape with
   one value differing), so a change is a real change. `.githooks/pre-push` runs it on every push,
@@ -198,10 +198,19 @@ Every change passes this gate before a PR (the `rask-ship` skill):
   required checks, so it rode red through three merges before anyone noticed
   ([#919](https://github.com/pal-tamas/rask/issues/919)). That job is gone; this is the only copy.
 
-  **Both gates always run, even when the first fails.** In CI they are two steps in one job, so a
+  **It also smoke-runs the three live-session capacity reports** (`session-footprint`, `session-churn`,
+  `session-load`) for about four seconds in total. Two of the three had been dead on startup for four days with
+  nothing to notice, because the nightly job that ran them went when the rest of CI did
+  ([#922](https://github.com/pal-tamas/rask/issues/922)) — and that outage hid a leak in which every
+  page served retained its whole live session. So `session-churn --smoke` does not merely run: it
+  **asserts** that 100 create→dispose cycles leave nothing behind. The full reports stay hand-run; run
+  them yourself before claiming a capacity number.
+
+  **Every gate always runs, even when an earlier one fails.** In CI they are two steps in one job, so a
   fail-fast on the first leaves the second unrun — which is how the vs-Blazor baseline stayed broken
-  while the standalone one was being fixed, and how a half-fix looked complete. Locally you get both
-  answers at once.
+  while the standalone one was being fixed, how a half-fix looked complete, and how `session-churn`'s
+  crash stayed invisible while `session-footprint`'s identical one was being looked at. Locally you get
+  every answer at once.
 
   **A regression here means one of two opposite things.** Either the render/diff path got heavier —
   fix the code, do not touch the baseline — or a benchmark scenario's own markup changed, which *does*

--- a/scripts/run-benchmarks-local.sh
+++ b/scripts/run-benchmarks-local.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Local payload-bytes gate — did this change move the wire bytes?
+# Local benchmark gates — did this change move the wire bytes, or start retaining sessions?
 #
 # Wire-bytes-per-update for a fixed set of scenarios is noise-free (no timing: every render emits the
 # same payload shape with one small value differing), so the numbers are compared byte-for-byte against
@@ -53,10 +53,48 @@ echo
 echo "==> Payload-bytes gate (vs Blazor)"
 dotnet run -c Release --project benchmarks/Rask.Benchmarks.VsBlazor --no-build -- payload-bytes --check || status=1
 
+# The live-session capacity reports, smoke-sized. They answer "how many sessions fit in a box", they
+# are documented in docs/scaling.md and docs/configuration.md as the way to size a host — and until
+# now NOTHING ran them. The nightly job that did was deleted when GitHub was cut back to publishing,
+# and the two of them then died on startup for four days, unnoticed, because a host service AddRask
+# had started to require was missing from the benchmark harness (#922).
+#
+# What that outage hid is the reason these are here rather than left as hand-run tools: every page
+# served was retaining its whole live session — ~1.1 MB a time, for the life of the process. The
+# session-churn smoke ASSERTS that residue, so the number a host actually pays is gated and not just
+# printed. About four seconds for all three; the full reports stay hand-run. (session-load is the one
+# with a real cost — left as a sweep its smoke was ~13s of every push, three pages of warmup-plus-
+# measure for an answer nothing reads, so --smoke runs ONE page and skips the JIT throwaway.)
+#
+# Run SEPARATELY, each with its own `|| status=1`. Ganged into one `run:` block, the first one to
+# abort left the rest UNRUN — which is precisely how session-churn's identical failure stayed
+# invisible while session-footprint's was being looked at (#922), and how the vs-Blazor baseline
+# stayed broken through the fix for the standalone one (#921).
+echo
+echo "==> Live-session capacity: session-footprint (smoke)"
+dotnet run -c Release --project benchmarks/Rask.Benchmarks --no-build -- session-footprint --smoke || status=1
+
+echo
+echo "==> Live-session capacity: session-churn (smoke, asserts nothing survives teardown)"
+dotnet run -c Release --project benchmarks/Rask.Benchmarks --no-build -- session-churn --smoke || status=1
+
+echo
+echo "==> Live-session capacity: session-load (smoke, real Kestrel + real sockets)"
+dotnet run -c Release --project benchmarks/Rask.Benchmarks --no-build -- session-load --smoke \
+  >/dev/null || status=1
+
 if [ "$status" -ne 0 ]; then
   cat >&2 <<'EOF'
 
-  One or both payload-bytes gates regressed. Two things it can mean, and they want opposite fixes:
+  A benchmark gate failed. Read the section above that went red — they fail for different reasons.
+
+  A CAPACITY SMOKE. session-churn reports the bytes a disposed session leaves behind: anything above
+  the budget means a session is outliving its own teardown, and the full report (`-- session-churn`)
+  prints the per-batch curve. session-footprint and session-load only have to RUN; if one threw, the
+  harness has lost a host service the framework now needs — fix the framework, not the harness, since
+  whatever a bare container is missing an unusual host is missing too.
+
+  A PAYLOAD-BYTES GATE. Two things it can mean, and they want opposite fixes:
 
   A RENDER OR DIFF CHANGE made the wire heavier. That is the regression this gate exists to catch —
   fix the code, do not touch the baseline.
@@ -77,4 +115,4 @@ EOF
 fi
 
 echo
-echo "==> Payload-bytes gates passed (both baselines)."
+echo "==> Benchmark gates passed (both payload-bytes baselines + the capacity smokes)."

--- a/src/Rask.Core/Builder/BuilderRuntime.cs
+++ b/src/Rask.Core/Builder/BuilderRuntime.cs
@@ -286,6 +286,59 @@ public static partial class BuilderRuntime
         slots.RemoveRange(write, slots.Count - write);
     }
 
+    /// <summary>
+    ///     How many entry slots are in flight on this thread. Paired with <see cref="DrainSlotsAbove" />
+    ///     to bracket a chain built from OUTSIDE any component's <c>Render()</c>.
+    /// </summary>
+    internal static int SlotDepth => _slots?.Count ?? 0;
+
+    /// <summary>
+    ///     Drains every slot pushed above <paramref name="depth" /> — the resets that
+    ///     <see cref="DrainSlots" /> would have run at the end of the enclosing <c>Render()</c>, for a
+    ///     chain that had no enclosing <c>Render()</c> to end.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The slot stack is drained by the component that owns it, when its <c>Render()</c> returns.
+    ///         A chain that runs during SERIALIZATION — the framework's own host injections, the live
+    ///         runtime <c>&lt;script&gt;</c> and the host head contribution — is attributed to whichever
+    ///         component is on the parent stack at that moment, and that component's <c>Render()</c>
+    ///         returned long ago. Its drain has already run, so nothing ever pops the slot: it sits on a
+    ///         <see cref="ThreadStaticAttribute" /> list holding a <c>Component</c> from a page that is
+    ///         otherwise finished with, and through that component's <c>LiveState</c> the entire live
+    ///         session — DI scope, component tree, buffers and all.
+    ///     </para>
+    ///     <para>
+    ///         That is a leak with no upper bound and no symptom: the thread is a long-lived request
+    ///         worker, so every page served on it retains one whole session for the life of the process.
+    ///         Measured at ~1.1 MB per session on a 200-row page, growing linearly
+    ///         (<c>session-churn</c>, whose whole purpose is to report exactly this and which had been
+    ///         crashing on startup, so nobody was reading it — #922).
+    ///     </para>
+    ///     <para>
+    ///         Bracketing by DEPTH rather than by parent identity: a host contribution can itself render
+    ///         nested components, and those push and drain their own slots in between, so the count
+    ///         returns to where it was. Everything still above the mark is what this build left behind,
+    ///         whoever it was attributed to.
+    ///     </para>
+    /// </remarks>
+    internal static void DrainSlotsAbove(int depth)
+    {
+        var slots = _slots;
+        if (slots is null || slots.Count <= depth)
+        {
+            return;
+        }
+
+        for (var i = depth; i < slots.Count; i++)
+        {
+            var slot = slots[i];
+            slot.Reset(slot.Target, slot.Pending);
+        }
+
+        slots.RemoveRange(depth, slots.Count - depth);
+    }
+
     /// <summary>A component with nothing to reset — no own props and not an <see cref="Element" />.</summary>
     public static void ResetNothing(Component target, ulong pending)
     {

--- a/src/Rask.Core/HtmlSerializer.cs
+++ b/src/Rask.Core/HtmlSerializer.cs
@@ -409,9 +409,35 @@ internal static class HtmlSerializer
                     // needed. Serialized inline on every render and kept byte-stable, so — like the body
                     // runtime <script> — it survives server live-updates and costs the diff codec nothing.
                     // No provider registered (the default, and on WASM) → nothing extra is emitted.
-                    if (live.Services?.GetService<IRaskHeadContribution>()?.Render() is { } headExtra)
+                    //
+                    // Bracketed by the slot depth: this chain runs during SERIALIZATION, so the entry
+                    // slot it pushes is attributed to whichever component is on the parent stack — a
+                    // component whose Render() returned long ago and whose drain has therefore already
+                    // happened. Nothing would ever pop it. See BuilderRuntime.DrainSlotsAbove.
+                    // try/finally, not a straight-line call: a contribution that throws mid-serialize
+                    // would otherwise skip the drain and leak the very thing this bracket exists to
+                    // stop — once per fault, on a thread that outlives the request. Component does the
+                    // same for its own drain, in a catch before it rethrows.
+                    var headSlotDepth = BuilderRuntime.SlotDepth;
+                    try
                     {
-                        Serialize(headExtra, sb);
+                        if (live.Services?.GetService<IRaskHeadContribution>()?.Render() is { } headExtra)
+                        {
+                            // BEFORE serializing, not after — this is the reset the enclosing Render()
+                            // would have run, and Component runs it before the serializer walks the
+                            // child. Draining afterwards would write the PREVIOUS render's value for
+                            // any prop this chain did not name (a contribution that conditionally
+                            // sets .Content(...) would emit the stale one for a render), and on the
+                            // server that stale byte is diffed and pushed.
+                            BuilderRuntime.DrainSlotsAbove(headSlotDepth);
+                            Serialize(headExtra, sb);
+                        }
+                    }
+                    finally
+                    {
+                        // Anything the walk itself left behind — and the whole bracket if Render() or
+                        // Serialize threw, which is host-supplied code and can.
+                        BuilderRuntime.DrainSlotsAbove(headSlotDepth);
                     }
                 }
 
@@ -424,10 +450,28 @@ internal static class HtmlSerializer
                 // so a sentinel would drop the script on the first update. Stable bytes also
                 // mean the diff codec never emits ops for it. On WASM no provider is
                 // registered (the runtime boots from the page shell), so nothing is injected.
-                if (tagName == "body" && live?.Services?.GetService<IRaskRuntimeScript>() is { } runtime
-                                      && runtime.Render() is { } runtimeScript)
+                //
+                // Slot-depth bracketed for the same reason as the head contribution above: built during
+                // serialization, so its entry slot has no enclosing Render() to drain it and would sit
+                // on this thread's slot stack holding the page — and the whole live session — for ever.
+                if (tagName == "body" && live?.Services?.GetService<IRaskRuntimeScript>() is { } runtime)
                 {
-                    Serialize(runtimeScript, sb);
+                    // try/finally for the same reason as the head bracket above: a fault must not be
+                    // able to skip the drain.
+                    var runtimeSlotDepth = BuilderRuntime.SlotDepth;
+                    try
+                    {
+                        if (runtime.Render() is { } runtimeScript)
+                        {
+                            // Before the walk, for the reason spelled out on the head bracket above.
+                            BuilderRuntime.DrainSlotsAbove(runtimeSlotDepth);
+                            Serialize(runtimeScript, sb);
+                        }
+                    }
+                    finally
+                    {
+                        BuilderRuntime.DrainSlotsAbove(runtimeSlotDepth);
+                    }
                 }
 
                 sb.Append("</").Append(tagName).Append('>');

--- a/src/Rask.Hosting.Shared/RaskDataProtectionSetup.cs
+++ b/src/Rask.Hosting.Shared/RaskDataProtectionSetup.cs
@@ -2,8 +2,10 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.DataProtection.Repositories;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Rask.Hosting.Shared;
@@ -40,13 +42,46 @@ namespace Rask.Hosting.Shared;
 /// </para>
 /// </remarks>
 internal sealed class RaskDataProtectionSetup(
-    IConfiguration configuration,
-    IHostEnvironment environment,
-    ILoggerFactory loggerFactory)
+    IConfiguration? configuration,
+    IHostEnvironment? environment,
+    ILoggerFactory? loggerFactory)
     : IConfigureOptions<KeyManagementOptions>, IConfigureOptions<DataProtectionOptions>
 {
     // The volume rask deploy mounts. Kept as a field so the probe is named once rather than spelled twice.
     private const string DeployVolume = "/data";
+
+    private readonly ILoggerFactory _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+
+    /// <summary>
+    /// Builds the setup from whatever host services the container actually has, rather than demanding them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every host builder registers <see cref="IConfiguration"/> and <see cref="IHostEnvironment"/>, so in a
+    /// real app this resolves all three and nothing about the behaviour above changes. It exists for the
+    /// container that is NOT a host: a test fixture or a benchmark harness composing <c>AddRask()</c> into a
+    /// bare <c>ServiceCollection</c>. Activating this type by constructor there threw
+    /// <c>InvalidOperationException: Unable to resolve service for type 'IConfiguration'</c> — and not at
+    /// registration, but lazily, the first time anything materialised the Data Protection options, which is
+    /// a long way from the cause (#922).
+    /// </para>
+    /// <para>
+    /// That mattered beyond the harness: <c>AddRask</c> deliberately ASKS for the Data Protection provider
+    /// with <c>GetService</c> rather than assuming it, so a host without one degrades instead of failing.
+    /// A hard constructor dependency here defeated that — the provider was registered, so the ask succeeded,
+    /// and then building it threw. Missing services now mean the framework default key ring, which is the
+    /// same thing a plain <c>dotnet run</c> already gets.
+    /// </para>
+    /// </remarks>
+    public static RaskDataProtectionSetup Create(IServiceProvider services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        return new RaskDataProtectionSetup(
+            services.GetService<IConfiguration>(),
+            services.GetService<IHostEnvironment>(),
+            services.GetService<ILoggerFactory>());
+    }
 
     /// <summary>
     /// The directory the key ring belongs in, or <c>null</c> when this host has nowhere durable to put it
@@ -54,7 +89,9 @@ internal sealed class RaskDataProtectionSetup(
     /// </summary>
     internal string? ResolveKeyPath()
     {
-        var configured = configuration["Rask:DataProtection:KeyPath"];
+        // A container with no IConfiguration reads as "nothing configured", which lands on the /data probe
+        // below — the same answer a host whose configuration omits the key gives.
+        var configured = configuration?["Rask:DataProtection:KeyPath"];
         if (configured is not null)
         {
             // An explicitly empty value is an opt-out, not a request to write to the working directory.
@@ -82,11 +119,11 @@ internal sealed class RaskDataProtectionSetup(
         // the warning names the one thing to fix.
         try
         {
-            options.XmlRepository = new FileSystemXmlRepository(Directory.CreateDirectory(keyPath), loggerFactory);
+            options.XmlRepository = new FileSystemXmlRepository(Directory.CreateDirectory(keyPath), _loggerFactory);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
         {
-            loggerFactory.CreateLogger<RaskDataProtectionSetup>().LogWarning(
+            _loggerFactory.CreateLogger<RaskDataProtectionSetup>().LogWarning(
                 ex,
                 "Rask could not persist the Data Protection key ring to {KeyPath}, so the framework default "
                 + "is being used instead. That ring does not outlive this process: every deploy will mint a "
@@ -106,6 +143,25 @@ internal sealed class RaskDataProtectionSetup(
         {
             // Leave the content-root-derived default alone: without a shared ring there is nothing for a
             // stable discriminator to unlock, and changing it would invalidate a dev machine's existing keys.
+            return;
+        }
+
+        if (environment is null)
+        {
+            // There IS a shared ring here but no application name to pin it to, so the discriminator keeps
+            // its content-root-derived default and two containers sharing the ring still derive different
+            // keys from it.
+            //
+            // Best-effort, and honestly so: this is only reachable in a container that is not a host, and
+            // such a container usually has no ILoggerFactory either (AddRask does not call AddLogging), in
+            // which case the warning goes to NullLoggerFactory and nobody reads it. It is worth emitting
+            // for the container that DID call AddLogging; it is not a substitute for the fact that a host
+            // with a shared key ring should register an IHostEnvironment.
+            _loggerFactory.CreateLogger<RaskDataProtectionSetup>().LogWarning(
+                "Rask is persisting the Data Protection key ring, but this container has no IHostEnvironment, "
+                + "so the application discriminator keeps its content-root default. Two hosts sharing the ring "
+                + "will still derive different keys from it. Register an IHostEnvironment, or set "
+                + "DataProtectionOptions.ApplicationDiscriminator yourself.");
             return;
         }
 

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -205,10 +205,17 @@ public static partial class RaskEndpointExtensions
         // it overrides ASP.NET's discovered default, and an app configuring its own ring after AddRask still
         // wins, because options setups run in registration order. See RaskDataProtectionSetup for why an
         // ephemeral ring signs every user out on redeploy without logging anything.
+        //
+        // Through its own factory rather than by constructor activation: the host services it reads are
+        // OPTIONAL. A container that is not a host — a test fixture, a benchmark harness — has no
+        // IConfiguration, and activating this by constructor there threw the first time anything
+        // materialised the options, a long way from the AddRask that caused it (#922).
         services.TryAddEnumerable(
-            ServiceDescriptor.Singleton<IConfigureOptions<KeyManagementOptions>, RaskDataProtectionSetup>());
+            ServiceDescriptor.Singleton<IConfigureOptions<KeyManagementOptions>, RaskDataProtectionSetup>(
+                RaskDataProtectionSetup.Create));
         services.TryAddEnumerable(
-            ServiceDescriptor.Singleton<IConfigureOptions<DataProtectionOptions>, RaskDataProtectionSetup>());
+            ServiceDescriptor.Singleton<IConfigureOptions<DataProtectionOptions>, RaskDataProtectionSetup>(
+                RaskDataProtectionSetup.Create));
 
         // Stop the hosted services CONCURRENTLY, inside a budget that fits under the deploy's SIGKILL.
         // Sequentially — .NET's default — each pillar's shutdown grace sums to 30s against a window that

--- a/src/Rask.Spa.Hosting/RaskSpaServiceCollectionExtensions.cs
+++ b/src/Rask.Spa.Hosting/RaskSpaServiceCollectionExtensions.cs
@@ -68,9 +68,11 @@ public static class RaskSpaServiceCollectionExtensions
         services.AddDataProtection();
 
         services.TryAddEnumerable(
-            ServiceDescriptor.Singleton<IConfigureOptions<KeyManagementOptions>, RaskDataProtectionSetup>());
+            ServiceDescriptor.Singleton<IConfigureOptions<KeyManagementOptions>, RaskDataProtectionSetup>(
+                RaskDataProtectionSetup.Create));
         services.TryAddEnumerable(
-            ServiceDescriptor.Singleton<IConfigureOptions<DataProtectionOptions>, RaskDataProtectionSetup>());
+            ServiceDescriptor.Singleton<IConfigureOptions<DataProtectionOptions>, RaskDataProtectionSetup>(
+                RaskDataProtectionSetup.Create));
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IConfigureOptions<HostOptions>, RaskShutdownDefaults>());
 

--- a/src/Rask.Wasm.Hosting/RaskWasmServiceCollectionExtensions.cs
+++ b/src/Rask.Wasm.Hosting/RaskWasmServiceCollectionExtensions.cs
@@ -70,9 +70,11 @@ public static class RaskWasmServiceCollectionExtensions
         services.AddDataProtection();
 
         services.TryAddEnumerable(
-            ServiceDescriptor.Singleton<IConfigureOptions<KeyManagementOptions>, RaskDataProtectionSetup>());
+            ServiceDescriptor.Singleton<IConfigureOptions<KeyManagementOptions>, RaskDataProtectionSetup>(
+                RaskDataProtectionSetup.Create));
         services.TryAddEnumerable(
-            ServiceDescriptor.Singleton<IConfigureOptions<DataProtectionOptions>, RaskDataProtectionSetup>());
+            ServiceDescriptor.Singleton<IConfigureOptions<DataProtectionOptions>, RaskDataProtectionSetup>(
+                RaskDataProtectionSetup.Create));
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IConfigureOptions<HostOptions>, RaskShutdownDefaults>());
 

--- a/tests/Rask.Core.Tests/Live/RuntimeScriptInjectionTests.cs
+++ b/tests/Rask.Core.Tests/Live/RuntimeScriptInjectionTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
@@ -56,6 +57,152 @@ public partial class RuntimeScriptInjectionTests : global::Rask.Core.RaskMarkup
     {
         // Body().ToHtml() outside a live render must stay bare (no provider reachable anyway).
         Assert.Equal("<body></body>", Body.ToHtml());
+    }
+
+    // ---- The host injections must not leave an entry slot behind -------------------------------
+    //
+    // Both host contributions (this one and IRaskHeadContribution) are built during SERIALIZATION, so
+    // the entry slot a CHAIN pushes is attributed to whichever component is on the parent stack — and
+    // that component's Render() returned long ago, taking its drain with it. Nothing pops the slot, so
+    // it stays on a [ThreadStatic] list holding a Component from a finished page, and through its
+    // LiveState the whole live session.
+    //
+    // Note the stub the tests above use returns a PRE-BUILT component, which pushes no slot and so
+    // cannot see any of this. The stub below builds through the chain, the way the real
+    // ServerRuntimeScript does (`Script.Src(...)`) — which is the only shape that reproduces it.
+
+    [Fact]
+    public void Body_ProviderBuildsThroughTheChain_LeavesNoEntrySlotBehind()
+    {
+        var view = new StubComponent(() => Shell(P["hi"]));
+        using var provider = new ServiceCollection()
+            .AddSingleton<IRaskRuntimeScript>(new ChainRuntimeScriptProvider())
+            .BuildServiceProvider();
+
+        var before = BuilderRuntime.SlotDepth;
+        var html = view.RenderAsLiveRoot(provider);
+
+        Assert.Contains("<script src=\"/rask/rask.js\"></script></body>", html);
+        Assert.Equal(before, BuilderRuntime.SlotDepth);
+    }
+
+    [Fact]
+    public void Head_ProviderBuildsThroughTheChain_LeavesNoEntrySlotBehind()
+    {
+        var view = new StubComponent(() => Shell(P["hi"]));
+        using var provider = new ServiceCollection()
+            .AddSingleton<IRaskHeadContribution>(new ChainHeadContribution())
+            .BuildServiceProvider();
+
+        var before = BuilderRuntime.SlotDepth;
+        view.RenderAsLiveRoot(provider);
+
+        Assert.Equal(before, BuilderRuntime.SlotDepth);
+    }
+
+    [Fact]
+    public void A_rendered_page_is_collectible_once_the_render_has_returned()
+    {
+        // The symptom, not the bookkeeping: a leaked slot holds the rendered COMPONENT, and on a real
+        // host the rendering thread is a long-lived request worker — so every page served on it was
+        // retained for the life of the process (~1.1 MB per live session, session-churn, #922).
+        //
+        // Rendered inside a non-inlined method so the only thing crossing back is the WeakReference:
+        // a local still in scope would keep the tree alive on its own and the test would fail for a
+        // reason that is not the bug. Deliberately NOT rendered on a throwaway thread — the leaked
+        // slot list is [ThreadStatic], so a thread that exits takes the leak with it and the test
+        // would pass while the bug was live.
+        var weak = RenderAndDrop();
+
+        for (var i = 0; i < 3; i++)
+        {
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
+            GC.WaitForPendingFinalizers();
+        }
+
+        Assert.False(weak.TryGetTarget(out _), "the rendered page was still reachable after its render returned");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference<Component> RenderAndDrop()
+    {
+        var view = new StubComponent(() => Shell(P["hi"]));
+        using var provider = new ServiceCollection()
+            .AddSingleton<IRaskRuntimeScript>(new ChainRuntimeScriptProvider())
+            .BuildServiceProvider();
+
+        view.RenderAsLiveRoot(provider);
+        return new WeakReference<Component>(view);
+    }
+
+    [Fact]
+    public void A_prop_the_contribution_stops_naming_is_reset_before_it_is_serialized()
+    {
+        // ORDER, not just presence. The drain is the reset the enclosing Render() would have run, and
+        // Component runs it BEFORE the serializer walks the child. Draining afterwards would serialize
+        // the PREVIOUS render's value for any prop this render's chain did not name — and on the server
+        // that stale byte is diffed and pushed to the client, breaking the byte-stability the injection
+        // relies on.
+        var contribution = new ConditionalHeadContribution { Color = "#000" };
+        var view = new StubComponent(() => Shell(P["hi"]));
+        using var provider = new ServiceCollection()
+            .AddSingleton<IRaskHeadContribution>(contribution)
+            .BuildServiceProvider();
+
+        Assert.Contains("content=\"#000\"", view.RenderAsLiveRoot(provider));
+
+        contribution.Color = null; // the chain stops naming Content
+        var second = view.RenderAsLiveRoot(provider);
+
+        Assert.DoesNotContain("content=\"#000\"", second);
+    }
+
+    // Names Content only sometimes, which is what makes the reset observable.
+    private sealed partial class ConditionalHeadContribution : global::Rask.Core.RaskMarkup, IRaskHeadContribution
+    {
+        public string? Color { get; set; }
+
+        public Component Render() =>
+            Color is null ? Meta.Name("theme-color") : Meta.Name("theme-color").Content(Color);
+    }
+
+    [Fact]
+    public void A_host_contribution_that_throws_still_drains_its_entry_slot()
+    {
+        // The error path leaks too, and it is the one a straight-line drain misses: the fault unwinds
+        // past the drain and the slot stays, once per fault, on a thread that outlives the request.
+        // A contribution CAN throw — it is host-supplied code running inside the serializer.
+        var view = new StubComponent(() => Shell(P["hi"]));
+        using var provider = new ServiceCollection()
+            .AddSingleton<IRaskRuntimeScript>(new ThrowingChainRuntimeScriptProvider())
+            .BuildServiceProvider();
+
+        var before = BuilderRuntime.SlotDepth;
+
+        Assert.Throws<InvalidOperationException>(() => view.RenderAsLiveRoot(provider));
+        Assert.Equal(before, BuilderRuntime.SlotDepth);
+    }
+
+    // Pushes a slot through the chain, then throws while the serializer is still inside the bracket.
+    private sealed partial class ThrowingChainRuntimeScriptProvider
+        : global::Rask.Core.RaskMarkup, IRaskRuntimeScript
+    {
+        public Component Render()
+        {
+            _ = Script.Src("/rask/rask.js");
+            throw new InvalidOperationException("boom");
+        }
+    }
+
+    // Builds through the chain rather than handing back a ready-made component — see the note above.
+    private sealed partial class ChainRuntimeScriptProvider : global::Rask.Core.RaskMarkup, IRaskRuntimeScript
+    {
+        public Component Render() => Script.Src("/rask/rask.js");
+    }
+
+    private sealed partial class ChainHeadContribution : global::Rask.Core.RaskMarkup, IRaskHeadContribution
+    {
+        public Component Render() => Meta.Name("theme-color").Content("#000");
     }
 
     private sealed class StubRuntimeScriptProvider : IRaskRuntimeScript

--- a/tests/Rask.Server.Tests/Security/DataProtectionKeyRingTests.cs
+++ b/tests/Rask.Server.Tests/Security/DataProtectionKeyRingTests.cs
@@ -145,6 +145,40 @@ public class DataProtectionKeyRingTests : IDisposable
     }
 
     [Fact]
+    public async Task AddRask_survives_a_container_that_is_not_a_host()
+    {
+        // A ServiceCollection with none of the host services in it — what a test fixture or a benchmark
+        // harness composes when it wants the live subsystem without a web host. Every host builder
+        // registers IConfiguration and IHostEnvironment, so this is not a shape any app has; it is the
+        // shape every harness has, and AddRask used to survive it.
+        //
+        // It stopped when RaskDataProtectionSetup arrived and took the two of them as CONSTRUCTOR
+        // dependencies. Nothing failed at AddRask: the throw came later and elsewhere, the first time
+        // anything materialised the Data Protection options — for the capacity reports, four frames deep
+        // inside a session render, as "Unable to resolve service for type 'IConfiguration'" (#922).
+        //
+        // It also defeated a deliberate design one line up in AddRask, which ASKS for the Data Protection
+        // provider with GetService rather than assuming it so a host without one degrades. The provider
+        // was registered, so the ask succeeded — and then building it threw.
+        //
+        // Driven through the OPTIONS, not through the registration: registering was never what failed.
+        // await using: resolving the store makes the container hold an IAsyncDisposable, which a
+        // synchronous Dispose refuses outright.
+        await using var provider = new ServiceCollection().AddRask().BuildServiceProvider();
+
+        var keys = provider.GetRequiredService<IOptions<KeyManagementOptions>>().Value;
+        var dp = provider.GetRequiredService<IOptions<DataProtectionOptions>>().Value;
+
+        // With no configuration to read and (on any machine this suite runs on) no /data volume, Rask has
+        // nowhere durable to put a ring, so it declines to choose exactly as it does on a plain dotnet run.
+        Assert.Null(keys.XmlRepository);
+        Assert.Null(dp.ApplicationDiscriminator);
+
+        // And the thing the harness was actually after: a live session store, built and usable.
+        Assert.NotNull(provider.GetRequiredService<LiveSessionStore>());
+    }
+
+    [Fact]
     public void The_discriminator_survives_Data_Protection_arriving_after_AddRask()
     {
         // The order a scaffolded app actually has: AddRask first, and Data Protection pulled in below it


### PR DESCRIPTION
## Summary

Fixes #922 — and the leak that its outage was hiding.

`session-footprint` and `session-churn` had been dead on startup since 2026-08-28, because
`RaskDataProtectionSetup` (#888) takes `IConfiguration`/`IHostEnvironment`/`ILoggerFactory` as
**constructor** dependencies, and the benchmark harness composes `AddRask()` into a bare
`ServiceCollection`. Nothing failed at `AddRask`; the throw arrived the first time anything
materialised the Data Protection options — four frames deep inside a session render. It also defeated
a deliberate decision one line above it, where `AddRask` *asks* for the Data Protection provider with
`GetService` so a host without one degrades: the provider was registered, so the ask succeeded, and
then building it threw. The setup now resolves all three optionally and falls back to the framework's
own key ring.

**With the reports running again, they immediately reported a leak: every page served was retaining
its whole live session.** The two host injections Rask serializes into a page — the live runtime
`<script>` at the close of `<body>` and the host's `<head>` contribution — build through the chain, and
a chain built inside a live render pushes an *entry slot* so its unnamed props can be reset when the
enclosing `Render()` returns. **These two have no enclosing `Render()`.** The slot was attributed to
whichever component sat on the parent stack, whose `Render()` had returned long ago and taken its drain
with it, so nothing ever popped it: it stayed on a `[ThreadStatic]` list holding a `Component` from a
finished page, and through its `LiveState` the entire live session — DI scope, component tree, buffers
and all. The rendering thread is a long-lived request worker, so this had no ceiling and no symptom.

Both sites now bracket by slot depth (`BuilderRuntime.SlotDepth` / `DrainSlotsAbove`) — by depth rather
than by parent identity, because a host contribution can render nested components that push and drain
their own slots in between.

Third change, which is the issue's own open question: **the capacity reports are gated instead of
hand-run.** They are what `docs/scaling.md` and `docs/configuration.md` tell you to run to size a host,
and nothing had run them since the nightly job went with the rest of CI. Four days later two of the
three were dead, and that is what hid the leak. `scripts/run-benchmarks-local.sh` now runs all three
smoke-sized on every push (~3s total); `session-churn --smoke` **asserts** the retained bytes rather
than printing them. The full reports stay hand-run.

## Testing

- Unit: `scripts/run-unit-local.sh` — **6,635 tests across 49 assemblies, 0 failures.**
- Six guards, **each verified to fail without its fix** (removed the fix, watched it go red,
  put it back):
  - `RuntimeScriptInjectionTests.Body_ProviderBuildsThroughTheChain_LeavesNoEntrySlotBehind` — the mechanism.
  - `RuntimeScriptInjectionTests.Head_ProviderBuildsThroughTheChain_LeavesNoEntrySlotBehind` — the second site.
  - `RuntimeScriptInjectionTests.A_rendered_page_is_collectible_once_the_render_has_returned` — the symptom.
  - `RuntimeScriptInjectionTests.A_prop_the_contribution_stops_naming_is_reset_before_it_is_serialized`
    — the drain's ORDER (see review round below).
  - `RuntimeScriptInjectionTests.A_host_contribution_that_throws_still_drains_its_entry_slot` — the
    error path; host-supplied code runs inside the serializer, so the bracket is a `try`/`finally`.
  - `DataProtectionKeyRingTests.AddRask_survives_a_container_that_is_not_a_host` — #922 itself, driven
    through the **options**, since registering was never what failed.

### Review round

Self-review + `/code-review high` found three things worth fixing, all now addressed:

1. **A real bug in the fix.** The drain ran *after* `Serialize(...)`, the opposite order from
   `DrainSlots`, which `Component` runs *before* the serializer walks the child. A contribution that
   conditionally sets a prop would have emitted the **previous** render's value for the render that
   drops it — and on the server that stale byte is diffed and pushed, breaking exactly the
   byte-stability the surrounding comments rely on. Drain now happens between `Render()` and
   `Serialize()`, with the `finally` kept as the error-path net. Pinned by a new test.
2. **The `session-load` smoke cost ~13s of every push**, not the "~1s each" I claimed — three pages of
   warmup-plus-measure plus a JIT throwaway, for an answer the gate never reads. It has a real
   `--smoke` now (one page, no throwaway); all three smokes total ~4s, and the three places that
   understated it are corrected.
3. **An over-claiming comment.** The new "no `IHostEnvironment`" warning goes to `NullLoggerFactory` in
   the only container that can reach it, so the comment no longer claims it says anything there.

Also filed #932 for a pre-existing 1-in-6 flake in `QuiescentRenderTests` the review surfaced — it
reproduces on the base commit and nothing here touches the quiescence path.
- The existing injection tests could not have caught the leak: their stub hands back a *pre-built*
  component, which pushes no slot. Only a stub that builds through the chain — as the real
  `ServerRuntimeScript` does — reproduces it.
- `session-churn --smoke` also verified by failing it: with the drains removed it reports
  `112584000 bytes retained across 100 disposed sessions (1125840 bytes each)` and exits 1.
- E2E: **63/63 green**, plus the CLI build gate, run from an isolated worktree via the pre-push hook.

  Worth recording: two earlier runs failed 10 WASM boot tests each, while another worktree passed 63/63
  on the same machine at the same time. It was neither this change nor load — another session was
  checking out branches **in the shared working tree** while the gate built and published from it. The
  same commit in its own worktree passes. If you see a WASM `TypeError: Failed to fetch` with an
  `integrity` digest of `47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=` (the SHA-256 of the empty
  string), suspect the tree moving under the run before you suspect the branch.

## Benchmarks

Render-hotpath change, so measured both ways — and the leak makes the retained number the headline:

| | before | after |
|---|---|---|
| `session-churn` RetainedTotal @ 500 cycles (200-row page) | **562,919,944 B** | **0 B** |
| `session-churn` AllocBytesPerUpdate (200 / 1,000 rows) | 140,648 / 644,377 | 140,648 / 644,377 |
| `session-churn` AllocBytesPerUpdate, handler shift | 143,337 / 647,012 | 143,337 / 647,012 |
| `session-churn` AllocBytesPerCycle | 2,267,409 | 2,267,411 |
| `HtmlSerializerLiveRootBenchmarks` Allocated (small/large/xlarge) | 4.05 / 93.28 / 568.58 KB | 4.05 / 93.28 / 568.58 KB |
| payload-bytes, both baselines | green | green |

Allocation is unchanged to the byte; the only thing that moved is the 563 MB that should never have
been retained. (`RetainedTotal` at 500 cycles was last recorded as zero in the CHANGELOG entry for the
buffer-return work, so this is a regression against a number the repo had already established.)

## CHANGELOG

- `[Unreleased] → Fixed`: three entries — the retained live session, `AddRask()` in a non-host
  container, and the capacity reports joining the local gate.
