### PR TITLE
fix(tailwind): a class library's stylesheet reaches the consuming app's publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **A class library's Tailwind stylesheet reaches the consuming app's publish.** Since #914 the docs
+  showcase at `https://rask.sh/docs/` has been serving
+  `_content/Rask.Example.Shared/css/app.css` as a **404** and rendering every page unstyled, while a
+  committed file two directories away in the same `wwwroot` served fine.
+
+  `Rask.Tailwind` writes its output at `BeforeBuild`, which runs after the SDK has globbed `wwwroot/**`
+  into `@(Content)` at **evaluation** time. For an app that is harmless — static-web-asset discovery
+  re-enumerates during the build and picks the file up anyway, verified on both `Sdk.Web` and
+  `Sdk.WebAssembly`. For a **Razor class library** it is fatal: an RCL's assets come from the evaluated
+  `@(Content)` with no second pass, so a stylesheet generated later never enters its manifest and never
+  reaches any consumer's publish.
+
+  The fix is one item, in `Rask.Tailwind.props`: name the output in a **literal** `Content` include
+  rather than leaving it to the glob. A literal include does not consult the disk at evaluation — the
+  item exists regardless, and the file is only required when it is copied, which is after the compiler
+  has run. That is the same distinction #852 turned on for pack, applied to the other side of it.
+
+  Why nothing caught it: the file always exists locally from a previous build, so the glob matches and
+  every developer publish — and every local E2E — is correct. Only the first build in a clone is wrong,
+  which is every CI run and no developer's machine. `TailwindPublishBuildE2ETests` was written for
+  exactly this bug and could not see it, because both its cases were **apps**, the shape that does not
+  fail; its own remarks asserted the wrong half of the mechanism and are corrected here. A third case
+  now covers an RCL consumed by an app, with a committed file beside the generated one as the control
+  so that a `_content` plumbing failure cannot be mistaken for this one.
+
 ### Added
 
 - **The Counter sample is pinned across its three front doors.** It is written in `README.md`, in

--- a/src/Rask.Tailwind/build/Rask.Tailwind.props
+++ b/src/Rask.Tailwind/build/Rask.Tailwind.props
@@ -61,4 +61,35 @@
     <RaskTailwindCacheRoot Condition="'$(RaskTailwindCacheRoot)' == ''">$(HOME)/.rask/tailwind</RaskTailwindCacheRoot>
   </PropertyGroup>
 
+  <!--
+    Name the generated stylesheet as a LITERAL Content item, here, at evaluation — before it exists.
+
+    The SDK globs `wwwroot/**` into @(Content) at evaluation time, which is before any target runs. The
+    Tailwind build writes its output at BeforeBuild, so on the FIRST build in a clone that glob cannot
+    have matched it. For an app (Sdk.Web, Sdk.WebAssembly) that turns out not to matter: static-web-asset
+    discovery re-enumerates during the build and picks the file up anyway. For a RAZOR CLASS LIBRARY it
+    matters completely — the RCL's assets come from the evaluated @(Content), so a file generated later
+    never enters its manifest and never reaches the consuming app's publish.
+
+    That is not a theory. It shipped: from #914 (Tailwind built in, Bootstrap gone) until this change,
+    every CI deploy of the docs showcase served `_content/Rask.Example.Shared/css/app.css` as a 404 and
+    rendered the whole site unstyled, while a committed file two directories away in the same wwwroot
+    served fine. It was invisible locally because a previous build always left the file on disk, so the
+    glob matched and every local publish — and every local E2E — was correct.
+
+    A literal Include is the fix because it does not consult the disk at evaluation. The item exists
+    regardless; the file is only required when it is COPIED, which is after the generating target has
+    run. This is the same distinction #852 turned on for pack, applied to the other side of it: there, a
+    glob silently collected nothing and shipped a package without its task assembly.
+
+    Guarded on !Exists so the second build — where the glob DOES match — does not declare it twice.
+    Guarded on the input existing so projects with no stylesheet (a class library, a test project, the
+    static-file half of a hosted WASM app) declare nothing, exactly as _RaskTailwindDoBuild decides.
+  -->
+  <ItemGroup Condition=" '$(RaskTailwindOutput)' != ''
+                         AND Exists('$(MSBuildProjectDirectory)/$(RaskTailwindInput)')
+                         AND !Exists('$(MSBuildProjectDirectory)/$(RaskTailwindOutput)') ">
+    <Content Include="$(RaskTailwindOutput)"/>
+  </ItemGroup>
+
 </Project>

--- a/tests/Rask.Cli.Tests/TailwindPublishBuildE2ETests.cs
+++ b/tests/Rask.Cli.Tests/TailwindPublishBuildE2ETests.cs
@@ -11,13 +11,27 @@ namespace Rask.Cli.Tests;
 ///         Every other Tailwind gate stops at "it builds". That is the one thing this failure mode does not
 ///         disturb: <c>Rask.Tailwind</c> writes <c>wwwroot/css/app.css</c> from a target hooked at
 ///         <c>BeforeBuild</c>, which runs <b>after</b> the SDK has globbed <c>wwwroot/**</c> as Content at
-///         evaluation time. On a clean build the file therefore is not an item, not a static web asset, and
-///         never lands in <c>publish/wwwroot</c> — while the build itself succeeds and the compiler really
-///         did emit the CSS. The app ships with a <c>&lt;link&gt;</c> to a 404 and renders unstyled.
+///         evaluation time. The build succeeds and the compiler really did emit the CSS; the only question
+///         is whether the bytes are in the artifact.
+///     </para>
+///     <para>
+///         <b>Where that actually bites, corrected.</b> For an APP — <c>Sdk.Web</c>, <c>Sdk.WebAssembly</c>,
+///         the two cases below — it does not: static-web-asset discovery re-enumerates during the build and
+///         picks the file up regardless of the glob. That was verified empirically on both SDKs, and an
+///         earlier fix written on the opposite belief was binned when a publish-asserting test passed
+///         against unfixed main.
+///     </para>
+///     <para>
+///         For a RAZOR CLASS LIBRARY it bites completely, and that is the case
+///         <see cref="A_class_librarys_compiled_stylesheet_reaches_the_consuming_apps_publish"/> covers.
+///         An RCL's assets come from the evaluated <c>@(Content)</c> with no second pass, so a file
+///         generated at <c>BeforeBuild</c> never enters its manifest. This class shipped for weeks
+///         asserting the wrong half of the mechanism, which is why the docs showcase served a 404 for its
+///         stylesheet and nothing went red.
 ///     </para>
 ///     <para>
 ///         A second build hides it, because by then the file is on disk from the first. That is what makes
-///         it intermittent, and why it gets blamed on whatever else changed.
+///         it look intermittent, and why it gets blamed on whatever else changed.
 ///     </para>
 ///     <para>
 ///         So this asserts on the <b>publish output</b>, into a directory that did not exist before the run.
@@ -77,6 +91,138 @@ public sealed class TailwindPublishBuildE2ETests
             Assert.True(
                 new FileInfo(css).Length > 0,
                 $"[{template}] {css} was published but is empty — Tailwind scanned no source.");
+        }
+        finally
+        {
+            try { Directory.Delete(temp, recursive: true); }
+            catch (IOException) { /* best effort */ }
+            catch (UnauthorizedAccessException) { /* best effort */ }
+        }
+    }
+
+    /// <summary>
+    ///     The same question for a RAZOR CLASS LIBRARY, which is the shape that actually broke.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The two cases above have never failed, and cannot: for an app (<c>Sdk.Web</c>,
+    ///         <c>Sdk.WebAssembly</c>) static-web-asset discovery re-enumerates <c>wwwroot</c> during the
+    ///         build, so a file written at <c>BeforeBuild</c> is picked up despite missing the
+    ///         evaluation-time glob. This class's own remarks assert the opposite, and were written on the
+    ///         belief that the app case was the dangerous one. It is not.
+    ///     </para>
+    ///     <para>
+    ///         An RCL is different, and the difference is total: its assets come from the <b>evaluated</b>
+    ///         <c>@(Content)</c>, so a stylesheet generated later never enters the library's manifest and
+    ///         never reaches the consuming app's publish. That shipped — from #914 until the fix this test
+    ///         accompanies, every CI deploy of the docs showcase served
+    ///         <c>_content/Rask.Example.Shared/css/app.css</c> as a 404 and rendered the site unstyled,
+    ///         while a committed file in the same wwwroot served fine.
+    ///     </para>
+    ///     <para>
+    ///         Invisible locally, always: a previous build leaves the CSS on disk, so the glob matches and
+    ///         every developer publish — and the two cases above — are correct. Only the first build in a
+    ///         clone is wrong, which is every CI run and nobody's machine.
+    ///     </para>
+    /// </remarks>
+    [SkippableFact]
+    public async Task A_class_librarys_compiled_stylesheet_reaches_the_consuming_apps_publish()
+    {
+        Skip.IfNot(CliBuildE2E.Enabled, CliBuildE2E.SkipReason);
+
+        var (feed, version) = await CliBuildE2E.LocalFeed.Value;
+
+        var temp = Path.Combine(Path.GetTempPath(), "rask-tailwind-rcl", Guid.NewGuid().ToString("N"));
+        var libDir = Path.Combine(temp, "RTwLib");
+        var appDir = Path.Combine(temp, "RTwApp");
+
+        try
+        {
+            var fs = new SystemFileSystem();
+            fs.CreateDirectory(Path.Combine(libDir, "Styles"));
+            fs.CreateDirectory(Path.Combine(libDir, "wwwroot", "css"));
+            fs.CreateDirectory(appDir);
+
+            // The control. This one IS on disk when the SDK globs wwwroot, so it reaches publish either
+            // way — if it is missing too, the failure is _content plumbing and not this bug.
+            fs.WriteAllText(Path.Combine(libDir, "wwwroot", "css", "committed.css"), "/* committed */");
+
+            fs.WriteAllText(Path.Combine(libDir, "Styles", "app.css"), "@import \"tailwindcss\";");
+            fs.WriteAllText(
+                Path.Combine(libDir, "Marker.cs"),
+                "namespace RTwLib; public static class Marker { public const string Classes = \"flex gap-4\"; }");
+
+            fs.WriteAllText(
+                Path.Combine(libDir, "RTwLib.csproj"),
+                $"""
+                 <Project Sdk="Microsoft.NET.Sdk.Razor">
+                   <PropertyGroup>
+                     <TargetFramework>net10.0</TargetFramework>
+                     <StaticWebAssetBasePath>_content/RTwLib</StaticWebAssetBasePath>
+                   </PropertyGroup>
+                   <ItemGroup>
+                     <PackageReference Include="Rask.Server" Version="{version}"/>
+                   </ItemGroup>
+                 </Project>
+                 """);
+
+            fs.WriteAllText(
+                Path.Combine(appDir, "RTwApp.csproj"),
+                $"""
+                 <Project Sdk="Microsoft.NET.Sdk.Web">
+                   <PropertyGroup>
+                     <TargetFramework>net10.0</TargetFramework>
+                     <!-- WebApplication comes from Microsoft.AspNetCore.Builder, which the Web SDK adds
+                          only as an IMPLICIT using. Without this the one-line host does not compile and
+                          the test fails at the publish, long before it can say anything about CSS. -->
+                     <ImplicitUsings>enable</ImplicitUsings>
+                     <Nullable>enable</Nullable>
+                   </PropertyGroup>
+                   <ItemGroup>
+                     <PackageReference Include="Rask.Server" Version="{version}"/>
+                     <!-- Absolute, and spelled from the same string as every other path here. A
+                          relative "..\RTwLib\RTwLib.csproj" made the static-web-assets reference check
+                          fail on macOS: MSBuild resolved the library through /private/var and the app
+                          through /var (the same directory, since /var is a symlink), and the target
+                          compares those as strings — "Unable to find a project reference for project
+                          configuration item". -->
+                     <ProjectReference Include="{Path.Combine(libDir, "RTwLib.csproj").Replace('\\', '/')}"/>
+                   </ItemGroup>
+                 </Project>
+                 """);
+
+            fs.WriteAllText(
+                Path.Combine(appDir, "Program.cs"),
+                "var b = WebApplication.CreateBuilder(args); var a = b.Build(); a.Run();");
+
+            CliBuildE2E.WriteNuGetConfig(fs, temp, feed);
+
+            // Never published into before, so a stale file cannot make a broken publish look correct.
+            var publishDir = Path.Combine(temp, "published");
+
+            var (exit, output) = await CliBuildE2E.RunDotnet(
+                $"publish \"{Path.Combine(appDir, "RTwApp.csproj")}\" -c Release -o \"{publishDir}\" -m:1 -nodeReuse:false");
+
+            Assert.True(exit == 0, $"publish failed.{output}");
+
+            var contentCss = Path.Combine(publishDir, "wwwroot", "_content", "RTwLib", "css");
+
+            Assert.True(
+                File.Exists(Path.Combine(contentCss, "committed.css")),
+                $"the control file is missing from {contentCss} — this is _content plumbing failing, not "
+                + "the generated-asset bug this test is about.");
+
+            var generated = Path.Combine(contentCss, "app.css");
+            Assert.True(
+                File.Exists(generated),
+                $"the class library compiled Tailwind and the consuming app's publish did not carry it: "
+                + $"{generated} is absent while committed.css beside it is present. Any page styled by this "
+                + "library renders unstyled, and the build succeeds — which is why only the artifact can "
+                + "catch it.");
+
+            Assert.True(
+                new FileInfo(generated).Length > 0,
+                $"{generated} was published but is empty — Tailwind scanned no source.");
         }
         finally
         {


### PR DESCRIPTION
Closes #931.

Since #914 the docs showcase has served `_content/Rask.Example.Shared/css/app.css` as a **404** and rendered every page unstyled, while a committed file two directories away in the same `wwwroot` served **200**.

## Mechanism

`Rask.Tailwind` writes its output at `BeforeBuild`, after the SDK globs `wwwroot/**` into `@(Content)` at **evaluation** time.

- **App** (`Sdk.Web`, `Sdk.WebAssembly`) — harmless; static-web-asset discovery re-enumerates during the build.
- **Razor class library** — fatal; an RCL's assets come from the evaluated `@(Content)` with no second pass, so a file generated later never enters its manifest.

## Fix

One item in `Rask.Tailwind.props`: name the output in a **literal** `Content` include. A literal include does not consult the disk at evaluation — the item exists regardless, and the file is only required when copied, after the compiler has run. Same distinction #852 turned on for pack, other side of it. Guarded on `!Exists` so the second build (where the glob does match) does not declare it twice, and on the input existing so projects with no stylesheet stay silent.

Isolated first in a two-project probe with no packages, after **four** candidate fixes that did not work: `Content` at `BeforeBuild`; a hook on `ResolveStaticWebAssetsInputs` (a target that does not exist, so `BeforeTargets` was silently ignored); a hook on the real `ResolveProjectStaticWebAssets`; and `DefineStaticWebAssets`, which crashed the compression task.

## Testing

Proved both ways on `samples/Rask.Example.Wasm` from the fresh-clone state (generated CSS deleted first):

| | `_content/Rask.Example.Shared/css/` |
|---|---|
| without the fix | directory **absent entirely** |
| with the fix | `app.css` 28,368 B + `.br` + `.gz` |

New test `A_class_librarys_compiled_stylesheet_reaches_the_consuming_apps_publish`, verified load-bearing standalone:

| | |
|---|---|
| fix present | **passes** |
| fix removed | **fails** at "the class library compiled Tailwind and the consuming app's publish did not carry it" |
| control (`committed.css`) | present in **both** runs |

That control is what makes it specific: a `_content` plumbing regression surfaces as a different, clearly-labelled assertion.

Gates: browser E2E 63/63, payload-bytes both baselines, CLI build gate, install gate.

## Why nothing caught it

The file always exists locally from a previous build, so the glob matches and every developer publish — and every local E2E — is correct. Only the first build in a clone is wrong: every CI run, no developer's machine.

`TailwindPublishBuildE2ETests` was written for exactly this bug and could not see it, because both its cases are **apps**, the shape that does not fail. Its remarks asserted the wrong half of the mechanism and are corrected here.

## Blast radius

Wider than the demo site: `Rask.Tailwind.props` ships inside `Rask.Server` and `Rask.Wasm`, so any consumer putting components in a Razor class library has had a silently unstyled app on every clean CI build since #914.