### PR TITLE
fix(prerender): a prerendered WebAssembly page keeps the shell that boots it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ them until tagged releases begin.
 
 ### Fixed
 
+- **A prerendered WebAssembly page could never boot, and every guard around it said the publish had
+  worked.** `<RaskPrerender>true</RaskPrerender>` writes a document per route into the published
+  `wwwroot` — where `index.html` is already the shell the WebAssembly SDK has just filled with the
+  fingerprinted import map, the integrity-pinned preload, the `<base href>` and
+  `<script src="main.js">`. The pass wrote over it. What shipped was a static page carrying real
+  markup and no way to become interactive, on every prerendered route.
+
+  The framework could not simply re-emit those tags. The boot script comes from an
+  `IRaskRuntimeScript` registration and the WASM host deliberately registers none — the runtime boots
+  from the page shell — while the import map's fingerprints and integrity hashes are minted by the SDK
+  per publish, so managed code has nothing to reproduce them from. **The shell is now kept and the
+  render spliced into it**: the shell keeps `<base>`, `<meta charset>`, the import map, the preload
+  and every body `<script>`; the page supplies its `<title>`, the rest of its head, and the whole
+  body. The singletons are resolved rather than concatenated, because a browser takes the *first*
+  `<title>` and appending would have left every page titled whatever the shell said — the search
+  result the feature exists to fix. With no shell present the whole document is still written, and the
+  pass says so.
+
+  Three things kept this invisible. Every test rendered into an empty temporary directory, which is
+  the one arrangement with no shell to destroy. No sample, template or CI job had ever set the
+  property, so it had not run end to end. And the "wrote no pages" warning globbed the output for an
+  `index.html` — which the boot shell *is*, so it was non-empty whether the pass wrote every page, one
+  page, or none, and could never fire. The pass now prints `result written=N skipped=N` and the build
+  reads that back; a run that reports no summary at all is warned about separately.
+
+- **`<base href>` was rewritten only on the root page of a sub-path publish.** Prerendering writes a
+  directory per route, and each page carries its own `<base href="/">`. Rewriting just
+  `wwwroot/index.html` left `/docs/about/` resolving `main.js` against its own directory — the exact
+  failure the tag exists to prevent, on the pages a search result links to first. Every published page
+  is rewritten now.
+
+- **Prerendering failed outright for any app referencing the `Rask` metapackage.** The companion
+  project compiles the app's sources for `net10.0`, so a multi-targeted dependency resolves its
+  non-browser face — and the metapackage's `net10.0` face carries the server-only pieces a browser app
+  never saw. Two components that never met in the app met in the companion, and RASK040 (a warning)
+  became an error under warnings-as-errors and failed the publish. The companion now builds with
+  warnings-as-errors off, alongside the analyzers it already disabled: it renders, and the real build
+  is what judges the app's code.
+
 - **A Blazor island rendered EMPTY in a trimmed WebAssembly app, and nothing said so.** The package
   claimed WebAssembly support and the claim was pinned by a test that read the `.csproj` — no build,
   no publish, no browser. Hosting one in a real WASM app found three separate failures on the way to

--- a/docs/prerendering.md
+++ b/docs/prerendering.md
@@ -80,9 +80,57 @@ The common cause is a page that injects a browser-only API — a media-device or
 nothing to bind to off a browser. Guard such work behind a lifecycle hook that only runs in the
 browser if you want the route prerendered.
 
-If the pass writes **no** pages at all, the build raises a warning — asked of the output rather
-than of the exit code, because the pass reports what it skipped and carries on, so "it ran" and "it
-produced something" are different questions.
+If the pass writes **no** pages at all, the build raises a warning — because the pass reports what it
+skipped and carries on, so "it ran" and "it produced something" are different questions.
+
+The warning asks the **pass** how many pages it wrote, not the filesystem. Asking the filesystem
+cannot work here: the root route's own output is `wwwroot/index.html`, which is exactly where the boot
+shell already is. That file is present whether the pass wrote every page, one page, or none — so a
+publish that prerendered nothing looked identical to one that worked, which is the single thing this
+guard exists to tell apart. The pass therefore prints a line the build reads back:
+
+```
+[Rask.Prerender] result written=19 skipped=3
+```
+
+A run that reports no such line at all is warned about separately: that is a different failure from
+reporting zero, and saying nothing would restore the silence the guard is for.
+
+**A route table with no literal routes writes nothing.** The plan is built from the registered routes,
+so an app whose root component carries no `[Route]` — one that simply does
+`host.RunAsync<App>()` — has nothing to enumerate and produces no pages. Give the page a
+`[Route("/")]` and let `App` render the `Router`.
+
+## Each page is spliced into the boot shell, not written over it
+
+The pass writes into the published `wwwroot`, where `index.html` is already the shell the WebAssembly
+SDK has just filled in: the fingerprinted import map, the integrity-pinned preload, the
+`<base href>`, and `<script src="main.js">`. **The shell is kept and the render is spliced into it.**
+
+That is not a detail. On the Server the boot script comes from an `IRaskRuntimeScript` registration,
+but the WASM host deliberately registers none — the runtime boots from the page shell — and the
+import map's fingerprints and integrity hashes are minted by the SDK per publish, so managed code has
+nothing to reproduce them from. Writing the rendered document over the shell would publish a page
+with real markup and no way to become interactive, on **every** prerendered route.
+
+What is taken from each side:
+
+| From the shell | From the rendered page |
+| --- | --- |
+| `<base href>`, `<meta charset>` | `<title>`, and every other `<head>` contribution |
+| the import map, the preload, every `<script>` in the body | the whole `<body>` |
+
+The singleton tags are resolved rather than concatenated: a browser takes the **first** `<title>`, so
+appending the page's head to the shell's would leave every page titled whatever the shell says. The
+page's title wins; the shell's `<base>` wins.
+
+The runtime then does what it always did — morphs its first real render onto the document, exactly as
+it morphed over the boot spinner. The prerendered body is the placeholder that morph replaces; it is
+simply a useful one.
+
+If there is no shell in the output directory, the whole document is written instead and the pass says
+so. That page will not boot, which is the right outcome for a caller driving
+[the engine directly](#using-the-engine-directly) with no bundle to boot.
 
 ## How it runs
 
@@ -98,6 +146,13 @@ instead of booting — so the app's real entry point drives the pass, and there 
 keep registrations in sync.
 
 Generated files under `obj/` are rewritten on every publish; edit the app, never the companion.
+
+The companion builds with **warnings-as-errors off**, for the same reason its analyzers are off and
+one stronger one: *its reference closure is not the app's*. Targeting `net10.0` makes a multi-targeted
+dependency resolve its non-browser face — the `Rask` metapackage's `net10.0` face carries the
+server-only pieces a browser app never saw — so two components that never met in the app can meet
+here. That is a fact about the companion, not about your code, and the real build is what judges your
+code.
 
 ## Using the engine directly
 

--- a/src/Rask.Wasm/PrerenderShell.cs
+++ b/src/Rask.Wasm/PrerenderShell.cs
@@ -1,0 +1,277 @@
+using System.Text;
+
+namespace Rask.Wasm;
+
+/// <summary>
+///     Splices a prerendered document into the published boot shell.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Prerendering writes into the published <c>wwwroot</c>, where <c>index.html</c> is already
+///         the boot shell the WebAssembly SDK has just filled in — the fingerprinted import map, the
+///         subresource-integrity-pinned preload, the <c>&lt;base href&gt;</c>, and
+///         <c>&lt;script src="main.js"&gt;</c>. Writing the rendered document over it would take all of
+///         that with it, and the bundle would never boot: the page would carry real markup and no way
+///         to become interactive.
+///     </para>
+///     <para>
+///         The framework cannot re-emit those tags instead. On the Server the boot script comes from an
+///         <c>IRaskRuntimeScript</c> registration, but the WASM host deliberately registers none — the
+///         runtime boots from the page shell — and the import map's fingerprints and hashes are minted
+///         by the SDK per publish, so managed code has nothing to reproduce them from. The shell is the
+///         only place they exist. So it is kept, and the render is spliced into it.
+///     </para>
+///     <para>
+///         What the runtime then does with the result is unchanged: it morphs its first real render onto
+///         the document, exactly as it already morphs over the boot spinner. The prerendered body is the
+///         placeholder that morph was always designed to replace — it is simply a useful one.
+///     </para>
+/// </remarks>
+internal static class PrerenderShell
+{
+    /// <summary>
+    ///     Returns <paramref name="shell" /> carrying <paramref name="document" />'s head contributions
+    ///     and body, or <paramref name="document" /> unchanged when the two cannot be spliced.
+    /// </summary>
+    /// <remarks>
+    ///     Falling back to the whole document rather than throwing is deliberate: a caller driving its
+    ///     own pass may have no shell at all, and a prerendered page with no boot script is still worth
+    ///     more than a failed publish. The callers that DO have a shell are the ones that would notice.
+    /// </remarks>
+    internal static string Merge(string shell, string document)
+    {
+        ArgumentNullException.ThrowIfNull(shell);
+        ArgumentNullException.ThrowIfNull(document);
+
+        if (!TryFindElement(shell, "head", out var shellHead)
+            || !TryFindElement(shell, "body", out var shellBody)
+            || !TryFindElement(document, "body", out var documentBody))
+        {
+            return document;
+        }
+
+        // The document's head is optional in a way the body is not: a root component contributing no
+        // head assets still renders <head></head>, but a caller's hand-built component might not.
+        var documentHead = TryFindElement(document, "head", out var found) ? found : default;
+
+        var builder = new StringBuilder(shell.Length + document.Length);
+
+        // --- everything up to the shell's </head>, minus the tags the document is about to supply ---
+        var shellHeadInner = shell[shellHead.InnerStart..shellHead.InnerEnd];
+        var documentHeadInner = documentHead.InnerEnd > documentHead.InnerStart
+            ? document[documentHead.InnerStart..documentHead.InnerEnd]
+            : string.Empty;
+
+        builder.Append(shell, 0, shellHead.InnerStart);
+        builder.Append(HasTitle(documentHeadInner) ? RemoveTitle(shellHeadInner) : shellHeadInner);
+        builder.Append(StripShellOwnedTags(documentHeadInner));
+        builder.Append(shell, shellHead.InnerEnd, shellBody.InnerStart - shellHead.InnerEnd);
+
+        // --- the rendered body, then the shell's own scripts ---
+        // The shell's body is a boot placeholder plus the script that boots the bundle. The placeholder
+        // is exactly what the render replaces; the scripts are the whole reason for keeping the shell,
+        // so they are carried over verbatim and in order.
+        builder.Append(document, documentBody.InnerStart, documentBody.InnerEnd - documentBody.InnerStart);
+        AppendScripts(builder, shell.AsSpan(shellBody.InnerStart, shellBody.InnerEnd - shellBody.InnerStart));
+
+        builder.Append(shell, shellBody.InnerEnd, shell.Length - shellBody.InnerEnd);
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    ///     Tags the shell owns outright, dropped from the document's head so the merge cannot end up
+    ///     with two of them.
+    /// </summary>
+    /// <remarks>
+    ///     <c>&lt;base&gt;</c> is the load-bearing one: the shell's is what a sub-path publish rewrites,
+    ///     and a second one later in the head would silently win for every relative URL on the page.
+    ///     <c>&lt;meta charset&gt;</c> has to be the first thing in the head to count at all, so the
+    ///     document's copy is redundant wherever it lands.
+    /// </remarks>
+    private static string StripShellOwnedTags(string headInner)
+    {
+        var result = RemoveElements(headInner, "base", selfClosing: true);
+        return RemoveCharsetMeta(result);
+    }
+
+    private static bool HasTitle(string headInner) =>
+        headInner.Contains("<title", StringComparison.OrdinalIgnoreCase);
+
+    private static string RemoveTitle(string headInner) =>
+        RemoveElements(headInner, "title", selfClosing: false);
+
+    /// <summary>
+    ///     Copies every <c>&lt;script&gt;</c> element out of <paramref name="bodyInner" />, in order.
+    /// </summary>
+    private static void AppendScripts(StringBuilder builder, ReadOnlySpan<char> bodyInner)
+    {
+        var cursor = 0;
+        while (cursor < bodyInner.Length)
+        {
+            var open = IndexOfTag(bodyInner[cursor..], "script");
+            if (open < 0)
+            {
+                return;
+            }
+
+            open += cursor;
+            var close = bodyInner[open..].IndexOf("</script>", StringComparison.OrdinalIgnoreCase);
+            if (close < 0)
+            {
+                return;
+            }
+
+            close += open + "</script>".Length;
+            builder.Append('\n').Append(bodyInner[open..close]);
+            cursor = close;
+        }
+    }
+
+    /// <summary>
+    ///     Removes every occurrence of an element, with its content when it has an end tag.
+    /// </summary>
+    private static string RemoveElements(string html, string name, bool selfClosing)
+    {
+        var result = html;
+        while (true)
+        {
+            var open = IndexOfTag(result, name);
+            if (open < 0)
+            {
+                return result;
+            }
+
+            int end;
+            if (selfClosing)
+            {
+                var gt = result.AsSpan(open).IndexOf('>');
+                if (gt < 0)
+                {
+                    return result;
+                }
+
+                end = open + gt + 1;
+            }
+            else
+            {
+                var closeTag = $"</{name}>";
+                var close = result.IndexOf(closeTag, open, StringComparison.OrdinalIgnoreCase);
+                if (close < 0)
+                {
+                    return result;
+                }
+
+                end = close + closeTag.Length;
+            }
+
+            result = result.Remove(open, end - open);
+        }
+    }
+
+    /// <summary>
+    ///     Removes a <c>&lt;meta charset&gt;</c> declaration, in either of the two spellings.
+    /// </summary>
+    private static string RemoveCharsetMeta(string html)
+    {
+        var cursor = 0;
+        while (true)
+        {
+            var open = IndexOfTag(html.AsSpan(cursor), "meta");
+            if (open < 0)
+            {
+                return html;
+            }
+
+            open += cursor;
+            var gt = html.AsSpan(open).IndexOf('>');
+            if (gt < 0)
+            {
+                return html;
+            }
+
+            var end = open + gt + 1;
+            var tag = html[open..end];
+            if (tag.Contains("charset", StringComparison.OrdinalIgnoreCase))
+            {
+                return html.Remove(open, end - open);
+            }
+
+            cursor = end;
+        }
+    }
+
+    /// <summary>
+    ///     Finds <c>&lt;name</c> as a real tag rather than as a prefix of a longer one.
+    /// </summary>
+    /// <remarks>
+    ///     Without the delimiter check, looking for <c>&lt;base</c> also matches a hypothetical
+    ///     <c>&lt;basefont&gt;</c>, and looking for <c>&lt;script</c> would match <c>&lt;scripts&gt;</c>.
+    ///     A tag name ends at whitespace, <c>/</c>, or <c>&gt;</c>.
+    /// </remarks>
+    private static int IndexOfTag(ReadOnlySpan<char> html, string name)
+    {
+        var cursor = 0;
+        while (cursor < html.Length)
+        {
+            var hit = html[cursor..].IndexOf($"<{name}", StringComparison.OrdinalIgnoreCase);
+            if (hit < 0)
+            {
+                return -1;
+            }
+
+            hit += cursor;
+            var after = hit + 1 + name.Length;
+            if (after >= html.Length)
+            {
+                return -1;
+            }
+
+            var next = html[after];
+            if (char.IsWhiteSpace(next) || next is '>' or '/')
+            {
+                return hit;
+            }
+
+            cursor = after;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    ///     Where an element's content starts and ends, exclusive of its own tags.
+    /// </summary>
+    private readonly record struct ElementSpan(int InnerStart, int InnerEnd);
+
+    private static bool TryFindElement(string html, string name, out ElementSpan span)
+    {
+        span = default;
+
+        var open = IndexOfTag(html, name);
+        if (open < 0)
+        {
+            return false;
+        }
+
+        var gt = html.AsSpan(open).IndexOf('>');
+        if (gt < 0)
+        {
+            return false;
+        }
+
+        var innerStart = open + gt + 1;
+
+        // The LAST end tag, not the first: a </body> can legitimately appear inside a <script> string
+        // earlier in the document, and closing the body there would drop everything after it.
+        var closeTag = $"</{name}>";
+        var innerEnd = html.LastIndexOf(closeTag, StringComparison.OrdinalIgnoreCase);
+        if (innerEnd < innerStart)
+        {
+            return false;
+        }
+
+        span = new ElementSpan(innerStart, innerEnd);
+        return true;
+    }
+}

--- a/src/Rask.Wasm/WasmPrerender.cs
+++ b/src/Rask.Wasm/WasmPrerender.cs
@@ -60,6 +60,17 @@ public static class WasmPrerender
             Console.WriteLine($"[Rask.Prerender]   skipped {skipped} — its path is not known without data");
         }
 
+        // Read ONCE, before the first page is written — the shell being read is index.html, and the
+        // root route's own output is index.html. Reading it per page would hand page two the merged
+        // page one as its shell.
+        var shell = await ReadShellAsync(outputDirectory).ConfigureAwait(false);
+        if (shell is null)
+        {
+            Console.WriteLine(
+                $"[Rask.Prerender] no boot shell at {Path.Combine(outputDirectory, ShellFileName)} — "
+                + "writing whole documents, which will NOT boot the bundle");
+        }
+
         var written = 0;
         foreach (var path in plan.Paths)
         {
@@ -89,14 +100,45 @@ public static class WasmPrerender
                 continue;
             }
 
+            // Spliced into the shell rather than written over it. The shell carries the fingerprinted
+            // import map, the SRI-pinned preload, the <base href> and the script that boots the bundle;
+            // replacing the file would publish real markup that can never become interactive.
+            var html = shell is null ? result.Html : PrerenderShell.Merge(shell, result.Html);
+
             var file = OutputPathFor(outputDirectory, path);
             Directory.CreateDirectory(Path.GetDirectoryName(file)!);
-            await File.WriteAllTextAsync(file, result.Html).ConfigureAwait(false);
+            await File.WriteAllTextAsync(file, html).ConfigureAwait(false);
             written++;
         }
 
         Console.WriteLine($"[Rask.Prerender] wrote {written} page(s) to {outputDirectory}");
+
+        // A second line, for the build rather than for a reader. The build cannot ask the filesystem
+        // whether this pass produced anything: the root route's output IS index.html, which the boot
+        // shell already occupies, so "a page exists" is true before the pass runs and stays true when
+        // it writes nothing. Only the pass knows the count, so it says so in a form that survives a
+        // grep and carries no punctuation an MSBuild condition has to escape.
+        Console.WriteLine($"{SummaryPrefix}written={written} skipped={plan.Skipped.Count}");
+
         return written;
+    }
+
+    /// <summary>
+    ///     Marks the machine-readable summary line. Read by <c>RaskPrerenderPages</c>.
+    /// </summary>
+    internal const string SummaryPrefix = "[Rask.Prerender] result ";
+
+    /// <summary>
+    ///     The published boot shell, or <c>null</c> when there is none to splice into.
+    /// </summary>
+    internal const string ShellFileName = "index.html";
+
+    private static async Task<string?> ReadShellAsync(string outputDirectory)
+    {
+        var path = Path.Combine(outputDirectory, ShellFileName);
+        return File.Exists(path)
+            ? await File.ReadAllTextAsync(path).ConfigureAwait(false)
+            : null;
     }
 
     /// <summary>

--- a/src/Rask.Wasm/build/Rask.Wasm.Prerender.targets
+++ b/src/Rask.Wasm/build/Rask.Wasm.Prerender.targets
@@ -71,6 +71,17 @@
       <_RaskPrerenderLine Include="    &lt;EnableDefaultCompileItems&gt;false&lt;/EnableDefaultCompileItems&gt;"/>
       <!-- The app's own analyzers would re-report what the real build already reported. -->
       <_RaskPrerenderLine Include="    &lt;RunAnalyzers&gt;false&lt;/RunAnalyzers&gt;"/>
+      <!--
+        Nor may a warning fail this build, for the same reason and one stronger one: the companion's
+        reference closure is NOT the app's. It targets net10.0, so a multi-targeted dependency resolves
+        its non-browser face — and the Rask metapackage's net10.0 face carries the server-only pieces
+        the browser app never saw, Rask.Dashboard among them. Two components that never met in the app
+        meet here, and RASK040 (a warning) became an error under warnings-as-errors and failed the
+        whole publish. That diagnostic is about which chain entries the app gets; the companion only
+        renders, and the real build is what judges the app's own code.
+      -->
+      <_RaskPrerenderLine Include="    &lt;TreatWarningsAsErrors&gt;false&lt;/TreatWarningsAsErrors&gt;"/>
+      <_RaskPrerenderLine Include="    &lt;WarningsAsErrors&gt;&lt;/WarningsAsErrors&gt;"/>
       <_RaskPrerenderLine Include="  &lt;/PropertyGroup&gt;"/>
 
       <!--
@@ -126,24 +137,48 @@
     <Exec Command="dotnet build &quot;$(RaskPrerenderCompanionProject)&quot; -c $(Configuration) -o &quot;$(RaskPrerenderCompanionOutput)&quot; --nologo -v:minimal -nodeReuse:false"
           WorkingDirectory="$(MSBuildProjectDirectory)"/>
 
+    <!--
+      ConsoleToMSBuild so the summary line below can be read back. StandardOutputImportance keeps the
+      per-route log visible in a normal build, as it was before it was captured — a capture that also
+      silenced the skip list would trade one blind spot for another.
+    -->
     <Exec Command="dotnet &quot;$(RaskPrerenderCompanionOutput)$(RaskPrerenderCompanionName).dll&quot;"
           WorkingDirectory="$(MSBuildProjectDirectory)"
-          EnvironmentVariables="RASK_PRERENDER_OUT=$(PublishDir)wwwroot"/>
-
-    <ItemGroup>
-      <_RaskPrerenderedPage Include="$(PublishDir)wwwroot\**\index.html"/>
-    </ItemGroup>
+          EnvironmentVariables="RASK_PRERENDER_OUT=$(PublishDir)wwwroot"
+          ConsoleToMSBuild="true"
+          StandardOutputImportance="high">
+      <Output TaskParameter="ConsoleOutput" ItemName="_RaskPrerenderLog"/>
+    </Exec>
 
     <!--
-      Asked of the OUTPUT rather than of the exit code. The pass reports what it skipped and carries on,
-      so "it ran" and "it produced something" are different questions — and a publish that silently
-      prerendered nothing looks exactly like one that worked.
+      Asked of what the PASS REPORTED, not of the filesystem. The obvious check — glob the output for
+      an index.html — cannot work here, and quietly did not: the root route's own output is
+      wwwroot/index.html, which is the boot shell the SDK published moments earlier. That file is
+      there whether the pass wrote every page, one page, or none, so the glob was non-empty in all
+      three cases and the warning below could never fire. A publish that prerendered nothing looked
+      exactly like one that worked, which is the single thing this guard exists to tell apart.
+
+      So the pass prints a summary line and the build reads it back. `written=0` is an unambiguous
+      statement by the only component that knows.
     -->
-    <Warning Condition=" '@(_RaskPrerenderedPage)' == '' "
+    <PropertyGroup>
+      <_RaskPrerenderLogText>@(_RaskPrerenderLog, '%0A')</_RaskPrerenderLogText>
+      <_RaskPrerenderWroteNothing>false</_RaskPrerenderWroteNothing>
+      <_RaskPrerenderWroteNothing Condition="$(_RaskPrerenderLogText.Contains('result written=0'))">true</_RaskPrerenderWroteNothing>
+      <_RaskPrerenderReported>false</_RaskPrerenderReported>
+      <_RaskPrerenderReported Condition="$(_RaskPrerenderLogText.Contains('result written='))">true</_RaskPrerenderReported>
+    </PropertyGroup>
+
+    <Warning Condition=" '$(_RaskPrerenderWroteNothing)' == 'true' "
              Text="Rask: prerendering ran and wrote no pages. Every route was either parameterised, faulted, or did not settle within the budget — see the log above for which. The bundle still serves them at runtime, so this is a lost optimisation rather than a broken site."/>
 
-    <Message Importance="high" Condition=" '@(_RaskPrerenderedPage)' != '' "
-             Text="Rask: prerendered @(_RaskPrerenderedPage->Count()) page(s)"/>
+    <!--
+      The pass not reporting at all is a different failure from it reporting zero — an older
+      Rask.Wasm on the companion's reference graph, or a run that died before its summary. Saying
+      nothing here would restore exactly the silence this target was rewritten to remove.
+    -->
+    <Warning Condition=" '$(_RaskPrerenderReported)' != 'true' "
+             Text="Rask: prerendering ran but reported no summary line, so the build cannot tell how many pages it wrote. Treat the published bundle as un-prerendered until this is explained."/>
   </Target>
 
 </Project>

--- a/src/Rask.Wasm/build/Rask.Wasm.targets
+++ b/src/Rask.Wasm/build/Rask.Wasm.targets
@@ -186,19 +186,40 @@
   -->
   <Target Name="_RaskRewriteBaseHref"
           AfterTargets="Publish"
-          Condition=" '$(RaskWasm)' == 'true' AND '$(RaskPathBase)' != '' AND '$(RaskPathBase)' != '/' AND Exists('$(PublishDir)wwwroot\index.html') ">
+          Condition=" '$(RaskWasm)' == 'true' AND '$(RaskPathBase)' != '' AND '$(RaskPathBase)' != '/' ">
     <PropertyGroup>
       <_RaskNormalizedBase>$(RaskPathBase.TrimEnd('/'))</_RaskNormalizedBase>
       <_RaskNormalizedBase Condition=" !$(_RaskNormalizedBase.StartsWith('/')) ">/$(_RaskNormalizedBase)</_RaskNormalizedBase>
-      <_RaskIndexHtml>$([System.IO.File]::ReadAllText('$(PublishDir)wwwroot\index.html'))</_RaskIndexHtml>
-      <_RaskIndexHtml>$(_RaskIndexHtml.Replace('&lt;base href=&quot;/&quot;/&gt;', '&lt;base href=&quot;$(_RaskNormalizedBase)/&quot;/&gt;'))</_RaskIndexHtml>
     </PropertyGroup>
-    <WriteLinesToFile File="$(PublishDir)wwwroot\index.html"
-                      Lines="$(_RaskIndexHtml)"
+
+    <!--
+      EVERY published page, not just the root one. Prerendering writes a directory per route
+      (about/index.html, docs/intro/index.html), and each is a whole document carrying its own
+      <base href="/"> from the shell it was spliced into. Rewriting only the root left every
+      prerendered sub-page resolving main.js against its own directory — /about/main.js — which is
+      the exact failure the <base href> exists to prevent, on the pages a crawler is most likely to
+      land on first. The item is globbed inside the target because prerendering runs earlier in this
+      same AfterTargets="Publish" chain, so these files do not exist at evaluation time.
+
+      The base is ABSOLUTE, so one value is correct at every depth.
+    -->
+    <ItemGroup>
+      <_RaskPublishedPage Include="$(PublishDir)wwwroot\**\index.html"/>
+    </ItemGroup>
+
+    <!--
+      WriteLinesToFile, not File::WriteAllText: MSBuild's property-function whitelist has no writer.
+      The read is escaped by MSBuild on the way into the property, so a document's semicolons do not
+      split it into separate lines and its percent-escapes (a data: URI's %3C, say) survive verbatim.
+    -->
+    <WriteLinesToFile File="%(_RaskPublishedPage.FullPath)"
+                      Lines="$([System.IO.File]::ReadAllText('%(_RaskPublishedPage.FullPath)').Replace('&lt;base href=&quot;/&quot;/&gt;', '&lt;base href=&quot;$(_RaskNormalizedBase)/&quot;/&gt;'))"
                       Overwrite="true"
                       WriteOnlyWhenDifferent="true"/>
+
     <Message Importance="High"
-             Text="Rask: rewrote &lt;base href&gt; to &quot;$(_RaskNormalizedBase)/&quot; in $(PublishDir)wwwroot/index.html"/>
+             Condition=" '@(_RaskPublishedPage)' != '' "
+             Text="Rask: rewrote &lt;base href&gt; to &quot;$(_RaskNormalizedBase)/&quot; in @(_RaskPublishedPage->Count()) published page(s)"/>
   </Target>
 
   <!--

--- a/tests/Rask.Wasm.Tests/Hosting/PrerenderShellTests.cs
+++ b/tests/Rask.Wasm.Tests/Hosting/PrerenderShellTests.cs
@@ -1,0 +1,169 @@
+using Rask.Wasm;
+
+namespace Rask.Wasm.Tests.Hosting;
+
+// The splice that keeps a prerendered WASM page able to boot.
+//
+// Prerendering writes into the published wwwroot, where index.html is already the shell the
+// WebAssembly SDK filled with the fingerprinted import map, the SRI-pinned preload, the <base href>
+// and <script src="main.js">. Writing the rendered document over it produced a page with real markup
+// and no way to become interactive — and nothing said so, because every existing test rendered into
+// an empty temp directory, which is precisely the path where there is no shell to lose.
+public class PrerenderShellTests
+{
+    // A shell with the parts that actually matter: the SDK's two filled placeholders, the base href,
+    // a pre-paint script, a boot placeholder, and the module script that starts the bundle.
+    private const string Shell =
+        """
+        <!doctype html>
+        <html lang="en">
+        <head>
+            <meta charset="utf-8"/>
+            <base href="/"/>
+            <title>Rask</title>
+            <link rel="preload" id="webassembly" href="_framework/dotnet.abcd1234.js"/>
+            <script type="importmap">{"imports":{"./dotnet.js":"./dotnet.abcd1234.js"}}</script>
+            <script>window.__preboot = 1;</script>
+        </head>
+        <body data-rask-root>
+        <div class="rask-boot">Loading…</div>
+        <script src="main.js" type="module"></script>
+        </body>
+        </html>
+        """;
+
+    private const string Document =
+        """
+        <!doctype html><html lang="en"><head><meta charset="utf-8"/>
+        <title>Rask — the .NET One Person Framework</title>
+        <meta name="description" content="Ship a whole product."/>
+        <link rel="stylesheet" href="/css/app.css"/></head>
+        <body><h1>Ship a whole product.</h1><p>Just you, and C#.</p></body></html>
+        """;
+
+    [Fact]
+    public void TheBundleCanStillBoot()
+    {
+        var merged = PrerenderShell.Merge(Shell, Document);
+
+        // The whole point. Each of these is minted by the SDK per publish and is not reproducible from
+        // managed code, so losing the shell loses them permanently.
+        Assert.Contains("<script src=\"main.js\" type=\"module\"></script>", merged, StringComparison.Ordinal);
+        Assert.Contains("type=\"importmap\"", merged, StringComparison.Ordinal);
+        Assert.Contains("id=\"webassembly\"", merged, StringComparison.Ordinal);
+        Assert.Contains("<base href=\"/\"/>", merged, StringComparison.Ordinal);
+        Assert.Contains("window.__preboot", merged, StringComparison.Ordinal);
+        Assert.Contains("data-rask-root", merged, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheRenderedMarkupReplacesTheBootPlaceholder()
+    {
+        var merged = PrerenderShell.Merge(Shell, Document);
+
+        Assert.Contains("<h1>Ship a whole product.</h1>", merged, StringComparison.Ordinal);
+        Assert.Contains("Just you, and C#.", merged, StringComparison.Ordinal);
+
+        // The spinner is what a crawler used to index. It has no business surviving into a page that
+        // now has the real thing.
+        Assert.DoesNotContain("rask-boot", merged, StringComparison.Ordinal);
+        Assert.DoesNotContain("Loading…", merged, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ThePagesOwnTitleWins()
+    {
+        var merged = PrerenderShell.Merge(Shell, Document);
+
+        // A browser takes the FIRST <title>, and the shell's is a placeholder that ships with every
+        // page. Appending the document's head without resolving this would leave every prerendered
+        // page titled "Rask" — the search result the feature exists to fix.
+        Assert.Contains("<title>Rask — the .NET One Person Framework</title>", merged, StringComparison.Ordinal);
+        Assert.DoesNotContain("<title>Rask</title>", merged, StringComparison.Ordinal);
+        Assert.Equal(1, CountOf(merged, "<title"));
+    }
+
+    [Fact]
+    public void TheHeadKeepsExactlyOneOfEachSingletonTag()
+    {
+        var merged = PrerenderShell.Merge(Shell, Document);
+
+        // A second <base> silently wins for every relative URL after it, and a charset that is not the
+        // first thing in the head counts for nothing. Both documents carry both.
+        Assert.Equal(1, CountOf(merged, "<base"));
+        Assert.Equal(1, CountOf(merged, "charset"));
+    }
+
+    [Fact]
+    public void ThePagesOwnHeadAssetsSurvive()
+    {
+        var merged = PrerenderShell.Merge(Shell, Document);
+
+        // The head contributions are the SEO payload — the reason for prerendering at all.
+        Assert.Contains("name=\"description\"", merged, StringComparison.Ordinal);
+        Assert.Contains("/css/app.css", merged, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EveryScriptInTheShellBodyIsCarriedOverInOrder()
+    {
+        const string twoScripts =
+            """
+            <html><head></head><body>
+            <div>boot</div>
+            <script src="first.js"></script>
+            <script src="main.js" type="module"></script>
+            </body></html>
+            """;
+
+        var merged = PrerenderShell.Merge(twoScripts, Document);
+
+        Assert.True(
+            merged.IndexOf("first.js", StringComparison.Ordinal)
+            < merged.IndexOf("main.js", StringComparison.Ordinal),
+            "the shell's scripts must keep their order — a bundle that boots before its polyfill is a race");
+    }
+
+    [Fact]
+    public void ADocumentWithNoShellToSpliceIntoIsReturnedWhole()
+    {
+        // A caller driving its own pass may have no shell at all. Returning the document is worth more
+        // than failing the publish; the callers that DO have a shell are the ones that would notice.
+        Assert.Equal(Document, PrerenderShell.Merge("not a document", Document));
+    }
+
+    [Fact]
+    public void ABodyEndTagInsideAScriptDoesNotTruncateTheShell()
+    {
+        // The end tag is found from the END of the document for this reason. Scanning forward would
+        // close the body on the string below and drop the boot script that follows it.
+        const string trickyShell =
+            """
+            <html><head></head><body>
+            <script>var t = "</body>";</script>
+            <script src="main.js" type="module"></script>
+            </body></html>
+            """;
+
+        var merged = PrerenderShell.Merge(trickyShell, Document);
+
+        Assert.Contains("main.js", merged, StringComparison.Ordinal);
+    }
+
+    private static int CountOf(string haystack, string needle)
+    {
+        var count = 0;
+        var cursor = 0;
+        while (true)
+        {
+            var hit = haystack.IndexOf(needle, cursor, StringComparison.OrdinalIgnoreCase);
+            if (hit < 0)
+            {
+                return count;
+            }
+
+            count++;
+            cursor = hit + needle.Length;
+        }
+    }
+}

--- a/tests/Rask.Wasm.Tests/Hosting/WasmPrerenderTests.cs
+++ b/tests/Rask.Wasm.Tests/Hosting/WasmPrerenderTests.cs
@@ -124,6 +124,114 @@ public class WasmPrerenderTests
         Assert.Null(WasmPrerender.RequestedOutput);
     }
 
+    [Fact]
+    public async Task APageWrittenBesideABootShellIsSplicedIntoItRatherThanOverIt()
+    {
+        // The gap every other test in this file walked past. They render into an EMPTY temp directory,
+        // which is the one arrangement where there is no shell to destroy — so a pass that overwrote
+        // the published boot shell, and shipped a page that could never become interactive, passed
+        // them all. Here the shell is on disk first, exactly as it is in a real published wwwroot.
+        var dir = Path.Combine(Path.GetTempPath(), "rask-prerender-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+
+        RouteRegistry.Replace(nameof(APageWrittenBesideABootShellIsSplicedIntoItRatherThanOverIt), [
+            new RouteRegistration(typeof(Home), "/", null),
+            new RouteRegistration(typeof(Home), "/about", null),
+        ]);
+
+        await File.WriteAllTextAsync(
+            Path.Combine(dir, "index.html"),
+            """
+            <!doctype html><html lang="en"><head><meta charset="utf-8"/><base href="/"/><title>Rask</title>
+            <script type="importmap">{"imports":{}}</script></head>
+            <body data-rask-root><div class="rask-boot">Loading…</div>
+            <script src="main.js" type="module"></script></body></html>
+            """);
+
+        var services = new ServiceCollection();
+        services.AddScoped<RouteState>();
+
+        try
+        {
+            await WasmPrerender.RunAsync<Home>(
+                services.BuildServiceProvider(), dir, TimeSpan.FromSeconds(5));
+
+            var root = await File.ReadAllTextAsync(Path.Combine(dir, "index.html"));
+
+            Assert.Contains("home-page", root, StringComparison.Ordinal);
+            Assert.Contains("<script src=\"main.js\" type=\"module\">", root, StringComparison.Ordinal);
+            Assert.Contains("type=\"importmap\"", root, StringComparison.Ordinal);
+            Assert.Contains("<base href=\"/\"/>", root, StringComparison.Ordinal);
+
+            // Every route gets the shell, not just the root one — a sub-page without the boot script
+            // is a dead end, and it is the page a search result links to.
+            var about = await File.ReadAllTextAsync(Path.Combine(dir, "about", "index.html"));
+            Assert.Contains("home-page", about, StringComparison.Ordinal);
+            Assert.Contains("<script src=\"main.js\" type=\"module\">", about, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch (IOException) { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task TheShellIsReadOnceSoTheRootPageIsNotUsedAsTheNextPagesShell()
+    {
+        // The root route's output IS index.html — the same file the shell is read from. Reading it per
+        // page would hand page two a shell that already contains page one's markup, and every page
+        // after the first would accumulate the ones before it.
+        var dir = Path.Combine(Path.GetTempPath(), "rask-prerender-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+
+        RouteRegistry.Replace(nameof(TheShellIsReadOnceSoTheRootPageIsNotUsedAsTheNextPagesShell), [
+            new RouteRegistration(typeof(Home), "/", null),
+            new RouteRegistration(typeof(Home), "/about", null),
+        ]);
+
+        await File.WriteAllTextAsync(
+            Path.Combine(dir, "index.html"),
+            """
+            <!doctype html><html><head><title>Rask</title></head>
+            <body><div class="rask-boot">Loading…</div><script src="main.js" type="module"></script></body></html>
+            """);
+
+        var services = new ServiceCollection();
+        services.AddScoped<RouteState>();
+
+        try
+        {
+            await WasmPrerender.RunAsync<Home>(
+                services.BuildServiceProvider(), dir, TimeSpan.FromSeconds(5));
+
+            var about = await File.ReadAllTextAsync(Path.Combine(dir, "about", "index.html"));
+
+            Assert.Equal(1, Occurrences(about, "home-page"));
+            Assert.Equal(1, Occurrences(about, "main.js"));
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch (IOException) { /* best effort */ }
+        }
+    }
+
+    private static int Occurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var cursor = 0;
+        while (true)
+        {
+            var hit = haystack.IndexOf(needle, cursor, StringComparison.Ordinal);
+            if (hit < 0)
+            {
+                return count;
+            }
+
+            count++;
+            cursor = hit + needle.Length;
+        }
+    }
+
     private sealed class Home : Component
     {
         protected override Component? Render() => Div["home-page"];


### PR DESCRIPTION
## Summary

`<RaskPrerender>true</RaskPrerender>` shipped pages that could never boot, and every guard around it
reported success. This is the first of four PRs; the landing site and docs rebuild sit on top of it.

The pass writes a document per route into the published `wwwroot` — where `index.html` is already the
shell the WebAssembly SDK has just filled with the fingerprinted import map, the integrity-pinned
preload, the `<base href>` and `<script src="main.js">`. It wrote **over** it. What shipped was a
static page carrying real markup with no way to become interactive, on every prerendered route.

The framework cannot simply re-emit those tags: the boot script comes from an `IRaskRuntimeScript`
and the WASM host deliberately registers none (the runtime boots from the page shell), while the
import map's fingerprints and integrity hashes are minted by the SDK per publish. The shell is the
only place they exist, so it is now **kept and the render spliced into it**.

| From the shell | From the rendered page |
| --- | --- |
| `<base href>`, `<meta charset>` | `<title>`, and every other `<head>` contribution |
| import map, preload, every body `<script>` | the whole `<body>` |

Singletons are resolved rather than concatenated — a browser takes the *first* `<title>`, so
appending would have left every page titled whatever the shell said, which is the search result the
feature exists to fix.

### Two more defects on the same path

- **`<base href>` was rewritten only on the root page** of a sub-path publish, leaving
  `/docs/about/` resolving `main.js` against its own directory. Every published page is rewritten now.
- **Prerendering failed outright for any app referencing the `Rask` metapackage.** The companion
  compiles for `net10.0`, so a multi-targeted dependency resolves its non-browser face, and the
  metapackage's `net10.0` face carries server-only pieces a browser app never saw. `Rask.Dashboard`'s
  `NotFoundPage` met the sample's own, and RASK040 (a warning) became an error under
  warnings-as-errors and failed the publish. The companion now builds with warnings-as-errors off,
  alongside the analyzers it already disabled.

## Why nothing caught this

Three independent blind spots, all now closed:

- Every test rendered into an **empty temp directory** — the one arrangement with no shell to destroy.
- **No sample, template or CI job had ever set the property**, so it had never run end to end.
- The "wrote no pages" warning **globbed the output for an `index.html`** — which the boot shell *is*,
  so it was non-empty whether the pass wrote every page, one page, or none, and could never fire.

The pass now prints `result written=N skipped=N` and the build reads that back, warning separately
when no summary appears at all.

## Testing

- New `PrerenderShellTests` (8 cases) covering the splice: boot machinery survives, markup replaces
  the spinner, the page's title wins, exactly one of each singleton tag, script order preserved, a
  `</body>` inside a script does not truncate the shell, and no-shell falls back to the whole document.
- Two new integration cases in `WasmPrerenderTests` that put a shell on disk first. **Both confirmed
  to fail without the splice** (verified by reverting it), which the previous suite did not.
- Full `Rask.Wasm.Tests` 276/276, `Rask.Core.Tests` prerender 7/7.
- Local gate green: `dotnet format`, `-warnaserror`, unit gate 407/407, browser E2E 70/70.

### Verified end to end, not just by unit test

`dotnet publish samples/Rask.Example.Wasm -c Release -p:RaskPrerender=true` — 20 routes planned, 5
written (15 browser-only API demos throw and are skipped by design, 3 are parameterised). Each
written page carries **both** the rendered markup and a working import map, `<base href>` and
`main.js`. Repeated with `-p:RaskPathBase=/docs`: all 5 pages, including
`routing-demo/nested/profile/`, get `<base href="/docs/">`.

## Changelog

Three entries under `[Unreleased] / Fixed`.
