### PR TITLE
chore: attribute every commit from the maintainer address to "pt"

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+# Canonical author identity for this repository.
+# All commits from this address are attributed to "pt", regardless of the
+# name recorded in the commit itself. See gitmailmap(5).
+pt <pal.tamas@pptgateway.hu>


### PR DESCRIPTION
## Summary

`git shortlog` reported this repository as two contributors — `Tamás Pál` (706 commits on `main`) and
`pt` (274) — because the same address, `pal.tamas@pptgateway.hu`, was committed under two different
names over time. Both are the same person, and `pt` is the name to use everywhere.

This adds a `.mailmap` that maps the address to `pt`, so every git tool that honours
gitmailmap(5) — `shortlog`, `log`, `blame`, `annotate` — reports one contributor instead of two,
for past commits as well as future ones.

Global `user.name` was already `pt`, so new commits needed no change; only the history's display
did.

## Testing

Before:

```
$ git shortlog -sne HEAD
   706  Tamás Pál <pal.tamas@pptgateway.hu>
   274  pt <pal.tamas@pptgateway.hu>
```

After:

```
$ git shortlog -sne HEAD
   984  pt <pal.tamas@pptgateway.hu>
```

`dependabot[bot]` is deliberately left alone.

No code, markup, or package content changes, so `pre-commit` skipped the format + unit gate on its
own ("no code changes staged"), and the browser E2E and benchmark gates — which are unfiltered and
would otherwise run — were skipped explicitly with `RASK_SKIP_E2E=1 RASK_SKIP_BENCHMARKS=1`, the
docs-only bypass the hook documents. The attribution guard ran and passed; the four path-filtered
gates (CLI build, watch, deploy, install) self-skipped.

## Changelog

None — repository metadata, not a user-facing change.
