### PR TITLE
feat(meta): host a meta framework front end beside C# in one container

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,6 +39,7 @@ jobs:
           dotnet pack src/Rask.Wasm/Rask.Wasm.csproj -c Release -o ./artifacts
           dotnet pack src/Rask.Wasm.Hosting/Rask.Wasm.Hosting.csproj -c Release -o ./artifacts
           dotnet pack src/Rask.Spa.Hosting/Rask.Spa.Hosting.csproj -c Release -o ./artifacts
+          dotnet pack src/Rask.Meta.Hosting/Rask.Meta.Hosting.csproj -c Release -o ./artifacts
           dotnet pack src/Rask.Validation.DataAnnotations/Rask.Validation.DataAnnotations.csproj -c Release -o ./artifacts
           dotnet pack src/Rask.Validation.FluentValidation/Rask.Validation.FluentValidation.csproj -c Release -o ./artifacts
           dotnet pack src/Rask.Blazor/Rask.Blazor.csproj -c Release -o ./artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Pack Rask.Spa.Hosting
         run: dotnet pack src/Rask.Spa.Hosting/Rask.Spa.Hosting.csproj -c Release --no-build -o ./artifacts
 
+      - name: Pack Rask.Meta.Hosting
+        run: dotnet pack src/Rask.Meta.Hosting/Rask.Meta.Hosting.csproj -c Release --no-build -o ./artifacts
+
       - name: Pack Rask.Blazor
         run: dotnet pack src/Rask.Blazor/Rask.Blazor.csproj -c Release --no-build -o ./artifacts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,53 @@ them until tagged releases begin.
 
 ### Added
 
+- **`Rask.Meta.Hosting` — a meta framework front end and your C# in one container.** The first landing
+  of [#946](https://github.com/pal-tamas/rask/issues/946): `AddRaskMeta()` supervises the framework's
+  own Node server, and `UseRaskMeta()` forwards to it everything Kestrel did not answer itself.
+
+  This is a third lane, not a change to either existing one. `Rask.Spa.Hosting` serves a static bundle
+  and needs no Node at runtime; islands put a `.tsx` inside a Rask page. Here the meta framework owns
+  the **whole** front end — routing, rendering, its own server — and Rask is the backend it integrates
+  with. Kestrel keeps the public port, so ASP.NET authentication, rate limiting, logging and health
+  still sit in front of every request, and `rask deploy` still ships one container on one port.
+
+  Six frameworks reduce to **three server shapes**, which is why the adapter is data rather than a class
+  per framework: `MetaFramework.Nuxt`, `.TanStackStart` and `.SolidStart` share `.output/server/index.mjs`
+  (Nitro), `.Analog` is Nitro under `dist/analog/server`, `.SvelteKit` is `adapter-node`'s
+  `build/index.js`, and `.Next` is standalone's `server.js` — which reads `HOSTNAME` where every other
+  one reads `HOST`. Each preset is a record, so `MetaFramework.Next with { ServerEntry = … }` adjusts one
+  field and keeps the rest. Every value is pinned by a test, because each was read out of the framework's
+  current documentation and none of it is checkable anywhere else.
+
+  All six expose a single directly executable entry, so the supervisor runs `node <entry>` and never
+  `npm start` — npm spawns the real server as a grandchild, and killing npm would orphan it. The process
+  binds `127.0.0.1` only, never `0.0.0.0`, so publishing the container's ports cannot expose an
+  unauthenticated renderer beside the app. Its stdout and stderr both arrive as `Information`, since a
+  great deal of Node tooling writes ordinary progress to stderr; the exit code is what signals a fault.
+
+  Before the port answers, requests get **503 with `Retry-After`** rather than being forwarded into a
+  closed socket and surfacing as 502 — for the first seconds of a container's life that state is normal
+  and genuinely temporary. A crash is retried with capped exponential backoff, and when the budget is
+  spent the **host stops** rather than serving errors indefinitely: an orchestrator restarting the
+  container is a better supervisor than this loop, and an exit is visible where a degraded process is
+  not. On shutdown the process gets `SIGTERM` and a grace period before its tree is killed.
+
+  Forwarding is YARP's `IHttpForwarder` — the direct-forwarding API only, no route table or config
+  model. That is the package's one external dependency and a deliberate one: it already gets right
+  WebSocket upgrade, hop-by-hop header handling, and **unbuffered response streaming**, which is the
+  property the whole lane rests on. React Server Components and streaming SSR send a page over many
+  flushes, and a proxy that waits for the last byte turns a streaming page into a slow blank one while
+  every other test still passes — so a test holds the backend open until the client has already read the
+  first chunk, and cannot pass if anything starts buffering.
+
+  `UseRaskMeta()` registers a **fallback**, so mapped endpoints still win — but map your API first; the
+  symptom of getting it wrong is an API call answered with a rendered page. `SuperviseNode = false`
+  forwards to a front end you are running yourself.
+
+  Not here yet, and tracked on the epic: the build and publish targets, the Node-bearing runtime image,
+  the generated server-side contract client that lets SSR call back carrying the visitor's cookie, and
+  `rask new` templates. Until those land this package is usable but unwired.
+
 - **Tailwind reaches inside an island.** A utility written in a `.vue`, `.tsx` or `.svelte` now
   survives into the emitted stylesheet, and editing one rebuilds it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,14 @@ them until tagged releases begin.
   and genuinely temporary. A crash is retried with capped exponential backoff, and when the budget is
   spent the **host stops** rather than serving errors indefinitely: an orchestrator restarting the
   container is a better supervisor than this loop, and an exit is visible where a degraded process is
-  not. On shutdown the process gets `SIGTERM` and a grace period before its tree is killed.
+  not. That budget counts **consecutive** failures — a run that stayed up past
+  `HealthyRunThreshold` resets it, so a server that crashes once a month is never mistaken for one that
+  will not start. On shutdown the process gets `SIGTERM` and a grace period before its tree is killed.
+
+  **No built front end fails startup**, with a message naming the path it looked for and the option
+  that moves it. Detecting it in the supervision loop instead would also have ended the process, but by
+  cancelling Kestrel's own bind mid-startup — so the app died with `TaskCanceledException`, which says
+  nothing about the front end and buries the line that did.
 
   Forwarding is YARP's `IHttpForwarder` — the direct-forwarding API only, no route table or config
   model. That is the package's one external dependency and a deliberate one: it already gets right
@@ -85,7 +92,16 @@ them until tagged releases begin.
   property the whole lane rests on. React Server Components and streaming SSR send a page over many
   flushes, and a proxy that waits for the last byte turns a streaming page into a slow blank one while
   every other test still passes — so a test holds the backend open until the client has already read the
-  first chunk, and cannot pass if anything starts buffering.
+  first chunk, and cannot pass if anything starts buffering. An **upgraded connection gets no idle
+  cap**: the request timeout is an idle one and applies to WebSockets too, so leaving it on would drop
+  any socket quiet for 100 seconds and show the client a disconnect with no cause.
+
+  Asset URLs forward like everything else. That is worth stating because the obvious spelling of the
+  fallback — `MapFallback(handler)` — maps `{*path:nonfile}` and silently matches **nothing with a dot
+  in its last segment**, so every hashed chunk, `favicon.ico` and `robots.txt` would 404 and the page
+  would load with no JS and no CSS. `Rask.Spa.Hosting` leans on that same behaviour deliberately,
+  because there a static-file middleware serves the assets; here the Node server is the origin for its
+  own, so nothing else can.
 
   `UseRaskMeta()` registers a **fallback**, so mapped endpoints still win — but map your API first; the
   symptom of getting it wrong is an API call answered with a rendered page. `SuperviseNode = false`

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -79,6 +79,13 @@
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
     <PackageVersion Include="System.Reflection.Metadata" Version="10.0.11" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.85" />
+    <!--
+      Rask.Meta.Hosting's only external dependency, and only for IHttpForwarder — YARP's direct
+      forwarding API, with no route table or config model attached. It is what puts WebSocket upgrade,
+      unbuffered response streaming and hop-by-hop header handling on a supported implementation
+      rather than a hand-rolled one; Microsoft-published, same family as the ASP.NET packages above.
+    -->
+    <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
   </ItemGroup>

--- a/NUGET.md
+++ b/NUGET.md
@@ -45,6 +45,7 @@ dotnet add package Rask.Server            # the lean host on its own: server-ren
 dotnet add package Rask.Wasm              # client-side WebAssembly
 dotnet add package Rask.Wasm.Hosting      # host a published WASM bundle on ASP.NET
 dotnet add package Rask.Spa.Hosting       # host a built TypeScript SPA on ASP.NET
+dotnet add package Rask.Meta.Hosting      # host Nuxt/Next/SvelteKit/Start/SolidStart/Analog beside your C# (needs Node)
 dotnet add package Rask.External           # a .tsx/.vue/.svelte/Lit component as a Rask component (needs Node)
 dotnet add package Rask.Blazor             # a real Blazor component (MudBlazor, an RCL) as a Rask component
 ```

--- a/Rask.slnx
+++ b/Rask.slnx
@@ -46,6 +46,7 @@
         <Project Path="src/Rask.Server/Rask.Server.csproj"/>
         <Project Path="src/Rask.Signaling/Rask.Signaling.csproj"/>
         <Project Path="src/Rask.Query/Rask.Query.csproj"/>
+        <Project Path="src/Rask.Meta.Hosting/Rask.Meta.Hosting.csproj"/>
         <Project Path="src/Rask.Spa.Hosting/Rask.Spa.Hosting.csproj"/>
         <Project Path="src/Rask.Spa.Tasks/Rask.Spa.Tasks.csproj"/>
         <Project Path="src/Rask.Tailwind/Rask.Tailwind.csproj"/>
@@ -100,6 +101,7 @@
         <Project Path="tests/Rask.Server.Tests/Rask.Server.Tests.csproj"/>
         <Project Path="tests/Rask.Signaling.Tests/Rask.Signaling.Tests.csproj"/>
         <Project Path="tests/Rask.Query.Tests/Rask.Query.Tests.csproj"/>
+        <Project Path="tests/Rask.Meta.Hosting.Tests/Rask.Meta.Hosting.Tests.csproj"/>
         <Project Path="tests/Rask.Spa.Hosting.Tests/Rask.Spa.Hosting.Tests.csproj"/>
         <Project Path="tests/Rask.Spa.Tasks.Tests/Rask.Spa.Tasks.Tests.csproj"/>
         <Project Path="tests/Rask.Tailwind.Tasks.Tests/Rask.Tailwind.Tasks.Tests.csproj"/>

--- a/src/Rask.Meta.Hosting/MetaFramework.cs
+++ b/src/Rask.Meta.Hosting/MetaFramework.cs
@@ -100,10 +100,15 @@ public sealed record MetaFramework
     /// <remarks>
     ///     <para>
     ///         Standalone deliberately omits <c>public</c> and <c>.next/static</c> — Next's own docs say
-    ///         those are "ideally served by a CDN". Under this package's topology Kestrel is already in
-    ///         front, so Rask can serve them directly and never forward those requests at all. What
-    ///         reads as Next's awkward case elsewhere is the one place this arrangement is strictly
-    ///         better than the CDN it assumes.
+    ///         those are "ideally served by a CDN". <b>This package does not serve them yet</b>, and
+    ///         nothing else will: the standalone server does not have those directories, so until the
+    ///         build targets land, a Next app needs them copied next to <c>server.js</c> (the <c>cp</c>
+    ///         Next's own Docker guidance gives) or its assets 404.
+    ///     </para>
+    ///     <para>
+    ///         Serving them from Kestrel is the plan rather than the state: this topology already puts
+    ///         Kestrel in front with the cache rules to do it well, which is the one place Next's
+    ///         CDN assumption suits this arrangement better than it suits a plain Node deployment.
     ///     </para>
     ///     <para><c>HOSTNAME</c> rather than <c>HOST</c>; see <see cref="HostVariable" />.</para>
     /// </remarks>

--- a/src/Rask.Meta.Hosting/MetaFramework.cs
+++ b/src/Rask.Meta.Hosting/MetaFramework.cs
@@ -1,0 +1,116 @@
+namespace Rask.Meta.Hosting;
+
+/// <summary>
+///     Everything this package needs to know about one meta framework: where its built server entry
+///     lives, and which environment variables that entry reads to decide what to listen on.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Deliberately five fields rather than a class per framework. Six frameworks reduce to three
+///         server shapes — Nitro (<see cref="Nuxt" />, <see cref="TanStackStart" />,
+///         <see cref="SolidStart" />, <see cref="Analog" />), <c>adapter-node</c>
+///         (<see cref="SvelteKit" />) and Next's standalone output (<see cref="Next" />) — and all
+///         three produce a single directly executable entry that takes its port from the environment.
+///         Once that is true the framework's identity stops mattering to the host, and what is left is
+///         data.
+///     </para>
+///     <para>
+///         That single executable entry is also why the supervisor runs <c>node &lt;entry&gt;</c>
+///         rather than <c>npm start</c>: npm spawns the real server as a <em>grandchild</em>, so
+///         killing npm orphans it. Every one of the six can be executed directly, so the orphan case
+///         never has to be handled at all.
+///     </para>
+/// </remarks>
+public sealed record MetaFramework
+{
+    /// <summary>The framework's name, used in logs and diagnostics.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    ///     The built server entry, relative to <see cref="MetaHostingOptions.AppDirectory" />.
+    /// </summary>
+    public required string ServerEntry { get; init; }
+
+    /// <summary>The environment variable the entry reads for its port.</summary>
+    public string PortVariable { get; init; } = "PORT";
+
+    /// <summary>
+    ///     The environment variable the entry reads for its bind address.
+    /// </summary>
+    /// <remarks>
+    ///     Next's standalone server reads <c>HOSTNAME</c> where everything Nitro-based reads
+    ///     <c>HOST</c>. One word, and exactly the kind of difference that silently produces a server
+    ///     bound to <c>0.0.0.0</c> when the whole point is that it is reachable only from inside the
+    ///     container.
+    /// </remarks>
+    public string HostVariable { get; init; } = "HOST";
+
+    /// <summary>Nuxt, built with the default <c>node-server</c> Nitro preset.</summary>
+    public static MetaFramework Nuxt { get; } = new()
+    {
+        Name = "nuxt",
+        ServerEntry = ".output/server/index.mjs",
+    };
+
+    /// <summary>TanStack Start, built with the Vite bundler onto Nitro.</summary>
+    /// <remarks>
+    ///     The Vite bundler rather than Rsbuild is a pinned choice, not a default. Rsbuild emits a
+    ///     fetch-style entry that needs srvx or a custom Node host in front of it, which would add a
+    ///     fourth server shape to a seam that otherwise has three.
+    /// </remarks>
+    public static MetaFramework TanStackStart { get; } = new()
+    {
+        Name = "tanstack-start",
+        ServerEntry = ".output/server/index.mjs",
+    };
+
+    /// <summary>SolidStart v2, on Vite with Nitro's <c>node_server</c> preset.</summary>
+    public static MetaFramework SolidStart { get; } = new()
+    {
+        Name = "solidstart",
+        ServerEntry = ".output/server/index.mjs",
+    };
+
+    /// <summary>AnalogJS — Angular on Vite, with Node as Nitro's default preset.</summary>
+    /// <remarks>
+    ///     Analog is the one framework here whose output does not sit under <c>.output</c>. It is also
+    ///     what lets Angular join this lane on the same terms as everything else: the SPA lane has to
+    ///     carve Angular out entirely, because there the build belongs to the Angular CLI rather than
+    ///     to Vite.
+    /// </remarks>
+    public static MetaFramework Analog { get; } = new()
+    {
+        Name = "analog",
+        ServerEntry = "dist/analog/server/index.mjs",
+    };
+
+    /// <summary>SvelteKit, built with <c>adapter-node</c>.</summary>
+    /// <remarks>
+    ///     The one framework whose output is not self-contained: <c>adapter-node</c> emits a server
+    ///     that still resolves its production dependencies from <c>node_modules</c>, so the image needs
+    ///     an <c>npm ci --omit=dev</c> that the Nitro four do not.
+    /// </remarks>
+    public static MetaFramework SvelteKit { get; } = new()
+    {
+        Name = "sveltekit",
+        ServerEntry = "build/index.js",
+    };
+
+    /// <summary>Next.js, built with <c>output: 'standalone'</c>.</summary>
+    /// <remarks>
+    ///     <para>
+    ///         Standalone deliberately omits <c>public</c> and <c>.next/static</c> — Next's own docs say
+    ///         those are "ideally served by a CDN". Under this package's topology Kestrel is already in
+    ///         front, so Rask can serve them directly and never forward those requests at all. What
+    ///         reads as Next's awkward case elsewhere is the one place this arrangement is strictly
+    ///         better than the CDN it assumes.
+    ///     </para>
+    ///     <para><c>HOSTNAME</c> rather than <c>HOST</c>; see <see cref="HostVariable" />.</para>
+    /// </remarks>
+    public static MetaFramework Next { get; } = new()
+    {
+        Name = "nextjs",
+        ServerEntry = "server.js",
+        HostVariable = "HOSTNAME",
+    };
+}

--- a/src/Rask.Meta.Hosting/MetaHostingOptions.cs
+++ b/src/Rask.Meta.Hosting/MetaHostingOptions.cs
@@ -48,6 +48,17 @@ public sealed class MetaHostingOptions
     public int MaxRestartAttempts { get; set; } = 5;
 
     /// <summary>
+    ///     How long a run must last to count as a recovery, resetting the restart budget.
+    /// </summary>
+    /// <remarks>
+    ///     Without this the budget would be a <em>lifetime</em> one, and a server that runs happily for
+    ///     weeks would still take the host down on its fifth crash however far apart those were. What
+    ///     <see cref="MaxRestartAttempts" /> is meant to catch is a process that will not stay running
+    ///     — consecutive failures — not the ordinary attrition of a long-lived one.
+    /// </remarks>
+    public TimeSpan HealthyRunThreshold { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
     ///     The base URL handed to the Node process so server-side rendering can call back into this
     ///     app, under the variable named by <see cref="BaseUrlVariable" />.
     /// </summary>

--- a/src/Rask.Meta.Hosting/MetaHostingOptions.cs
+++ b/src/Rask.Meta.Hosting/MetaHostingOptions.cs
@@ -1,0 +1,78 @@
+namespace Rask.Meta.Hosting;
+
+/// <summary>
+///     Configures the supervised Node process and the forwarder in front of it.
+/// </summary>
+public sealed class MetaHostingOptions
+{
+    /// <summary>Which framework's build output is being hosted.</summary>
+    public MetaFramework Framework { get; set; } = MetaFramework.TanStackStart;
+
+    /// <summary>
+    ///     The directory holding the framework's build output. Relative paths resolve against the
+    ///     content root.
+    /// </summary>
+    public string AppDirectory { get; set; } = "frontend";
+
+    /// <summary>The <c>node</c> executable, resolved on <c>PATH</c> unless given a full path.</summary>
+    public string NodeExecutable { get; set; } = "node";
+
+    /// <summary>The loopback port the Node process is told to listen on.</summary>
+    /// <remarks>
+    ///     A fixed default rather than an ephemeral port picked by binding to 0. Picking one means
+    ///     binding a socket, reading the port, closing it and handing the number to a process that
+    ///     binds it a moment later — a race with anything else on the machine doing the same. Inside a
+    ///     container, which is where this runs, there is nothing to collide with.
+    /// </remarks>
+    public int Port { get; set; } = 3000;
+
+    /// <summary>
+    ///     How long the Node process has to accept a connection before a start attempt is abandoned.
+    /// </summary>
+    public TimeSpan StartupTimeout { get; set; } = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    ///     How long the Node process is given to exit on <c>SIGTERM</c> before its tree is killed.
+    /// </summary>
+    public TimeSpan ShutdownTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    ///     How many times a crashed Node process is restarted before the whole application is stopped.
+    /// </summary>
+    /// <remarks>
+    ///     Exhausting this budget stops the host rather than serving 502s for ever. An orchestrator
+    ///     restarting the container — fresh filesystem, fresh memory, and an event someone can see —
+    ///     is a better supervisor than one written here, and a hard exit is louder than a degraded
+    ///     process that still answers health checks.
+    /// </remarks>
+    public int MaxRestartAttempts { get; set; } = 5;
+
+    /// <summary>
+    ///     The base URL handed to the Node process so server-side rendering can call back into this
+    ///     app, under the variable named by <see cref="BaseUrlVariable" />.
+    /// </summary>
+    /// <remarks>
+    ///     Injected by the host rather than configured in the front end, so it cannot drift from where
+    ///     the app is actually listening. It is also never derived from a request header: server-side
+    ///     rendering calls back carrying the visitor's own cookie, so a destination an attacker can
+    ///     influence turns that into a confused deputy.
+    /// </remarks>
+    public string? BaseUrl { get; set; }
+
+    /// <summary>The environment variable carrying <see cref="BaseUrl" />.</summary>
+    public string BaseUrlVariable { get; set; } = "RASK_BASE_URL";
+
+    /// <summary>Extra environment variables for the Node process.</summary>
+    public IDictionary<string, string> Environment { get; } =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>
+    ///     Whether to supervise a Node process at all. <c>false</c> forwards to an already-running
+    ///     server on <see cref="Port" />.
+    /// </summary>
+    /// <remarks>
+    ///     The escape hatch for running the front end yourself — under a debugger, or as a second
+    ///     container behind the same proxy. The forwarder does not care what is listening.
+    /// </remarks>
+    public bool SuperviseNode { get; set; } = true;
+}

--- a/src/Rask.Meta.Hosting/NodeForwarder.cs
+++ b/src/Rask.Meta.Hosting/NodeForwarder.cs
@@ -1,0 +1,115 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Yarp.ReverseProxy.Forwarder;
+
+namespace Rask.Meta.Hosting;
+
+/// <summary>
+///     Forwards a request Kestrel did not answer itself to the framework's Node server on loopback.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The handler below is configured for proxying rather than for calling an API, and each
+///         departure from the defaults matters. Redirects are not followed and cookies are not stored,
+///         because both belong to the browser and handling them here would silently rewrite the
+///         visitor's session. Decompression is off so a compressed response streams through untouched
+///         rather than being inflated and re-deflated.
+///     </para>
+///     <para>
+///         <see cref="IHttpForwarder" /> keeps the response UNBUFFERED, which is the property the whole
+///         lane depends on: React Server Components and streaming SSR send a response over many
+///         flushes, and a proxy that waits for the end turns a streaming page into a slow blank one
+///         without failing a single test.
+///     </para>
+/// </remarks>
+internal sealed partial class NodeForwarder : IDisposable
+{
+    private readonly string _destination;
+    private readonly IHttpForwarder _forwarder;
+    private readonly HttpMessageInvoker _invoker;
+    private readonly ILogger<NodeForwarder> _logger;
+    private readonly MetaHostingOptions _options;
+    private readonly NodeReadiness _readiness;
+    private readonly ForwarderRequestConfig _requestConfig;
+
+    // Public on an internal type: the container resolves only public constructors, and this one is
+    // never visible outside the assembly because the type is not.
+    public NodeForwarder(
+        MetaHostingOptions options,
+        NodeReadiness readiness,
+        IHttpForwarder forwarder,
+        ILogger<NodeForwarder> logger)
+    {
+        _options = options;
+        _readiness = readiness;
+        _forwarder = forwarder;
+        _logger = logger;
+        _destination = string.Create(
+            CultureInfo.InvariantCulture,
+            $"http://127.0.0.1:{options.Port}/");
+
+        _invoker = new HttpMessageInvoker(new SocketsHttpHandler
+        {
+            UseProxy = false,
+            AllowAutoRedirect = false,
+            AutomaticDecompression = DecompressionMethods.None,
+            UseCookies = false,
+            ConnectTimeout = TimeSpan.FromSeconds(15),
+            ActivityHeadersPropagator = new ReverseProxyPropagator(DistributedContextPropagator.Current),
+        });
+
+        _requestConfig = new ForwarderRequestConfig
+        {
+            // Long enough for a slow first render and for a streamed response that pauses between
+            // flushes; short enough that a wedged renderer does not hold the connection for ever.
+            ActivityTimeout = TimeSpan.FromSeconds(100),
+        };
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => _invoker.Dispose();
+
+    /// <summary>Forwards one request, or refuses it while the front end is still starting.</summary>
+    internal async Task ForwardAsync(HttpContext context)
+    {
+        if (!_readiness.IsReady)
+        {
+            await WriteStartingAsync(context).ConfigureAwait(false);
+            return;
+        }
+
+        var error = await _forwarder
+            .SendAsync(context, _destination, _invoker, _requestConfig)
+            .ConfigureAwait(false);
+
+        if (error != ForwarderError.None && !context.Response.HasStarted)
+        {
+            var reason = context.GetForwarderErrorFeature()?.Exception?.Message ?? error.ToString();
+            LogForwardFailed(context.Request.Path.ToString(), _options.Framework.Name, reason);
+        }
+    }
+
+    /// <summary>
+    ///     Answers 503 while the Node process is not accepting connections.
+    /// </summary>
+    /// <remarks>
+    ///     A 503 with <c>Retry-After</c> rather than forwarding into a closed port and letting it
+    ///     surface as a 502: this state is normal for the first seconds of a container's life, and it
+    ///     is genuinely temporary, so it should say so in the one way clients and orchestrators
+    ///     already understand.
+    /// </remarks>
+    private static async Task WriteStartingAsync(HttpContext context)
+    {
+        context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+        context.Response.Headers.RetryAfter = "1";
+        context.Response.ContentType = "text/plain; charset=utf-8";
+        await context.Response.WriteAsync("The front end is still starting.").ConfigureAwait(false);
+    }
+
+    [LoggerMessage(EventId = 1, Level = LogLevel.Error,
+        Message = "Forwarding {Path} to {Framework} failed: {Reason}")]
+    private partial void LogForwardFailed(string path, string framework, string reason);
+}

--- a/src/Rask.Meta.Hosting/NodeForwarder.cs
+++ b/src/Rask.Meta.Hosting/NodeForwarder.cs
@@ -34,6 +34,7 @@ internal sealed partial class NodeForwarder : IDisposable
     private readonly MetaHostingOptions _options;
     private readonly NodeReadiness _readiness;
     private readonly ForwarderRequestConfig _requestConfig;
+    private readonly ForwarderRequestConfig _upgradeConfig;
 
     // Public on an internal type: the container resolves only public constructors, and this one is
     // never visible outside the assembly because the type is not.
@@ -67,6 +68,13 @@ internal sealed partial class NodeForwarder : IDisposable
             // flushes; short enough that a wedged renderer does not hold the connection for ever.
             ActivityTimeout = TimeSpan.FromSeconds(100),
         };
+
+        // An upgraded connection gets no idle cap. ActivityTimeout is an IDLE timeout that applies to
+        // WebSockets too, so the ordinary one would tear down any socket quiet for 100 seconds — a
+        // chat with nobody typing, a notification channel between pings — and the client would see a
+        // disconnect with no cause. Liveness on an upgraded connection is the application's job, and
+        // it has the ping frames to do it with.
+        _upgradeConfig = new ForwarderRequestConfig { ActivityTimeout = null };
     }
 
     /// <inheritdoc />
@@ -81,11 +89,17 @@ internal sealed partial class NodeForwarder : IDisposable
             return;
         }
 
+        var config = context.WebSockets.IsWebSocketRequest ? _upgradeConfig : _requestConfig;
+
         var error = await _forwarder
-            .SendAsync(context, _destination, _invoker, _requestConfig)
+            .SendAsync(context, _destination, _invoker, config)
             .ConfigureAwait(false);
 
-        if (error != ForwarderError.None && !context.Response.HasStarted)
+        // No HasStarted guard on the LOGGING. A failure part-way through a streamed response — the
+        // Node process dying mid-render — is the one the visitor actually sees, as a page that stops
+        // half-written, and gating the log on "nothing was sent yet" is precisely what would leave
+        // that case recorded nowhere.
+        if (error != ForwarderError.None)
         {
             var reason = context.GetForwarderErrorFeature()?.Exception?.Message ?? error.ToString();
             LogForwardFailed(context.Request.Path.ToString(), _options.Framework.Name, reason);

--- a/src/Rask.Meta.Hosting/NodeReadiness.cs
+++ b/src/Rask.Meta.Hosting/NodeReadiness.cs
@@ -1,0 +1,24 @@
+namespace Rask.Meta.Hosting;
+
+/// <summary>
+///     Whether the supervised Node process is currently accepting connections.
+/// </summary>
+/// <remarks>
+///     Shared between the supervisor, which sets it, and the forwarder, which refuses to forward
+///     before it is set. Without this gate the first request after a container start is forwarded into
+///     a closed port and surfaces as a 502 — a real deployment reads as broken for however long the
+///     framework takes to boot, which for a cold Node process is seconds, not milliseconds.
+/// </remarks>
+internal sealed class NodeReadiness
+{
+    private volatile bool _ready;
+
+    /// <summary>Whether the process is up and listening.</summary>
+    internal bool IsReady => _ready;
+
+    /// <summary>Marks the process ready to receive forwarded requests.</summary>
+    internal void MarkReady() => _ready = true;
+
+    /// <summary>Marks the process unavailable — it exited, or has not finished starting.</summary>
+    internal void MarkNotReady() => _ready = false;
+}

--- a/src/Rask.Meta.Hosting/NodeSupervisor.cs
+++ b/src/Rask.Meta.Hosting/NodeSupervisor.cs
@@ -53,6 +53,30 @@ internal sealed partial class NodeSupervisor : BackgroundService
     /// <summary>The absolute path of the server entry this supervisor runs.</summary>
     internal string ServerEntryPath => Path.Combine(_appDirectory, _options.Framework.ServerEntry);
 
+    /// <summary>
+    ///     Refuses to start at all when there is no built front end to run.
+    /// </summary>
+    /// <remarks>
+    ///     Checked here, in <see cref="IHostedService.StartAsync" />, rather than in the loop below,
+    ///     because the two produce very different failures. Throwing here aborts startup with the
+    ///     message naming the path that is missing. Calling <c>StopApplication()</c> from the loop
+    ///     instead cancels Kestrel's own <c>BindAsync</c> mid-startup, and the process then dies with
+    ///     <c>TaskCanceledException</c> — which says nothing about the front end and buries the
+    ///     Critical line that did. "You have not built the front end" is a configuration mistake, and a
+    ///     configuration mistake should fail fast and name itself.
+    /// </remarks>
+    public override async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_options.SuperviseNode && !File.Exists(ServerEntryPath))
+        {
+            throw new InvalidOperationException(
+                $"Rask.Meta.Hosting: no {_options.Framework.Name} server entry at '{ServerEntryPath}'. "
+                + "Build the front end, or set MetaHostingOptions.AppDirectory to where it was built.");
+        }
+
+        await base.StartAsync(cancellationToken).ConfigureAwait(false);
+    }
+
     /// <inheritdoc />
     protected override Task ExecuteAsync(CancellationToken stoppingToken) => RunAsync(stoppingToken);
 
@@ -79,7 +103,8 @@ internal sealed partial class NodeSupervisor : BackgroundService
             return;
         }
 
-        for (var attempt = 0; !stoppingToken.IsCancellationRequested; attempt++)
+        var attempt = 0;
+        while (!stoppingToken.IsCancellationRequested)
         {
             if (attempt > 0)
             {
@@ -100,7 +125,11 @@ internal sealed partial class NodeSupervisor : BackgroundService
                 }
             }
 
+            var startedAt = TimeProvider.System.GetTimestamp();
             await RunOnceAsync(entry, stoppingToken).ConfigureAwait(false);
+            var lasted = TimeProvider.System.GetElapsedTime(startedAt);
+
+            attempt = NextAttempt(attempt, lasted, _options.HealthyRunThreshold);
         }
 
         if (stoppingToken.IsCancellationRequested)
@@ -114,6 +143,18 @@ internal sealed partial class NodeSupervisor : BackgroundService
         LogGivingUp(_options.Framework.Name, _options.MaxRestartAttempts);
         _lifetime.StopApplication();
     }
+
+    /// <summary>
+    ///     The restart budget after a run that lasted <paramref name="lasted" />.
+    /// </summary>
+    /// <remarks>
+    ///     A run that stayed up counts as recovery rather than as another strike. Without this the
+    ///     budget is a <em>lifetime</em> one: a server that runs happily for a week and crashes once a
+    ///     month still takes the host down on its fifth crash, months apart — which is not what "will
+    ///     not stay running" means. Consecutive failures are the signal; scattered ones are not.
+    /// </remarks>
+    internal static int NextAttempt(int attempt, TimeSpan lasted, TimeSpan healthyThreshold) =>
+        lasted >= healthyThreshold ? 1 : attempt + 1;
 
     /// <summary>
     ///     Exponential backoff, capped — 1s, 2s, 4s, 8s, 16s, then 30s for anything beyond.
@@ -152,6 +193,15 @@ internal sealed partial class NodeSupervisor : BackgroundService
             {
                 _readiness.MarkReady();
                 LogReady(_options.Framework.Name, _options.Port);
+            }
+            else if (!process.HasExited && !stoppingToken.IsCancellationRequested)
+            {
+                // The budget exists to end exactly this state. A process that is alive but has not
+                // bound its port never exits on its own, so waiting for it below would hold the app at
+                // 503 for ever without ever spending a restart attempt — the "degraded process that
+                // still answers" outcome this class refuses. Abandoning the attempt hands it to the
+                // backoff loop, which eventually gives up and stops the host.
+                return;
             }
 
             await process.WaitForExitAsync(stoppingToken).ConfigureAwait(false);
@@ -234,7 +284,11 @@ internal sealed partial class NodeSupervisor : BackgroundService
             {
                 using var probe = new TcpClient();
                 await probe.ConnectAsync("127.0.0.1", _options.Port, stoppingToken).ConfigureAwait(false);
-                return true;
+
+                // A connect proves something owns the port, not that OUR child does. If the child
+                // failed to bind because another process already had it, the probe would happily
+                // succeed against that stranger and we would forward this app's traffic to it.
+                return !process.HasExited;
             }
             catch (SocketException)
             {
@@ -307,6 +361,13 @@ internal sealed partial class NodeSupervisor : BackgroundService
         catch (NotSupportedException)
         {
             // No process tree to walk on this platform.
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            // The kill itself was refused — a partially exited tree, or no permission to signal one of
+            // its members. Caught because this runs inside RunOnceAsync's finally: letting it escape
+            // would leave the supervision loop through BackgroundServiceExceptionBehavior.StopHost and
+            // take the whole app down, when the process we were trying to end is already going away.
         }
     }
 

--- a/src/Rask.Meta.Hosting/NodeSupervisor.cs
+++ b/src/Rask.Meta.Hosting/NodeSupervisor.cs
@@ -1,0 +1,369 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Rask.Meta.Hosting;
+
+/// <summary>
+///     Owns the meta framework's Node process for the lifetime of the app: starts it, waits for it to
+///     listen, streams its output into <see cref="ILogger" />, restarts it when it dies, and stops the
+///     whole host when it will not stay up.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The process is a child of this one, so there is exactly one runtime owning lifetime and one
+///         place logs come out. The cost of that choice, taken deliberately, is that restart and
+///         backoff policy now live here rather than in an init system.
+///     </para>
+///     <para>
+///         It is bound to <c>127.0.0.1</c> and never <c>0.0.0.0</c>. Kestrel is the only thing that
+///         should be able to reach it, so publishing the container's ports must not expose an
+///         unauthenticated server-side renderer alongside the app.
+///     </para>
+/// </remarks>
+internal sealed partial class NodeSupervisor : BackgroundService
+{
+    private readonly IHostApplicationLifetime _lifetime;
+    private readonly ILogger<NodeSupervisor> _logger;
+    private readonly MetaHostingOptions _options;
+    private readonly NodeReadiness _readiness;
+    private readonly string _appDirectory;
+
+    // Public on an internal type, for the same reason as NodeForwarder: the container resolves only
+    // public constructors, and an internal type's members are not public API.
+    public NodeSupervisor(
+        MetaHostingOptions options,
+        NodeReadiness readiness,
+        IHostEnvironment environment,
+        IHostApplicationLifetime lifetime,
+        ILogger<NodeSupervisor> logger)
+    {
+        _options = options;
+        _readiness = readiness;
+        _lifetime = lifetime;
+        _logger = logger;
+        _appDirectory = Path.IsPathRooted(options.AppDirectory)
+            ? options.AppDirectory
+            : Path.Combine(environment.ContentRootPath, options.AppDirectory);
+    }
+
+    /// <summary>The absolute path of the server entry this supervisor runs.</summary>
+    internal string ServerEntryPath => Path.Combine(_appDirectory, _options.Framework.ServerEntry);
+
+    /// <inheritdoc />
+    protected override Task ExecuteAsync(CancellationToken stoppingToken) => RunAsync(stoppingToken);
+
+    /// <summary>
+    ///     The supervision loop, separated from <see cref="ExecuteAsync" /> so it can be driven
+    ///     directly. What is worth testing here is the policy — when it gives up, when it refuses to
+    ///     start — and reaching that through <see cref="BackgroundService" />'s start semantics tests
+    ///     the host rather than this.
+    /// </summary>
+    internal async Task RunAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.SuperviseNode)
+        {
+            // Someone else is running the front end. Nothing to supervise, and nothing to wait for.
+            _readiness.MarkReady();
+            return;
+        }
+
+        var entry = ServerEntryPath;
+        if (!File.Exists(entry))
+        {
+            LogEntryMissing(_options.Framework.Name, entry);
+            _lifetime.StopApplication();
+            return;
+        }
+
+        for (var attempt = 0; !stoppingToken.IsCancellationRequested; attempt++)
+        {
+            if (attempt > 0)
+            {
+                if (attempt > _options.MaxRestartAttempts)
+                {
+                    break;
+                }
+
+                var backoff = BackoffFor(attempt);
+                LogRestarting(_options.Framework.Name, attempt, _options.MaxRestartAttempts, backoff.TotalSeconds);
+                try
+                {
+                    await Task.Delay(backoff, stoppingToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+            }
+
+            await RunOnceAsync(entry, stoppingToken).ConfigureAwait(false);
+        }
+
+        if (stoppingToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        // The budget is spent. Stopping the host is the honest outcome: an orchestrator restarting the
+        // container is a better supervisor than this loop, and an exit is visible where a permanently
+        // degraded process that still answers health checks is not.
+        LogGivingUp(_options.Framework.Name, _options.MaxRestartAttempts);
+        _lifetime.StopApplication();
+    }
+
+    /// <summary>
+    ///     Exponential backoff, capped — 1s, 2s, 4s, 8s, 16s, then 30s for anything beyond.
+    /// </summary>
+    internal static TimeSpan BackoffFor(int attempt)
+    {
+        var seconds = Math.Min(30d, Math.Pow(2, Math.Max(0, attempt - 1)));
+        return TimeSpan.FromSeconds(seconds);
+    }
+
+    /// <summary>Runs the process once, returning when it exits or the host is stopping.</summary>
+    private async Task RunOnceAsync(string entry, CancellationToken stoppingToken)
+    {
+        using var process = new Process { StartInfo = BuildStartInfo(entry), EnableRaisingEvents = true };
+
+        // stdout and stderr are BOTH Information. A great deal of Node tooling writes ordinary
+        // progress to stderr, so mapping it to Error would fill the log with warnings that mean
+        // nothing. What actually signals a fault is the exit code, which is reported below.
+        process.OutputDataReceived += (_, e) => LogNodeOutput(e.Data);
+        process.ErrorDataReceived += (_, e) => LogNodeOutput(e.Data);
+
+        if (!process.Start())
+        {
+            LogStartFailed(_options.Framework.Name);
+            return;
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        LogStarted(_options.Framework.Name, process.Id, _options.Port);
+
+        try
+        {
+            var ready = await WaitForListeningAsync(process, stoppingToken).ConfigureAwait(false);
+            if (ready)
+            {
+                _readiness.MarkReady();
+                LogReady(_options.Framework.Name, _options.Port);
+            }
+
+            await process.WaitForExitAsync(stoppingToken).ConfigureAwait(false);
+            _readiness.MarkNotReady();
+
+            if (!stoppingToken.IsCancellationRequested)
+            {
+                LogExited(_options.Framework.Name, process.ExitCode);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // The host is shutting down, not a crash.
+        }
+        finally
+        {
+            _readiness.MarkNotReady();
+            await StopProcessAsync(process).ConfigureAwait(false);
+        }
+    }
+
+    private ProcessStartInfo BuildStartInfo(string entry)
+    {
+        var info = new ProcessStartInfo(_options.NodeExecutable)
+        {
+            WorkingDirectory = _appDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        info.ArgumentList.Add(entry);
+
+        info.Environment[_options.Framework.PortVariable] =
+            _options.Port.ToString(CultureInfo.InvariantCulture);
+        info.Environment[_options.Framework.HostVariable] = "127.0.0.1";
+
+        // Set rather than overridden: Next in particular logs a warning on every request without it,
+        // but an app that has deliberately chosen otherwise keeps its choice.
+        if (!info.Environment.ContainsKey("NODE_ENV"))
+        {
+            info.Environment["NODE_ENV"] = "production";
+        }
+
+        if (!string.IsNullOrEmpty(_options.BaseUrl))
+        {
+            info.Environment[_options.BaseUrlVariable] = _options.BaseUrl;
+        }
+
+        foreach (var (key, value) in _options.Environment)
+        {
+            info.Environment[key] = value;
+        }
+
+        return info;
+    }
+
+    /// <summary>
+    ///     Polls a loopback connect until the process accepts one, it exits, or the startup budget runs
+    ///     out.
+    /// </summary>
+    /// <remarks>
+    ///     A TCP connect rather than a sentinel line on stdout: every one of the six frameworks
+    ///     announces itself differently, and some say nothing at all, but all of them are only useful
+    ///     once the port answers. Watching the port is the one signal that means the same thing
+    ///     everywhere.
+    /// </remarks>
+    private async Task<bool> WaitForListeningAsync(Process process, CancellationToken stoppingToken)
+    {
+        var deadline = DateTimeOffset.UtcNow + _options.StartupTimeout;
+
+        while (!stoppingToken.IsCancellationRequested && DateTimeOffset.UtcNow < deadline)
+        {
+            if (process.HasExited)
+            {
+                return false;
+            }
+
+            try
+            {
+                using var probe = new TcpClient();
+                await probe.ConnectAsync("127.0.0.1", _options.Port, stoppingToken).ConfigureAwait(false);
+                return true;
+            }
+            catch (SocketException)
+            {
+                // Not listening yet.
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(100), stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
+        }
+
+        if (!stoppingToken.IsCancellationRequested)
+        {
+            LogStartupTimedOut(_options.Framework.Name, _options.StartupTimeout.TotalSeconds);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     Asks the process to stop, then insists.
+    /// </summary>
+    /// <remarks>
+    ///     <see cref="Process.Kill()" /> is <c>SIGKILL</c> on Unix, which drops in-flight renders on
+    ///     the floor. A well-behaved shutdown sends <c>SIGTERM</c> first and gives the framework its
+    ///     own grace period — so the signal goes through libc, and <see cref="Process.Kill(bool)" />
+    ///     stays the fallback for a process that ignores it and for Windows, which has no equivalent.
+    /// </remarks>
+    private async Task StopProcessAsync(Process process)
+    {
+        if (process.HasExited)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!OperatingSystem.IsWindows() && Terminate(process.Id, SIGTERM) == 0)
+            {
+                using var grace = new CancellationTokenSource(_options.ShutdownTimeout);
+                try
+                {
+                    await process.WaitForExitAsync(grace.Token).ConfigureAwait(false);
+                    return;
+                }
+                catch (OperationCanceledException)
+                {
+                    LogGraceExpired(_options.Framework.Name, _options.ShutdownTimeout.TotalSeconds);
+                }
+            }
+
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Exited between the check and the signal.
+        }
+        catch (NotSupportedException)
+        {
+            // No process tree to walk on this platform.
+        }
+    }
+
+    private const int SIGTERM = 15;
+
+    /// <remarks>
+    ///     <c>DllImport</c> rather than the newer <c>LibraryImport</c>: the source generator behind
+    ///     that attribute emits unsafe code, so it would mean turning on
+    ///     <c>AllowUnsafeBlocks</c> for the whole package to gain nothing here. Both arguments are
+    ///     blittable <see cref="int" />s, which is the case where the two are equivalent and there is
+    ///     no marshalling for a generator to improve on.
+    /// </remarks>
+    [DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+    private static extern int Terminate(int pid, int signal);
+
+    private void LogNodeOutput(string? line)
+    {
+        if (!string.IsNullOrWhiteSpace(line))
+        {
+            LogNodeLine(_options.Framework.Name, line);
+        }
+    }
+
+    [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "{Framework}: {Line}")]
+    private partial void LogNodeLine(string framework, string line);
+
+    [LoggerMessage(EventId = 2, Level = LogLevel.Information,
+        Message = "{Framework} starting (pid {ProcessId}) on 127.0.0.1:{Port}.")]
+    private partial void LogStarted(string framework, int processId, int port);
+
+    [LoggerMessage(EventId = 3, Level = LogLevel.Information,
+        Message = "{Framework} is listening on 127.0.0.1:{Port}; forwarding enabled.")]
+    private partial void LogReady(string framework, int port);
+
+    [LoggerMessage(EventId = 4, Level = LogLevel.Warning, Message = "{Framework} exited with code {ExitCode}.")]
+    private partial void LogExited(string framework, int exitCode);
+
+    [LoggerMessage(EventId = 5, Level = LogLevel.Warning,
+        Message = "Restarting {Framework} (attempt {Attempt} of {MaxAttempts}) in {Seconds}s.")]
+    private partial void LogRestarting(string framework, int attempt, int maxAttempts, double seconds);
+
+    [LoggerMessage(EventId = 6, Level = LogLevel.Critical,
+        Message = "{Framework} failed to stay running after {MaxAttempts} restarts; stopping the application.")]
+    private partial void LogGivingUp(string framework, int maxAttempts);
+
+    [LoggerMessage(EventId = 7, Level = LogLevel.Critical,
+        Message = "{Framework} server entry not found at '{Entry}'; stopping the application. Build the front end, or set MetaHostingOptions.AppDirectory.")]
+    private partial void LogEntryMissing(string framework, string entry);
+
+    [LoggerMessage(EventId = 8, Level = LogLevel.Error, Message = "Could not start a process for {Framework}.")]
+    private partial void LogStartFailed(string framework);
+
+    [LoggerMessage(EventId = 9, Level = LogLevel.Error,
+        Message = "{Framework} did not accept a connection within {Seconds}s.")]
+    private partial void LogStartupTimedOut(string framework, double seconds);
+
+    [LoggerMessage(EventId = 10, Level = LogLevel.Warning,
+        Message = "{Framework} did not exit within {Seconds}s of SIGTERM; killing its process tree.")]
+    private partial void LogGraceExpired(string framework, double seconds);
+}

--- a/src/Rask.Meta.Hosting/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Rask.Meta.Hosting/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -20,6 +20,8 @@ Rask.Meta.Hosting.MetaHostingOptions.BaseUrlVariable.get -> string!
 Rask.Meta.Hosting.MetaHostingOptions.BaseUrlVariable.set -> void
 Rask.Meta.Hosting.MetaHostingOptions.Environment.get -> System.Collections.Generic.IDictionary<string!, string!>!
 Rask.Meta.Hosting.MetaHostingOptions.Framework.get -> Rask.Meta.Hosting.MetaFramework!
+Rask.Meta.Hosting.MetaHostingOptions.HealthyRunThreshold.get -> System.TimeSpan
+Rask.Meta.Hosting.MetaHostingOptions.HealthyRunThreshold.set -> void
 Rask.Meta.Hosting.MetaHostingOptions.Framework.set -> void
 Rask.Meta.Hosting.MetaHostingOptions.MaxRestartAttempts.get -> int
 Rask.Meta.Hosting.MetaHostingOptions.MaxRestartAttempts.set -> void

--- a/src/Rask.Meta.Hosting/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Rask.Meta.Hosting/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,51 @@
+#nullable enable
+Rask.Meta.Hosting.MetaFramework
+Rask.Meta.Hosting.MetaFramework.<Clone>$() -> Rask.Meta.Hosting.MetaFramework!
+Rask.Meta.Hosting.MetaFramework.Equals(Rask.Meta.Hosting.MetaFramework? other) -> bool
+Rask.Meta.Hosting.MetaFramework.HostVariable.get -> string!
+Rask.Meta.Hosting.MetaFramework.HostVariable.init -> void
+Rask.Meta.Hosting.MetaFramework.MetaFramework() -> void
+Rask.Meta.Hosting.MetaFramework.Name.get -> string!
+Rask.Meta.Hosting.MetaFramework.Name.init -> void
+Rask.Meta.Hosting.MetaFramework.PortVariable.get -> string!
+Rask.Meta.Hosting.MetaFramework.PortVariable.init -> void
+Rask.Meta.Hosting.MetaFramework.ServerEntry.get -> string!
+Rask.Meta.Hosting.MetaFramework.ServerEntry.init -> void
+Rask.Meta.Hosting.MetaHostingOptions
+Rask.Meta.Hosting.MetaHostingOptions.AppDirectory.get -> string!
+Rask.Meta.Hosting.MetaHostingOptions.AppDirectory.set -> void
+Rask.Meta.Hosting.MetaHostingOptions.BaseUrl.get -> string?
+Rask.Meta.Hosting.MetaHostingOptions.BaseUrl.set -> void
+Rask.Meta.Hosting.MetaHostingOptions.BaseUrlVariable.get -> string!
+Rask.Meta.Hosting.MetaHostingOptions.BaseUrlVariable.set -> void
+Rask.Meta.Hosting.MetaHostingOptions.Environment.get -> System.Collections.Generic.IDictionary<string!, string!>!
+Rask.Meta.Hosting.MetaHostingOptions.Framework.get -> Rask.Meta.Hosting.MetaFramework!
+Rask.Meta.Hosting.MetaHostingOptions.Framework.set -> void
+Rask.Meta.Hosting.MetaHostingOptions.MaxRestartAttempts.get -> int
+Rask.Meta.Hosting.MetaHostingOptions.MaxRestartAttempts.set -> void
+Rask.Meta.Hosting.MetaHostingOptions.MetaHostingOptions() -> void
+Rask.Meta.Hosting.MetaHostingOptions.NodeExecutable.get -> string!
+Rask.Meta.Hosting.MetaHostingOptions.NodeExecutable.set -> void
+Rask.Meta.Hosting.MetaHostingOptions.Port.get -> int
+Rask.Meta.Hosting.MetaHostingOptions.Port.set -> void
+Rask.Meta.Hosting.MetaHostingOptions.ShutdownTimeout.get -> System.TimeSpan
+Rask.Meta.Hosting.MetaHostingOptions.ShutdownTimeout.set -> void
+Rask.Meta.Hosting.MetaHostingOptions.StartupTimeout.get -> System.TimeSpan
+Rask.Meta.Hosting.MetaHostingOptions.StartupTimeout.set -> void
+Rask.Meta.Hosting.MetaHostingOptions.SuperviseNode.get -> bool
+Rask.Meta.Hosting.MetaHostingOptions.SuperviseNode.set -> void
+Rask.Meta.Hosting.RaskMetaEndpointExtensions
+Rask.Meta.Hosting.RaskMetaServiceCollectionExtensions
+override Rask.Meta.Hosting.MetaFramework.Equals(object? obj) -> bool
+override Rask.Meta.Hosting.MetaFramework.GetHashCode() -> int
+override Rask.Meta.Hosting.MetaFramework.ToString() -> string!
+static Rask.Meta.Hosting.MetaFramework.Analog.get -> Rask.Meta.Hosting.MetaFramework!
+static Rask.Meta.Hosting.MetaFramework.Next.get -> Rask.Meta.Hosting.MetaFramework!
+static Rask.Meta.Hosting.MetaFramework.Nuxt.get -> Rask.Meta.Hosting.MetaFramework!
+static Rask.Meta.Hosting.MetaFramework.SolidStart.get -> Rask.Meta.Hosting.MetaFramework!
+static Rask.Meta.Hosting.MetaFramework.SvelteKit.get -> Rask.Meta.Hosting.MetaFramework!
+static Rask.Meta.Hosting.MetaFramework.TanStackStart.get -> Rask.Meta.Hosting.MetaFramework!
+static Rask.Meta.Hosting.MetaFramework.operator !=(Rask.Meta.Hosting.MetaFramework? left, Rask.Meta.Hosting.MetaFramework? right) -> bool
+static Rask.Meta.Hosting.MetaFramework.operator ==(Rask.Meta.Hosting.MetaFramework? left, Rask.Meta.Hosting.MetaFramework? right) -> bool
+static Rask.Meta.Hosting.RaskMetaEndpointExtensions.UseRaskMeta(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints) -> Microsoft.AspNetCore.Routing.IEndpointRouteBuilder!
+static Rask.Meta.Hosting.RaskMetaServiceCollectionExtensions.AddRaskMeta(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Rask.Meta.Hosting.MetaHostingOptions!>? configure = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Rask.Meta.Hosting/Rask.Meta.Hosting.csproj
+++ b/src/Rask.Meta.Hosting/Rask.Meta.Hosting.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Rask.Meta.Hosting</RootNamespace>
+
+    <PackageId>Rask.Meta.Hosting</PackageId>
+    <Title>Rask — Meta Framework Host</Title>
+    <Description>ASP.NET host for a meta framework front end — Nuxt, TanStack Start, SolidStart, SvelteKit, Analog or Next.js — running beside your C# in ONE container. Kestrel owns the public port and answers /_rask itself; the framework's own Node server is a supervised child on loopback, and everything else is forwarded to it with WebSocket upgrade and unbuffered streaming intact. Pairs with Rask.Cqrs.Server, which gives server-side rendering a typed wire back into your C#. Distinct from Rask.Spa.Hosting, which serves a static bundle and needs no Node at runtime.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      The one external dependency in this package, and a deliberate one. IHttpForwarder is YARP's
+      low-level "direct forwarding" surface — no route table, no config model, just
+      SendAsync(context, destination, invoker, config, transformer). It is the piece that already gets
+      right the three things a hand-rolled HttpClient proxy gets wrong, and all three are mandatory
+      here rather than nice to have: WebSocket (and HTTP/2 CONNECT) upgrade, UNBUFFERED response
+      streaming — React Server Components and streaming SSR are the entire reason to adopt a meta
+      framework, and buffering deletes the feature while every test still passes — and hop-by-hop
+      header stripping. Reimplementing that is exactly the "prefer standard .NET APIs, don't reinvent"
+      this repo warns against, and the package is Microsoft-published.
+    -->
+    <PackageReference Include="Yarp.ReverseProxy"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Rask.Meta.Hosting.Tests"/>
+  </ItemGroup>
+
+</Project>

--- a/src/Rask.Meta.Hosting/RaskMetaEndpointExtensions.cs
+++ b/src/Rask.Meta.Hosting/RaskMetaEndpointExtensions.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Rask.Meta.Hosting;
+
+/// <summary>
+///     Puts the meta framework's Node server behind this app: everything Kestrel does not answer
+///     itself is forwarded to it.
+/// </summary>
+public static class RaskMetaEndpointExtensions
+{
+    /// <summary>
+    ///     Forwards unmatched requests to the framework's Node server.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Map your API before calling this.</b> <c>MapRaskCqrs()</c>, any minimal APIs and any
+    ///         health checks must be mapped first. What is registered here is a fallback, so a literal
+    ///         route still wins — but the ordering is the contract rather than a coincidence, and the
+    ///         symptom of getting it wrong is an API call answered with a rendered HTML page.
+    ///     </para>
+    ///     <para>
+    ///         Requires <see cref="RaskMetaServiceCollectionExtensions.AddRaskMeta" />, which is what
+    ///         starts and supervises the process this forwards to.
+    ///     </para>
+    /// </remarks>
+    /// <param name="endpoints">The app's endpoint route builder.</param>
+    /// <returns><paramref name="endpoints" />, for chaining.</returns>
+    /// <exception cref="InvalidOperationException"><c>AddRaskMeta()</c> was not called.</exception>
+    public static IEndpointRouteBuilder UseRaskMeta(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var forwarder = endpoints.ServiceProvider.GetService<NodeForwarder>()
+            ?? throw new InvalidOperationException(
+                "UseRaskMeta() requires AddRaskMeta() on the service collection.");
+
+        endpoints.MapFallback(forwarder.ForwardAsync);
+
+        return endpoints;
+    }
+}

--- a/src/Rask.Meta.Hosting/RaskMetaEndpointExtensions.cs
+++ b/src/Rask.Meta.Hosting/RaskMetaEndpointExtensions.cs
@@ -36,7 +36,12 @@ public static class RaskMetaEndpointExtensions
             ?? throw new InvalidOperationException(
                 "UseRaskMeta() requires AddRaskMeta() on the service collection.");
 
-        endpoints.MapFallback(forwarder.ForwardAsync);
+        // "{*path}" and NOT the handler-only MapFallback overload, which maps "{*path:nonfile}" and so
+        // matches nothing whose last segment contains a dot. Every hashed chunk, favicon and
+        // robots.txt would 404 and the page would load with no JS and no CSS. Rask.Spa.Hosting depends
+        // on that same constraint deliberately — there a static-file middleware serves the assets —
+        // but here the Node server is the origin for its own, so nothing else can.
+        endpoints.MapFallback("{*path}", forwarder.ForwardAsync);
 
         return endpoints;
     }

--- a/src/Rask.Meta.Hosting/RaskMetaServiceCollectionExtensions.cs
+++ b/src/Rask.Meta.Hosting/RaskMetaServiceCollectionExtensions.cs
@@ -34,7 +34,12 @@ public static class RaskMetaServiceCollectionExtensions
         services.TryAddSingleton<NodeReadiness>();
         services.AddHttpForwarder();
         services.TryAddSingleton<NodeForwarder>();
-        services.AddSingleton<IHostedService, NodeSupervisor>();
+
+        // AddHostedService, which is TryAddEnumerable underneath, rather than a plain AddSingleton —
+        // that appends unconditionally, so calling AddRaskMeta() twice (an app plus a library, or a
+        // duplicated line) would start TWO supervisors racing for the same port. The second loses with
+        // EADDRINUSE, restarts until its budget is spent, and takes the host down with it.
+        services.AddHostedService<NodeSupervisor>();
 
         return services;
     }

--- a/src/Rask.Meta.Hosting/RaskMetaServiceCollectionExtensions.cs
+++ b/src/Rask.Meta.Hosting/RaskMetaServiceCollectionExtensions.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace Rask.Meta.Hosting;
+
+/// <summary>
+///     Registers the supervised Node process and the forwarding machinery in front of it.
+/// </summary>
+public static class RaskMetaServiceCollectionExtensions
+{
+    /// <summary>
+    ///     Adds hosting for a meta framework front end running as a supervised Node process.
+    /// </summary>
+    /// <remarks>
+    ///     Registration is where the options live, rather than at
+    ///     <see cref="RaskMetaEndpointExtensions.UseRaskMeta" />, because the supervisor needs them
+    ///     before the pipeline is built — it has to start the process and wait for it to listen while
+    ///     the app is still coming up.
+    /// </remarks>
+    /// <param name="services">The app's service collection.</param>
+    /// <param name="configure">Adjusts <see cref="MetaHostingOptions" />.</param>
+    /// <returns><paramref name="services" />, for chaining.</returns>
+    public static IServiceCollection AddRaskMeta(
+        this IServiceCollection services,
+        Action<MetaHostingOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var options = new MetaHostingOptions();
+        configure?.Invoke(options);
+
+        services.TryAddSingleton(options);
+        services.TryAddSingleton<NodeReadiness>();
+        services.AddHttpForwarder();
+        services.TryAddSingleton<NodeForwarder>();
+        services.AddSingleton<IHostedService, NodeSupervisor>();
+
+        return services;
+    }
+}

--- a/tests/Rask.Meta.Hosting.Tests/MetaFrameworkTests.cs
+++ b/tests/Rask.Meta.Hosting.Tests/MetaFrameworkTests.cs
@@ -1,0 +1,104 @@
+namespace Rask.Meta.Hosting.Tests;
+
+/// <summary>
+///     Pins each framework's built server entry and the environment variables it reads.
+/// </summary>
+/// <remarks>
+///     These look like restatements of constants, and that is exactly what makes them worth having.
+///     Every value here was read out of the framework's own current documentation rather than
+///     remembered, and each one is load-bearing at a moment when nothing else can check it: the
+///     supervisor executes <see cref="MetaFramework.ServerEntry" /> in a container, and a wrong path or
+///     a wrong variable name produces a process that either never starts or starts listening somewhere
+///     nobody forwards to. A test is the only place that knowledge survives the next person's
+///     reasonable-sounding guess.
+/// </remarks>
+public class MetaFrameworkTests
+{
+    /// <summary>
+    ///     The four Nitro-based frameworks converge on one entry path.
+    /// </summary>
+    /// <remarks>
+    ///     This convergence is the whole reason the adapter seam is data rather than a class per
+    ///     framework — six frameworks, three server shapes, and four of them identical here.
+    /// </remarks>
+    [Theory]
+    [InlineData("nuxt")]
+    [InlineData("tanstack-start")]
+    [InlineData("solidstart")]
+    public void Nitro_frameworks_share_one_server_entry(string name)
+    {
+        var framework = name switch
+        {
+            "nuxt" => MetaFramework.Nuxt,
+            "tanstack-start" => MetaFramework.TanStackStart,
+            _ => MetaFramework.SolidStart,
+        };
+
+        Assert.Equal(name, framework.Name);
+        Assert.Equal(".output/server/index.mjs", framework.ServerEntry);
+    }
+
+    /// <summary>Analog is Nitro too, but does not emit under <c>.output</c>.</summary>
+    [Fact]
+    public void Analog_emits_under_its_own_dist_directory()
+    {
+        Assert.Equal("dist/analog/server/index.mjs", MetaFramework.Analog.ServerEntry);
+    }
+
+    /// <summary>SvelteKit's <c>adapter-node</c> entry.</summary>
+    [Fact]
+    public void SvelteKit_uses_the_adapter_node_entry()
+    {
+        Assert.Equal("build/index.js", MetaFramework.SvelteKit.ServerEntry);
+    }
+
+    /// <summary>
+    ///     Next reads <c>HOSTNAME</c> where everything else reads <c>HOST</c>.
+    /// </summary>
+    /// <remarks>
+    ///     The single most consequential one-word difference in this package. Get it wrong and the
+    ///     standalone server ignores the bind address it was given and listens on <c>0.0.0.0</c> — so a
+    ///     container that publishes a port exposes an unauthenticated renderer beside the app, and
+    ///     everything still appears to work.
+    /// </remarks>
+    [Fact]
+    public void Next_reads_HOSTNAME_rather_than_HOST()
+    {
+        Assert.Equal("HOSTNAME", MetaFramework.Next.HostVariable);
+        Assert.Equal("server.js", MetaFramework.Next.ServerEntry);
+    }
+
+    /// <summary>Everything else reads <c>HOST</c>, and all six read <c>PORT</c>.</summary>
+    [Fact]
+    public void Every_other_framework_reads_HOST_and_all_read_PORT()
+    {
+        MetaFramework[] nitro =
+        [
+            MetaFramework.Nuxt,
+            MetaFramework.TanStackStart,
+            MetaFramework.SolidStart,
+            MetaFramework.Analog,
+            MetaFramework.SvelteKit,
+        ];
+
+        Assert.All(nitro, f => Assert.Equal("HOST", f.HostVariable));
+        Assert.All([.. nitro, MetaFramework.Next], f => Assert.Equal("PORT", f.PortVariable));
+    }
+
+    /// <summary>
+    ///     A preset can be adjusted without restating it.
+    /// </summary>
+    /// <remarks>
+    ///     The reason <see cref="MetaFramework" /> is a record: an app whose build lands somewhere
+    ///     unusual changes the one field that differs and keeps everything else the preset knows.
+    /// </remarks>
+    [Fact]
+    public void A_preset_can_be_customised_with_a_with_expression()
+    {
+        var custom = MetaFramework.Next with { ServerEntry = "custom/server.js" };
+
+        Assert.Equal("custom/server.js", custom.ServerEntry);
+        Assert.Equal("HOSTNAME", custom.HostVariable);
+        Assert.Equal("server.js", MetaFramework.Next.ServerEntry);
+    }
+}

--- a/tests/Rask.Meta.Hosting.Tests/NodeForwarderTests.cs
+++ b/tests/Rask.Meta.Hosting.Tests/NodeForwarderTests.cs
@@ -1,0 +1,186 @@
+using System.Net;
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Rask.Meta.Hosting.Tests;
+
+/// <summary>
+///     The forwarder, driven end to end over real sockets against a stand-in for the Node server.
+/// </summary>
+/// <remarks>
+///     Real hosts rather than a <c>TestServer</c>, deliberately. The properties worth checking here —
+///     that a response is not buffered, that an upgrade is possible at all — are properties of an
+///     actual connection, and an in-memory transport would report them as passing whether or not they
+///     hold.
+/// </remarks>
+public class NodeForwarderTests
+{
+    private static CancellationToken Timeout() =>
+        new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;
+
+    /// <summary>Starts a host on an ephemeral loopback port and reports the port it got.</summary>
+    private static async Task<(WebApplication App, int Port)> StartAsync(
+        Action<WebApplicationBuilder>? configure,
+        Action<WebApplication> map)
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Logging.ClearProviders();
+        configure?.Invoke(builder);
+
+        var app = builder.Build();
+        map(app);
+        await app.StartAsync();
+
+        var addresses = app.Services.GetRequiredService<IServer>().Features
+            .Get<IServerAddressesFeature>()!;
+        return (app, new Uri(addresses.Addresses.First()).Port);
+    }
+
+    /// <summary>Starts a Rask host forwarding to <paramref name="nodePort" />.</summary>
+    private static Task<(WebApplication App, int Port)> StartRaskAsync(
+        int nodePort,
+        Action<WebApplication>? map = null) =>
+        StartAsync(
+            builder => builder.Services.AddRaskMeta(options =>
+            {
+                options.SuperviseNode = false;
+                options.Port = nodePort;
+            }),
+            app =>
+            {
+                map?.Invoke(app);
+                app.UseRaskMeta();
+            });
+
+    private static HttpClient ClientFor(int port) =>
+        new() { BaseAddress = new Uri($"http://127.0.0.1:{port}") };
+
+    /// <summary>A request Kestrel does not answer reaches the Node server.</summary>
+    [Fact]
+    public async Task An_unmatched_request_is_forwarded()
+    {
+        var (node, nodePort) = await StartAsync(null, app => app.MapGet("/page", () => "from node"));
+        await using var _ = node;
+        var (rask, raskPort) = await StartRaskAsync(nodePort);
+        await using var __ = rask;
+
+        using var client = ClientFor(raskPort);
+        Assert.Equal("from node", await client.GetStringAsync("/page", Timeout()));
+    }
+
+    /// <summary>
+    ///     A mapped endpoint wins over the forwarder.
+    /// </summary>
+    /// <remarks>
+    ///     The ordering contract in one assertion. What is registered is a fallback, so the API answers
+    ///     its own routes and only what is left over crosses to Node — and the failure this guards is
+    ///     the memorable one: an API call answered with a rendered HTML page.
+    /// </remarks>
+    [Fact]
+    public async Task A_mapped_endpoint_wins_over_the_forwarder()
+    {
+        var (node, nodePort) = await StartAsync(null, app => app.MapFallback(() => "from node"));
+        await using var _ = node;
+        var (rask, raskPort) = await StartRaskAsync(
+            nodePort, app => app.MapGet("/_rask/ping", () => "from rask"));
+        await using var __ = rask;
+
+        using var client = ClientFor(raskPort);
+        Assert.Equal("from rask", await client.GetStringAsync("/_rask/ping", Timeout()));
+        Assert.Equal("from node", await client.GetStringAsync("/anything-else", Timeout()));
+    }
+
+    /// <summary>
+    ///     The response is streamed through rather than buffered.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The single most important property in this package, and the one that fails silently:
+    ///         React Server Components and streaming SSR send a page over many flushes, and a proxy
+    ///         that waits for the last byte turns a streaming page into a slow blank one while every
+    ///         other test still passes.
+    ///     </para>
+    ///     <para>
+    ///         The backend deliberately will not finish until the client has already read the first
+    ///         chunk, so buffering cannot merely look slow here — it deadlocks, and the timeout turns
+    ///         that into a failure instead of a hang.
+    ///     </para>
+    /// </remarks>
+    [Fact]
+    public async Task The_response_is_not_buffered()
+    {
+        var released = new TaskCompletionSource();
+
+        var (node, nodePort) = await StartAsync(null, app => app.MapGet("/stream", async (HttpContext context) =>
+        {
+            context.Response.ContentType = "text/plain";
+            await context.Response.WriteAsync("first");
+            await context.Response.Body.FlushAsync();
+            await released.Task;
+            await context.Response.WriteAsync("second");
+        }));
+        await using var _ = node;
+        var (rask, raskPort) = await StartRaskAsync(nodePort);
+        await using var __ = rask;
+
+        using var client = ClientFor(raskPort);
+        using var response = await client.GetAsync(
+            "/stream", HttpCompletionOption.ResponseHeadersRead, Timeout());
+        await using var stream = await response.Content.ReadAsStreamAsync(Timeout());
+
+        var head = new byte[5];
+        await stream.ReadExactlyAsync(head, Timeout());
+        Assert.Equal("first", Encoding.UTF8.GetString(head));
+
+        // Only now does the backend get to finish, so reaching this line at all proves the first
+        // chunk crossed before the response completed.
+        released.SetResult();
+
+        using var reader = new StreamReader(stream);
+        Assert.Equal("second", await reader.ReadToEndAsync(Timeout()));
+    }
+
+    /// <summary>
+    ///     While the Node process is not listening, requests are refused rather than forwarded.
+    /// </summary>
+    /// <remarks>
+    ///     503 with <c>Retry-After</c> rather than the 502 that forwarding into a closed port produces:
+    ///     for the first seconds of a container's life this state is normal and temporary, and it
+    ///     should say so in the terms clients and orchestrators already act on.
+    /// </remarks>
+    [Fact]
+    public async Task A_request_before_node_is_listening_is_refused_with_503()
+    {
+        var (node, nodePort) = await StartAsync(null, app => app.MapFallback(() => "from node"));
+        await using var _ = node;
+        var (rask, raskPort) = await StartRaskAsync(nodePort);
+        await using var __ = rask;
+
+        rask.Services.GetRequiredService<NodeReadiness>().MarkNotReady();
+
+        using var client = ClientFor(raskPort);
+        using var response = await client.GetAsync("/page", Timeout());
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Equal("1", response.Headers.RetryAfter?.Delta?.TotalSeconds.ToString("0"));
+    }
+
+    /// <summary>Forwarding without the services that start the process is a startup error.</summary>
+    [Fact]
+    public async Task UseRaskMeta_without_AddRaskMeta_throws()
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.Logging.ClearProviders();
+        await using var app = builder.Build();
+
+        var error = Assert.Throws<InvalidOperationException>(() => app.UseRaskMeta());
+        Assert.Contains("AddRaskMeta", error.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/Rask.Meta.Hosting.Tests/NodeForwarderTests.cs
+++ b/tests/Rask.Meta.Hosting.Tests/NodeForwarderTests.cs
@@ -76,6 +76,36 @@ public class NodeForwarderTests
     }
 
     /// <summary>
+    ///     An asset URL — a path whose last segment has a dot — is forwarded like anything else.
+    /// </summary>
+    /// <remarks>
+    ///     The whole front end hangs on this. `MapFallback(RequestDelegate)` maps
+    ///     <c>{*path:nonfile}</c>, so with that overload every hashed chunk, favicon and
+    ///     <c>robots.txt</c> 404s and the page loads with no JS or CSS at all — while a suite that only
+    ///     ever forwards extensionless paths stays green. Rask.Spa.Hosting relies on that same
+    ///     constraint deliberately, because there a static-file middleware serves the assets; here the
+    ///     Node server is the origin for its own, so nothing else can.
+    /// </remarks>
+    [Theory]
+    [InlineData("/_nuxt/entry.C1a9f.js")]
+    [InlineData("/_next/static/chunks/main.abc123.js")]
+    [InlineData("/_app/immutable/entry/start.abc.js")]
+    [InlineData("/favicon.ico")]
+    [InlineData("/robots.txt")]
+    public async Task An_asset_url_is_forwarded(string path)
+    {
+        // "{*path}" on the stand-in too — the bare MapFallback overload this test exists to catch
+        // would have the BACKEND 404 the asset, and the test would fail for the wrong reason.
+        var (node, nodePort) = await StartAsync(null, app => app.MapFallback("{*path}", () => "asset"));
+        await using var _ = node;
+        var (rask, raskPort) = await StartRaskAsync(nodePort);
+        await using var __ = rask;
+
+        using var client = ClientFor(raskPort);
+        Assert.Equal("asset", await client.GetStringAsync(path, Timeout()));
+    }
+
+    /// <summary>
     ///     A mapped endpoint wins over the forwarder.
     /// </summary>
     /// <remarks>
@@ -170,6 +200,81 @@ public class NodeForwarderTests
 
         Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
         Assert.Equal("1", response.Headers.RetryAfter?.Delta?.TotalSeconds.ToString("0"));
+    }
+
+    /// <summary>
+    ///     The Node server is told who the client is and what scheme it used.
+    /// </summary>
+    /// <remarks>
+    ///     YARP's default transformer copies headers but adds no <c>X-Forwarded-*</c> — those are an
+    ///     opt-in transform in the full proxy, and direct forwarding has to supply them. Without them
+    ///     every request reaches the framework looking like plain HTTP from localhost, so SSR builds
+    ///     absolute URLs with the wrong scheme behind TLS termination and sees no client address at
+    ///     all. Both matter to a framework that renders links and reads the request.
+    /// </remarks>
+    [Fact]
+    public async Task The_client_scheme_host_and_address_are_forwarded()
+    {
+        var seen = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        var (node, nodePort) = await StartAsync(null, app => app.MapGet("/echo", (HttpContext context) =>
+        {
+            foreach (var name in (string[])["X-Forwarded-Proto", "X-Forwarded-Host", "X-Forwarded-For"])
+            {
+                seen[name] = context.Request.Headers[name].ToString();
+            }
+
+            return "ok";
+        }));
+        await using var _ = node;
+        var (rask, raskPort) = await StartRaskAsync(nodePort);
+        await using var __ = rask;
+
+        using var client = ClientFor(raskPort);
+        await client.GetStringAsync("/echo", Timeout());
+
+        Assert.Equal("http", seen["X-Forwarded-Proto"]);
+        Assert.Equal($"127.0.0.1:{raskPort}", seen["X-Forwarded-Host"]);
+        Assert.Equal("127.0.0.1", seen["X-Forwarded-For"]);
+    }
+
+    /// <summary>
+    ///     A client cannot dictate the scheme or host the framework sees.
+    /// </summary>
+    /// <remarks>
+    ///     Rask is the edge here, so whatever a visitor sends in <c>X-Forwarded-Proto</c> or
+    ///     <c>X-Forwarded-Host</c> is a claim about itself, not information. If those passed through
+    ///     untouched, any framework that trusts them — to build absolute URLs, to decide it is on
+    ///     HTTPS, to generate a password-reset link — would be trusting the attacker.
+    /// </remarks>
+    [Fact]
+    public async Task A_client_cannot_spoof_the_forwarded_scheme_or_host()
+    {
+        var seen = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        var (node, nodePort) = await StartAsync(null, app => app.MapGet("/echo", (HttpContext context) =>
+        {
+            foreach (var name in (string[])["X-Forwarded-Proto", "X-Forwarded-Host"])
+            {
+                seen[name] = context.Request.Headers[name].ToString();
+            }
+
+            return "ok";
+        }));
+        await using var _ = node;
+        var (rask, raskPort) = await StartRaskAsync(nodePort);
+        await using var __ = rask;
+
+        using var client = ClientFor(raskPort);
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/echo");
+        request.Headers.Add("X-Forwarded-Proto", "https");
+        request.Headers.Add("X-Forwarded-Host", "evil.example.com");
+
+        using var response = await client.SendAsync(request, Timeout());
+        response.EnsureSuccessStatusCode();
+
+        Assert.Equal("http", seen["X-Forwarded-Proto"]);
+        Assert.DoesNotContain("evil.example.com", seen["X-Forwarded-Host"], StringComparison.Ordinal);
     }
 
     /// <summary>Forwarding without the services that start the process is a startup error.</summary>

--- a/tests/Rask.Meta.Hosting.Tests/NodeSupervisorTests.cs
+++ b/tests/Rask.Meta.Hosting.Tests/NodeSupervisorTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Rask.Meta.Hosting.Tests;
+
+/// <summary>
+///     The supervisor's policy: what it does before the process starts, and when it will not stay up.
+/// </summary>
+public class NodeSupervisorTests
+{
+    private sealed class TestEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+        public string ApplicationName { get; set; } = "MetaHostApp";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } =
+            new PhysicalFileProvider(AppContext.BaseDirectory);
+    }
+
+    private sealed class TestLifetime : IHostApplicationLifetime
+    {
+        private readonly CancellationTokenSource _stopping = new();
+        public CancellationToken ApplicationStarted => CancellationToken.None;
+        public CancellationToken ApplicationStopping => _stopping.Token;
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+        public bool Stopped { get; private set; }
+
+        public void StopApplication()
+        {
+            Stopped = true;
+            _stopping.Cancel();
+        }
+    }
+
+    private static NodeSupervisor Build(MetaHostingOptions options, TestLifetime lifetime) =>
+        new(options, new NodeReadiness(), new TestEnvironment(), lifetime,
+            NullLogger<NodeSupervisor>.Instance);
+
+    /// <summary>
+    ///     Backoff grows, then stops growing.
+    /// </summary>
+    /// <remarks>
+    ///     Capped rather than unbounded: a process that needs longer than half a minute between
+    ///     attempts is not going to be rescued by waiting longer still, and the restart budget is what
+    ///     ends the loop.
+    /// </remarks>
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(3, 4)]
+    [InlineData(4, 8)]
+    [InlineData(5, 16)]
+    [InlineData(6, 30)]
+    [InlineData(20, 30)]
+    public void Backoff_doubles_then_caps(int attempt, double expectedSeconds)
+    {
+        Assert.Equal(expectedSeconds, NodeSupervisor.BackoffFor(attempt).TotalSeconds);
+    }
+
+    /// <summary>
+    ///     A missing server entry stops the application rather than starting a restart loop.
+    /// </summary>
+    /// <remarks>
+    ///     Retrying would be pure noise: the file is not going to appear, and five rounds of backoff
+    ///     only delay the message that says what is actually wrong. This is the case where the front
+    ///     end was never built, or <see cref="MetaHostingOptions.AppDirectory" /> points somewhere
+    ///     else — both of which a person has to fix.
+    /// </remarks>
+    [Fact]
+    public async Task A_missing_server_entry_stops_the_application()
+    {
+        var lifetime = new TestLifetime();
+        var options = new MetaHostingOptions
+        {
+            AppDirectory = Path.Combine(AppContext.BaseDirectory, "no-such-frontend"),
+        };
+
+        using var supervisor = Build(options, lifetime);
+        await supervisor.RunAsync(CancellationToken.None);
+
+        Assert.True(lifetime.Stopped);
+    }
+
+    /// <summary>The entry path is resolved against the app directory, not the current directory.</summary>
+    [Fact]
+    public void The_server_entry_resolves_under_the_app_directory()
+    {
+        var options = new MetaHostingOptions
+        {
+            AppDirectory = "frontend",
+            Framework = MetaFramework.Nuxt,
+        };
+
+        using var supervisor = Build(options, new TestLifetime());
+
+        Assert.Equal(
+            Path.Combine(AppContext.BaseDirectory, "frontend", ".output/server/index.mjs"),
+            supervisor.ServerEntryPath);
+    }
+
+    /// <summary>
+    ///     With supervision off, nothing is started and forwarding is enabled immediately.
+    /// </summary>
+    /// <remarks>
+    ///     The escape hatch for a front end someone is running themselves. It must not consult the
+    ///     server entry at all — there is no build output in that arrangement, and demanding one would
+    ///     make the escape hatch unusable for the case it exists to serve.
+    /// </remarks>
+    [Fact]
+    public async Task Supervision_can_be_turned_off_without_a_build()
+    {
+        var lifetime = new TestLifetime();
+        var readiness = new NodeReadiness();
+        var options = new MetaHostingOptions
+        {
+            SuperviseNode = false,
+            AppDirectory = Path.Combine(AppContext.BaseDirectory, "no-such-frontend"),
+        };
+
+        using var supervisor = new NodeSupervisor(
+            options, readiness, new TestEnvironment(), lifetime, NullLogger<NodeSupervisor>.Instance);
+        await supervisor.RunAsync(CancellationToken.None);
+
+        Assert.False(lifetime.Stopped);
+        Assert.True(readiness.IsReady);
+    }
+}

--- a/tests/Rask.Meta.Hosting.Tests/NodeSupervisorTests.cs
+++ b/tests/Rask.Meta.Hosting.Tests/NodeSupervisorTests.cs
@@ -59,8 +59,32 @@ public class NodeSupervisorTests
     }
 
     /// <summary>
+    ///     A run that stayed up resets the budget; a short one spends it.
+    /// </summary>
+    /// <remarks>
+    ///     Without the reset the budget is a LIFETIME one, and a server crashing five times over five
+    ///     months takes the host down on the fifth — which is not what "will not stay running" means.
+    /// </remarks>
+    [Theory]
+    [InlineData(4, 90, 1)]   // lasted past the threshold: recovered, budget back to one strike
+    [InlineData(4, 5, 5)]    // died quickly again: another consecutive failure
+    [InlineData(0, 5, 1)]    // the very first crash
+    [InlineData(4, 60, 1)]   // exactly at the threshold counts as healthy
+    public void A_healthy_run_resets_the_restart_budget(int attempt, int lastedSeconds, int expected)
+    {
+        var next = NodeSupervisor.NextAttempt(
+            attempt, TimeSpan.FromSeconds(lastedSeconds), TimeSpan.FromMinutes(1));
+
+        Assert.Equal(expected, next);
+    }
+
+    /// <summary>
     ///     A missing server entry stops the application rather than starting a restart loop.
     /// </summary>
+    /// <remarks>
+    ///     The defensive path. Startup already refuses a missing entry — see
+    ///     <c>SupervisorSeamTests</c> — so this covers the file disappearing after the host came up.
+    /// </remarks>
     /// <remarks>
     ///     Retrying would be pure noise: the file is not going to appear, and five rounds of backoff
     ///     only delay the message that says what is actually wrong. This is the case where the front

--- a/tests/Rask.Meta.Hosting.Tests/Rask.Meta.Hosting.Tests.csproj
+++ b/tests/Rask.Meta.Hosting.Tests/Rask.Meta.Hosting.Tests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Rask.Meta.Hosting\Rask.Meta.Hosting.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/tests/Rask.Meta.Hosting.Tests/SupervisorSeamTests.cs
+++ b/tests/Rask.Meta.Hosting.Tests/SupervisorSeamTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Rask.Meta.Hosting.Tests;
+
+/// <summary>
+///     That the supervisor actually runs when a real host starts it.
+/// </summary>
+/// <remarks>
+///     The parts were tested and the seam was not. Every other supervisor test drives
+///     <see cref="NodeSupervisor.RunAsync" /> directly, and every forwarder test sets
+///     <see cref="MetaHostingOptions.SuperviseNode" /> to <c>false</c> — so nothing in the suite
+///     established that registering the hosted service causes any of it to happen. That is the gap
+///     where a package ships doing nothing at all, with a green suite.
+/// </remarks>
+public class SupervisorSeamTests
+{
+    private static WebApplication BuildHost(Action<MetaHostingOptions> configure)
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.Logging.ClearProviders();
+        builder.Services.AddRaskMeta(configure);
+        return builder.Build();
+    }
+
+    /// <summary>
+    ///     Starting the host runs the supervisor, and forwarding opens.
+    /// </summary>
+    /// <remarks>
+    ///     With supervision off there is no process to wait for, so readiness is the observable proof
+    ///     that the hosted service was reached at all.
+    /// </remarks>
+    [Fact]
+    public async Task Starting_the_host_runs_the_supervisor()
+    {
+        await using var app = BuildHost(options => options.SuperviseNode = false);
+
+        Assert.False(app.Services.GetRequiredService<NodeReadiness>().IsReady);
+
+        await app.StartAsync();
+
+        Assert.True(app.Services.GetRequiredService<NodeReadiness>().IsReady);
+    }
+
+    /// <summary>
+    ///     A missing server entry fails startup with a message naming the path.
+    /// </summary>
+    /// <remarks>
+    ///     This test is why the check moved into <c>StartAsync</c>. Calling <c>StopApplication()</c>
+    ///     from the supervision loop also ended the process, but it did so by cancelling Kestrel's
+    ///     <c>BindAsync</c> mid-startup, so the app died with <c>TaskCanceledException</c> — a message
+    ///     that says nothing about the front end, on top of the Critical log line that did. An
+    ///     unbuilt front end is a configuration mistake, and it should name itself.
+    /// </remarks>
+    [Fact]
+    public async Task A_missing_entry_fails_startup_and_names_the_path()
+    {
+        await using var app = BuildHost(options =>
+        {
+            options.AppDirectory = Path.Combine(AppContext.BaseDirectory, "no-such-frontend");
+            options.Framework = MetaFramework.Nuxt;
+        });
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() => app.StartAsync());
+
+        Assert.Contains("nuxt", error.Message, StringComparison.Ordinal);
+        Assert.Contains("no-such-frontend", error.Message, StringComparison.Ordinal);
+        Assert.Contains("AppDirectory", error.Message, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
First landing of #946.

A third hosting lane, for the case where **the meta framework owns the whole front end** — routing,
rendering, its own server — and Rask is the backend it integrates with. `Rask.Spa.Hosting` serves a
static bundle and needs no Node at runtime; islands put a `.tsx` inside a Rask page. Neither covers
this.

Kestrel keeps the public port, so ASP.NET authentication, rate limiting, logging and health still sit
in front of every request, and deploy still ships one container on one port.

```csharp
builder.Services.AddRaskMeta(o => o.Framework = MetaFramework.TanStackStart);

app.MapRaskCqrs();   // map the API FIRST
app.UseRaskMeta();   // terminal fallback — everything else goes to Node
```

## Six frameworks, three server shapes

`MetaFramework` is data rather than a class per framework, because the frameworks converge:

| Framework | Server | Entry |
|---|---|---|
| Nuxt · TanStack Start · SolidStart | Nitro | `.output/server/index.mjs` |
| AnalogJS | Nitro | `dist/analog/server/index.mjs` |
| SvelteKit | `adapter-node` | `build/index.js` |
| Next.js | standalone | `server.js`, and reads **`HOSTNAME`** not `HOST` |

Each preset is a record, so `MetaFramework.Next with { ServerEntry = … }` adjusts one field and keeps
the rest. Every value is pinned by a test — each was read out of the framework's current
documentation, and nothing else in the build can check it.

## The supervisor

All six expose a single directly executable entry, so it runs `node <entry>` and **never `npm start`**
— npm spawns the real server as a grandchild, so killing npm would orphan it.

- Binds **`127.0.0.1` only**, never `0.0.0.0`, so publishing the container's ports cannot expose an
  unauthenticated renderer beside the app.
- Before the port answers: **503 + `Retry-After`**, not a 502 from forwarding into a closed socket.
- Crash → capped exponential backoff over **consecutive** failures; budget spent → **the host stops**.
  An orchestrator restarting the container is a better supervisor than this loop.
- No built front end **fails startup**, naming the path it looked for.
- Shutdown sends `SIGTERM` and a grace period before killing the tree.

## The forwarder

YARP's `IHttpForwarder` — the direct-forwarding API only. It is this package's **one external
dependency** and a deliberate one: it already gets right WebSocket upgrade, hop-by-hop header
handling, `X-Forwarded-*`, and **unbuffered response streaming**.

That last one is what the whole lane rests on. RSC and streaming SSR send a page over many flushes, and
a proxy that waits for the last byte turns a streaming page into a slow blank one *with every other
test still green*. So the test holds the backend open until the client has already read the first
chunk — it cannot pass if anything starts buffering.

## Review pass

A `/code-review high` plus security pass over the branch found two problems that made the package
non-functional. Both are fixed, and both are now pinned by tests that fail without the fix.

**Asset URLs never reached the forwarder.** `MapFallback(handler)` maps `{*path:nonfile}`, so nothing
whose last path segment contains a dot matched: every hashed chunk, `favicon.ico` and `robots.txt`
404'd, and a page loaded with the document but not one byte of JS or CSS. The suite was green because
every forwarding test used an extensionless path — and the new test's own Node stand-in needed the
identical fix, which is a fair measure of how quietly this hides.

**`StartupTimeout` never abandoned the attempt.** It logged, then fell into `WaitForExitAsync`, which
never returns for a process that is alive but has not bound its port — a front end blocked on a missing
env var, say. Readiness never set, every request 503, the restart budget never spent, the host never
stopping: precisely the degraded-but-answering state the supervisor exists to refuse.

Also fixed: the restart budget counted a process's whole lifetime rather than consecutive failures; a
missing entry killed startup with `TaskCanceledException` instead of naming the path; `AddRaskMeta()`
twice started two supervisors racing for one port; the readiness probe accepted any listener on the
port as proof the child was up; mid-stream forwarding failures were logged nowhere; `ActivityTimeout`
was tearing down WebSockets idle for 100 s; and `Kill(entireProcessTree)` could throw `Win32Exception`
out of a `finally` and stop the host instead of restarting Node.

**Two findings were investigated and rejected on evidence.** The review held that YARP's default
transformer adds no `X-Forwarded-*`, and that client-supplied values pass through untouched. Tests
show it does add `Proto`/`Host`/`For`, and that it *overwrites* rather than appends — a visitor cannot
spoof the scheme or host the framework sees. Both behaviours are now pinned so they cannot regress.

One doc claim was corrected rather than implemented: `MetaFramework.Next` said Kestrel already serves
`public/` and `.next/static`. It does not yet — that lands with the build targets — so the remark now
says so instead of describing the plan as the state.

## Testing

- **36 tests**, over real sockets rather than `TestServer`: the properties worth checking here are
  properties of an actual connection. Covers forwarding (including asset URLs), endpoint-vs-fallback
  ordering, the 503 readiness gate, unbuffered streaming, `X-Forwarded-*` and its spoof resistance, the
  adapter facts per framework, backoff and budget-reset policy, and the hosted-service seam.
- Full local gate green: `dotnet format` (no changes), solution build `-warnaserror` **0 warnings**,
  unit suite, browser E2E, benchmark gates, CLI build gate.
- The gate caught two wiring gaps before this landed: a new packable project must be named in
  `NUGET.md` and packed by `nightly.yml` / `release.yml`.

**No dedicated forward-hop benchmark yet, deliberately.** There is no baseline to regress — the hop
exists only for apps that opt into this package, and measuring it needs a real framework server to
forward to. It belongs with the build/publish PR, where there is one.

## Not here yet

Tracked on #946: build and publish targets, the Node-bearing runtime image, serving Next's
`public/` and `.next/static` from Kestrel, the generated server-side contract client, and `rask new`
templates. Until those land this package is usable but unwired — which is why nothing in `samples/`
changes here.
