### PR TITLE
feat(gates): share the machine by a slot budget so worktrees stop blocking each other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,62 @@ them until tagged releases begin.
   nothing built, formatted or tested). The `check-nuget-updates` skill is now
   **`check-dependency-updates`**, widened to every axis and carrying an explicit do-not-bump list.
 
+### Changed
+
+- **The gates now share this machine by a slot budget instead of one all-or-nothing lane, so several
+  worktrees can test at once without lying to each other.** Eight worktrees run on one box here, and
+  the old arrangement went wrong in both directions at the same time.
+
+  Too much at once: nothing throttled `run-unit-local.sh`. It was the only gate in the repo without an
+  `-m` cap, so each run took every core, and three of them running from three worktrees put **35
+  MSBuild worker nodes on 14 cores, load average 98 at 0.0% idle, 41 of 48 GB resident**. That is not
+  merely slow — under load this repo's timing-sensitive tests fail in ways indistinguishable from real
+  bugs, so the standing rule is that a green under contention is trustworthy and a red is not. Every
+  contended run costs a re-run at minimum, and one previously cost an investigation into a test the
+  change under review could not reach (#850).
+
+  Too little at once: `run-e2e-local.sh` took the whole machine from its *first line* — before the
+  build. Measured on a live run, **9m30s of its first 10m12s was build and publish**, roughly a
+  quarter of the ~40m norm, during which it blocked every other worktree while using a single core
+  (that build is `-m:1`, and stays that way: three targets files shell out to nested `dotnet publish`
+  of the same projects, so raising it races on output paths).
+
+  Now the box publishes **10 slots** — the performance cores, not all 14, so the efficiency cores stay
+  free and no timing-sensitive test lands somewhere slower than the run that set its timeout — and
+  each gate claims against them:
+
+  - **The unit gate never waits.** It takes whatever is left, floor 2, and shrinks into it: `-m` on
+    the build and on `dotnet test` follow the number, and it prints the size it chose. `pre-commit`
+    decided long ago that a blocked commit costs more than a slow one, and that still holds — the gate
+    just gets smaller on a busy box.
+  - **The browser gate's build and publishes take a partial claim**, so several worktrees may build
+    concurrently. Only the suite itself serialises, and a gate queued for it has already built.
+
+  Precisely what that buys: two browser suites never overlap. It does *not* mean an empty machine — a
+  unit gate that started while the browser gate was building is younger than it, so it is not waited
+  for and keeps its slots. That follows from the unit gate never blocking a commit; making the suite
+  wait for unit gates too would let a stream of commits starve it, since unit gates never queue.
+
+  Ordering is unchanged from #934 and now covers every gate: you wait only for claims *older* than
+  yours, which is what stops two waiters deadlocking (a waiter is itself a gate process) and what
+  stops anything starving (a gate's age only grows, so nobody can be inserted ahead of you). Claims
+  are processes rather than files, for the reason this repo has always given — a file survives
+  `kill -9` and a laptop sleep and then wedges every gate until someone works out what to delete. A
+  gate *queued* for the suite publishes its claim **before** it waits, because it has not started
+  `dotnet test` yet and nothing in its process tree would otherwise say what it is about to need.
+
+  The per-assembly half is a new shared `tests/xunit.runner.json`: xUnit's default is a thread per
+  core, so bounding assemblies alone still allowed 14 × 14. The gate now spends half its slots across
+  assemblies and half inside them. `tests/Rask.Examples.E2E.Tests` keeps its own file — a browser
+  collection is a published host plus a Chromium page, tuned against the exclusive claim that suite
+  takes.
+
+  `RASK_LANE_SLOTS` sets the budget; `RASK_LANE_DISABLE=1` switches the whole thing off. Every
+  existing knob still works, and `RASK_E2E_ALLOW_CONCURRENT=1` is now strictly better than it was: the
+  claim stays published, so other gates account for the load it adds. `rask_e2e_lane_holders` is gone,
+  replaced by the budget's ordering — two copies of an ordering rule that must agree is a bug waiting
+  for the day they stop agreeing.
+
 ### Fixed
 
 - **A version pinned in two places was held together by a comment, and one of the comments was
@@ -123,6 +179,27 @@ them until tagged releases begin.
   restores, builds, packs and pushes with no `dotnet test` anywhere. Since a push to nuget.org is
   permanent, the skill now says plainly that nothing between the tag and nuget.org will catch a
   regression, and to run the local gates first.
+
+- **`scripts/run-watch-e2e.sh` deleted packages out of the machine-global NuGet cache, which another
+  worktree's build could be restoring at that moment.** It exports `RASK_CLI_BUILD_E2E=1` to share the
+  CLI gate's packed feed, and that switch also arms `CliBuildE2E.EvictFromGlobalCache`, which removes
+  `~/.nuget/packages/<pkg>/<version>` for all 22 `Rask.*` packages. The eviction itself is
+  load-bearing — without it a restore silently reuses a cached nupkg of the same version and the gate
+  tests stale bits (#534). But MinVer stamps the *same* version for the same commit in every worktree,
+  so the deletion reached straight out of this gate's sandbox into every other one.
+
+  `run-cli-build-e2e.sh` was given a gate-private `NUGET_PACKAGES` for exactly this reason and
+  documents it at length; the watch gate shares its switch and its feed and was simply missed, because
+  the eviction lives in the fixture rather than in either script. It now points at the same private
+  directory, which also means the two gates share what they have already downloaded.
+
+- **Two E2E suites running from different worktrees published different commits into one directory.**
+  The on-demand publish fallback in `ExampleAppFixture` resolved to
+  `$TMPDIR/rask-e2e-publish/<app>` — keyed on the app alone, so every checkout on the machine shared
+  it. The code comment already stated that two processes writing one MSBuild output directory corrupts
+  it, and guarded against it with a `lock`; a lock only reaches the fixtures inside one process, and
+  each worktree's suite is its own process. The path now carries a hash of the checkout's absolute
+  path as well, since the lock cannot be made to reach and the path can.
 
 - **A Blazor island rendered EMPTY in a trimmed WebAssembly app, and nothing said so.** The package
   claimed WebAssembly support and the claim was pinned by a test that read the `.csproj` — no build,

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -152,37 +152,75 @@ Every change passes this gate before a PR (the `rask-ship` skill):
   `RASK_E2E_FILTER='FullyQualifiedName~PlaygroundExampleTests' scripts/run-e2e-local.sh`. It says loudly
   that the run was filtered, because a narrowed green is not the gate.
 
-  **Only one browser gate runs at a time — and the second one queues.** Two suites on one machine
-  contend for resources, and that shows up as a plausible-looking red minutes later with nothing in the
-  log pointing back at it. So the gate names the other run (pid, elapsed, worktree) and then **waits for
-  it**, starting automatically when the lane frees. If you are working across several worktrees, this is
-  what stops you diagnosing a failure that was never in your branch — without costing you the push.
+  **The machine has a slot budget, and every gate claims against it.** Several worktrees share one
+  box, and the two things that go wrong there pull in opposite directions: too much work at once
+  (nothing used to throttle the unit gate — three of them ran together and put 35 MSBuild worker nodes
+  on 14 cores, load average 98 at 0.0% idle), and too little (the browser gate used to take the whole
+  machine for its *whole run*, including a build that uses one core). Both are fixed by the same
+  mechanism, in `scripts/lib/machine-lane.sh`.
+
+  The box publishes **10 slots** — the performance cores, deliberately not all 14, so the efficiency
+  cores stay free for your editor and no timing-sensitive test gets scheduled somewhere slower than
+  the run that set its timeout. A gate then asks one of two questions:
+
+  | gate | what it does | blocks? |
+  |---|---|---|
+  | `run-unit-local.sh` | takes whatever is left, floor 2, and **shrinks into it** — `-m` on the build and on `dotnet test` follow the number, and it prints the size it chose | **never** |
+  | `run-e2e-local.sh` — preflight, build, publishes | a partial claim; several worktrees may build at once | **never** |
+  | `run-e2e-local.sh` — the browser suite | claims the whole budget | **yes** — see the exact guarantee below |
+
+  **What "exclusive" does and does not promise.** Two browser suites never overlap: whichever gate is
+  older is waited for, and a younger one finds the budget fully claimed and waits in turn. What it does
+  *not* promise is an empty machine. A unit gate that started while the browser gate was still building
+  is **younger** than it, so the browser gate does not count it and does not wait for it — that unit
+  gate keeps the slots it sized itself to and runs alongside the suite. That is a deliberate
+  consequence of the unit gate never blocking a commit, not an oversight: making the suite wait for
+  every unit gate as well would let a steady stream of commits starve the browser gate indefinitely,
+  since unit gates never queue. If you need a genuinely quiet machine for a suspicious red, check with
+  `ps -Ao pid,etime,command | grep -E '[r]un-(e2e|unit)-local'` and re-run alone.
+
+  So a commit is never delayed — `.githooks/pre-commit` decided that a blocked commit costs more than
+  a slow one, and that still holds; the gate just gets smaller on a busy box. And a browser gate no
+  longer blocks seven worktrees while it builds: on a measured run, 9m30s of its first 10m12s was
+  build and publish, roughly a quarter of the ~40m norm, spent holding a machine it was using one core
+  of. Only the suite itself is exclusive now, and a gate queued for it has already finished building.
 
   The queue is ordered by process age: a gate waits only for gates *older* than itself, so the run
   holding the machine is ahead of everyone and each waiter is ahead of the ones that arrived later.
-  Exactly one is released at a time. That ordering is load-bearing rather than decorative — a waiting
-  gate is itself a `run-e2e-local.sh` process, so "wait until no other gate exists" would deadlock two
-  waiters against each other, and "start when the holder exits" would release them simultaneously into
-  the very contention the guard prevents.
+  Exactly one is released at a time, and nothing starves — a gate's age only grows and a new gate
+  starts at zero, so nobody can ever be inserted ahead of you. That ordering is load-bearing rather
+  than decorative: a waiting gate is itself a gate process, so "wait until no other gate exists" would
+  deadlock two waiters against each other, and "start when the holder exits" would release them
+  simultaneously into the very contention this prevents.
+
+  Claims are processes, not files (`scripts/lib/lane-claim.sh`) — a file survives `kill -9` and a
+  laptop sleep and then wedges every gate on the box until someone works out what to delete, whereas a
+  claim whose owner is gone stops counting the moment `ps` forgets it. A gate that is *queued* for the
+  browser suite publishes its claim **before** it waits: it has not started `dotnet test` yet, so
+  nothing in its process tree would otherwise say what it is about to need, and a junior would start
+  work the waiter is about to need the whole machine for.
 
   | variable | effect |
   |---|---|
-  | `RASK_E2E_QUEUE_TIMEOUT` | seconds to wait before giving up (default `5400`, 90m). Past it the gate exits 1 and names what still holds the lane — a run past the ~40m norm is usually wedged, not busy. |
+  | `RASK_LANE_SLOTS` | the budget (default `10`). |
+  | `RASK_LANE_DISABLE=1` | switch the whole mechanism off: every gate gets its maximum and nothing waits. |
+  | `RASK_E2E_QUEUE_TIMEOUT` | seconds to wait before giving up (default `5400`, 90m). Past it the gate exits 1 and names what still holds the slots — a run past the ~40m norm is usually wedged, not busy. |
   | `RASK_E2E_QUEUE_POLL` | seconds between checks (default `20`). |
-  | `RASK_E2E_QUEUE=0` | do not wait; refuse immediately, as this gate did before. |
-  | `RASK_E2E_ALLOW_CONCURRENT=1` | do not wait; run alongside. Treat anything it reports as suspect until re-run alone. |
+  | `RASK_E2E_QUEUE=0` | do not wait; refuse immediately. |
+  | `RASK_E2E_ALLOW_CONCURRENT=1` | do not wait; run alongside. The claim is still published, so others account for the load — but treat anything the run reports as suspect until re-run alone. |
 
   Worth knowing when you read a red: contention produces boot timeouts and dead fixtures, never a false
   assertion pass. **A green under contention is trustworthy; a red is not.**
 
-  **What that guard does not cover.** It detects its own kind — a second browser gate. The commoner
-  collision is everything else competing with a live suite: a `pre-commit` hook, a plain `dotnet
-  build`, a `dotnet publish`, the CLI build gate. None of those is a browser gate, so nothing refuses
-  and nothing warns. Two things soften it now, both hints rather than decisions ([#850]):
-  `pre-commit` says so before it starts when a browser gate is live (it never refuses — a blocked
-  commit is worse than a slow one), and a red suite that finds a heavy build still running names it
-  and asks you to re-run alone before investigating. Neither claims your failure is not real; they
-  say the run was not clean enough to conclude that it is.
+  **What the budget does not cover.** Only the two gates above claim against it. The rest —
+  `run-benchmarks-local.sh`, `run-cli-build-e2e.sh`, the watch and deploy and install gates — and any
+  plain `dotnet build` you run by hand are invisible to it, so the accounting is *incomplete* rather
+  than wrong: work exists that nobody counted. A gate that goes unseen costs some over-subscription,
+  which is the safe direction; the alternative, a phantom gate, would shrink everyone else for as long
+  as it was believed in. Two older hints still soften the uncounted cases ([#850]): `pre-commit` says
+  so before it starts when a browser gate is live (it never refuses), and a red suite that finds a
+  heavy build still running names it and asks you to re-run alone before investigating. Neither claims
+  your failure is not real; they say the run was not clean enough to conclude that it is.
 
 - **Every gate says whether it ran.** The path-filtered gates — CLI build, watch hot-reload, deploy,
   install — used to take a silent branch when nothing in the push matched their paths, printing

--- a/scripts/lib/e2e-concurrency.sh
+++ b/scripts/lib/e2e-concurrency.sh
@@ -175,43 +175,10 @@ rask_e2e_etime_of() {
   ps -o etime= -p "$1" 2>/dev/null | tr -d ' '
 }
 
-# Of the other live gates, which ones outrank us for the lane? Prints their pids, one per line.
-# Empty output means it is our turn.
-#
-# This is what makes WAITING safe, and it is the whole reason the queue is not a plain sleep loop.
-#
-# A gate that is waiting for the lane is itself a `run-e2e-local.sh` process, so process detection
-# alone cannot tell a waiter from the run that holds the machine. Two waiters therefore see each
-# other. If both wait until no other gate exists, they deadlock; if both instead proceed the moment
-# the holder exits, they start simultaneously -- which is exactly the contention this guard exists to
-# prevent. A naive queue converts one honest refusal into either a hang or the very bug it replaced.
-#
-# Resolved by AGE, which totally orders the contenders with no shared state: you wait only for gates
-# OLDER than you. The holder is older than every waiter, so everyone waits for it. Among waiters each
-# waits for all of its seniors, so when the holder exits exactly one waiter -- the oldest -- is
-# released, and the others keep waiting because that one is still older than they are. FIFO, and fair.
-#
-# Ties (the same whole second, plausible when a merge train fires several pushes at once) break on
-# numeric pid, purely to make the order total. Any deterministic tiebreak would do; what matters is
-# that both sides compute the same one, so two processes never each conclude they outrank the other.
-#
-# Still no lockfile, for the reason this file has always given: process age is self-healing. Ctrl-C a
-# waiter and it drops out of everyone else's ordering with nothing to clean up.
-rask_e2e_lane_holders() {
-  self_pid="${1:-$$}"
-  parent_pid="${2:-$PPID}"
-
-  self_age="$(rask_etime_seconds "$(rask_e2e_etime_of "$self_pid")")"
-
-  for pid in $(rask_other_e2e_runs "$self_pid" "$parent_pid"); do
-    age="$(rask_etime_seconds "$(rask_e2e_etime_of "$pid")")"
-    if [ "$age" -gt "$self_age" ]; then
-      printf '%s\n' "$pid"
-    elif [ "$age" -eq "$self_age" ] && [ "$pid" -lt "$self_pid" ]; then
-      printf '%s\n' "$pid"
-    fi
-  done
-}
+# rask_e2e_lane_holders lived here until the gates moved to a slot budget. It ordered browser
+# gates against each other by process age; scripts/lib/machine-lane.sh now does that for every
+# gate and every phase, and carries the age-ordering argument in full. Two copies of an ordering
+# rule that must agree is a bug waiting for the day they stop agreeing, so there is one.
 
 # Indirected so the test can stub it without spawning real processes.
 rask_e2e_command_of() {

--- a/scripts/lib/lane-claim.sh
+++ b/scripts/lib/lane-claim.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# A gate's claim on this machine, expressed as a process.
+#
+#   argv:  bash <path>/lane-claim.sh <owner-pid> <cost> <phase>
+#
+# The ARGV IS THE CLAIM. This script does no work; it exists so that `ps -o command=` in another
+# worktree can read how many slots the owning gate is taking and for what. The body's only job is to
+# make the claim die with its owner.
+#
+# Why a process rather than a file, when scripts/lib/machine-lane.sh could just as easily have written
+# /tmp/rask-lane/<pid>: because a file survives kill -9 and a laptop sleep and then wedges every gate
+# on the machine until someone works out what to delete. That is the reasoning scripts/lib/
+# e2e-concurrency.sh has always given for detecting gates by process, and it applies with more force
+# here -- this claim gates BUILDS, not just the browser suite, so a stale one would slow every commit
+# on the box indefinitely, silently, and in a way whose cause is a file nobody knows about.
+#
+# Self-healing twice over. A reader ignores any claim whose owner `ps` no longer knows about, so a
+# kill -9'd gate stops counting immediately, before this process has even noticed. And this process
+# polls its owner and exits on its own within RASK_LANE_MARKER_POLL seconds of the owner dying, so an
+# orphan does not linger either. Neither path needs anyone to clean anything up.
+#
+# Why a claim is advertised at all, rather than the reader inferring the phase from the gate's own
+# process tree (the gate's `dotnet test` child is, after all, visible): because a gate that is WAITING
+# for slots has no such child yet. It would read as still building, its juniors would under-count it,
+# and one of them would start work that the waiter is about to need the whole machine for. The claim
+# has to state the REQUEST, not the current activity -- otherwise "exclusive" is only exclusive once
+# it is too late to matter.
+
+owner="${1:-}"
+
+if [ -z "$owner" ]; then
+  echo "lane-claim.sh: no owner pid given" >&2
+  exit 2
+fi
+
+trap 'exit 0' TERM INT
+
+# The sleep is BACKGROUNDED and waited on, which looks like a pointless detour and is not.
+#
+# Bash runs trap handlers only between foreground commands, so with a plain `sleep N` in the loop the
+# TERM above does not arrive until that sleep finishes on its own. rask_lane_release then blocks for up
+# to a full poll on every gate exit and on every claim that replaces another. Measured on this machine
+# with the poll set to 30s: release took 28,982ms. `wait` IS interruptible by a trap, so backgrounding
+# the sleep and waiting on it makes the handler run immediately -- which is what the release path has
+# always assumed, and what an earlier comment here wrongly claimed was already true.
+while kill -0 "$owner" 2>/dev/null; do
+  sleep "${RASK_LANE_MARKER_POLL:-5}" &
+  wait $!
+done

--- a/scripts/lib/machine-lane.sh
+++ b/scripts/lib/machine-lane.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+# How much of this machine may a gate take right now?
+#
+# The problem this solves is NOT the one scripts/lib/e2e-concurrency.sh solves. That file answers
+# "is another browser gate running?" and serialises the browser suite against itself. It is right
+# about that, and it stays. What it cannot see is the commoner and more expensive collision (#850):
+# several worktrees on one box each running the FULL unit gate, none of them bounded. Measured here
+# with three of them live: 35 MSBuild worker nodes on 14 cores, load average 98, 0.0% idle, 41 of
+# 48 GB resident. Nothing refused, nothing warned, and every timing-sensitive test in all three runs
+# became untrustworthy -- this repo's rule is that a green under contention is trustworthy and a red
+# is not, so each of those runs cost a re-run at minimum.
+#
+# So the unit is no longer "the lane" (one holder, everyone else waits) but SLOTS. The box publishes
+# a budget, each gate declares what it is taking, and a gate asks one of two questions:
+#
+#   rask_lane_fit  -- "how big may I be?"   Answers immediately. NEVER blocks. Used by the unit gate,
+#                     which runs from .githooks/pre-commit -- and that hook decided deliberately (see
+#                     its comment) that a blocked commit costs more than a slow one. Shrinking is how
+#                     a gate honours a busy machine without ever making someone wait for it.
+#
+#   rask_lane_fits -- "does this much fit?"  The predicate a blocking caller polls. Used only where
+#                     the work genuinely cannot share the box: the browser suite, whose journeys and
+#                     WebSocket timing tests fail under load in ways indistinguishable from real bugs.
+#
+# Both are computed from the same headroom function, over the ordering rule this file inherited from
+# e2e-concurrency.sh's rask_e2e_lane_holders and then replaced (that function is gone; two copies of
+# an ordering rule that must agree is a bug waiting for the day they stop agreeing).
+#
+# THE RULE: you count only gates OLDER than yourself. It is what makes waiting safe rather than
+# deadlocking, and the argument is worth keeping in full because it is not obvious and it is the
+# thing most likely to be "simplified" away later.
+#
+# A gate that is waiting is itself a gate process, so detection alone cannot tell a waiter from the
+# run that holds the machine, and two waiters therefore see each other. If both wait until nobody
+# else is present, they hang. If both instead start the moment the holder exits, they start
+# simultaneously -- which is exactly the contention the whole mechanism exists to prevent. A naive
+# queue converts one honest refusal into either a deadlock or the very bug it replaced.
+#
+# Resolved by AGE, which totally orders the contenders with no shared state: you wait only for gates
+# older than you. The holder is older than every waiter, so everyone waits for it; among waiters each
+# waits for all of its seniors, so when the holder exits exactly one waiter -- the oldest -- is
+# released, and the others keep waiting because that one is still older than they are. FIFO, and fair.
+# A gate's age only grows and a new gate starts at zero, so nobody can ever be INSERTED ahead of you:
+# the set you are waiting for only shrinks, which is why nothing starves.
+#
+# Ties (the same whole second, plausible when a merge train fires several pushes at once) break on
+# numeric pid, purely to make the order total. Any deterministic tiebreak would do; what matters is
+# that both sides compute the same one, so two processes never each conclude they outrank the other.
+#
+# Everything here is decided BY PROCESS, never a lockfile -- see scripts/lib/lane-claim.sh for why a
+# claim is itself a process, and why inferring a gate's phase from its own children is not enough.
+
+# shellcheck source=e2e-concurrency.sh
+. "${BASH_SOURCE%/*}/e2e-concurrency.sh"
+
+# The budget, in slots. One slot is meant to be one core's worth of work.
+#
+# Defaults to 10 on a 14-core box, and the missing 4 are deliberate rather than rounding. This
+# machine is 10 performance + 4 efficiency cores, and handing out the efficiency cores is how a
+# timing-sensitive test ends up scheduled somewhere far slower than the run that set its timeout --
+# which is a false red, the exact currency this whole file exists to stop spending. The remainder
+# also keeps an editor and a browser responsive while a gate runs, so nobody is tempted to skip it.
+rask_lane_budget() {
+  printf '%s' "${RASK_LANE_SLOTS:-10}"
+}
+
+# What a gate in its build/publish phase claims. Not the whole box: builds are throughput work, they
+# tolerate sharing, and the entire point of splitting the E2E gate by phase is that several worktrees
+# may build at once. Before that split, a gate held the whole machine from its first line -- measured
+# here at 9m30s of build and publish before `dotnet test` appeared at all, roughly a quarter of the
+# documented ~40m norm, during which seven other worktrees were blocked while the holder used a
+# single core (the build is -m:1, and stays that way -- see run-e2e-local.sh).
+rask_lane_build_cost() {
+  printf '%s' "${RASK_LANE_BUILD_COST:-4}"
+}
+
+# The largest a unit gate will ever size itself.
+rask_lane_unit_max() {
+  printf '%s' "${RASK_LANE_UNIT_MAX:-8}"
+}
+
+# Which script is this command line EXECUTING, if any? Prints a basename, or nothing.
+#
+# Generalises rask_is_e2e_gate_command to the scripts this file cares about, and keeps the thing that
+# made that function correct: the decision is made on ARGV POSITION, never a substring. The comment
+# there records what substring matching did in practice -- it reported three conflicts where there
+# was one, having matched an editor holding the file open and a `tee` of the gate's own log. Neither
+# is a gate, and counting them would shrink every real gate on the box for as long as the editor
+# stayed open.
+#
+# The shell-option walk and the -c arm are lifted from that function deliberately rather than
+# reimplemented; see its comments for why -c must bail (the argument is script TEXT, and the child
+# that actually runs the script is matched on its own pid) and for the known, written-down
+# limitations (a repo path containing a space; `bash --rcfile x script`). Both fail as a MISSED
+# detection, never a wrong one -- an unseen gate costs some over-subscription, while a phantom gate
+# would shrink everyone else for as long as it was believed in.
+rask_lane_script_of() {
+  [ -n "${1:-}" ] || return 0
+
+  set -f
+  # shellcheck disable=SC2086
+  set -- $1
+  set +f
+
+  first="${1:-}"
+
+  case "${first##*/}" in
+    bash | sh | zsh | dash | ksh)
+      shift
+      while [ $# -gt 0 ]; do
+        case "$1" in
+          -*c*) return 0 ;;
+          -*) shift ;;
+          *) break ;;
+        esac
+      done
+      target="${1:-}"
+      ;;
+    *) target="$first" ;;
+  esac
+
+  case "$target" in
+    */run-e2e-local.sh | run-e2e-local.sh) printf 'run-e2e-local.sh' ;;
+    */run-unit-local.sh | run-unit-local.sh) printf 'run-unit-local.sh' ;;
+    */lane-claim.sh | lane-claim.sh) printf 'lane-claim.sh' ;;
+  esac
+}
+
+# Direct children of a pid. Indirected so the tests can stub it without spawning anything.
+rask_lane_children_of() {
+  if [ -n "${RASK_LANE_COMMAND_STUB:-}" ]; then
+    eval "printf '%s' \"\${RASK_LANE_CHILDREN_$1:-}\""
+    return 0
+  fi
+  pgrep -P "$1" 2>/dev/null || true
+}
+
+# The slot count a gate has explicitly claimed via a lane-claim.sh child, if it has one.
+# Prints the cost, or nothing when the gate is running on its phase default.
+#
+# The claim is read from the marker's ARGV rather than from anything the gate itself could be asked,
+# because the reader is in another worktree and `ps` is all it has. The owner pid in argv is checked
+# against the gate we are asking about, so one gate's marker can never be credited to another.
+rask_lane_declared_cost_of() {
+  gate_pid="${1:-}"
+  [ -n "$gate_pid" ] || return 0
+
+  for child in $(rask_lane_children_of "$gate_pid"); do
+    cmd="$(rask_e2e_command_of "$child")"
+    [ "$(rask_lane_script_of "$cmd")" = "lane-claim.sh" ] || continue
+
+    set -f
+    # shellcheck disable=SC2086
+    set -- $cmd
+    set +f
+    # Walk to the script path, then read <owner> <cost> after it.
+    while [ $# -gt 0 ]; do
+      case "$(rask_lane_script_of "$1")" in
+        lane-claim.sh) break ;;
+      esac
+      shift
+    done
+    owner="${2:-}"
+    cost="${3:-}"
+
+    [ "$owner" = "$gate_pid" ] || continue
+    case "$cost" in
+      "" | *[!0-9]*) continue ;;
+    esac
+    printf '%s' "$cost"
+    return 0
+  done
+  return 0
+}
+
+# What is this gate currently taking? Prints a slot count.
+#
+# Order matters: an explicit claim wins over the phase default, because the claim is what a gate
+# publishes BEFORE it waits. A gate queued for the browser suite has not started `dotnet test` yet
+# and would otherwise still read as merely building -- so its juniors would under-count it and start
+# work it is about to need the whole machine for.
+#
+# The unit gate needs no marker: it never changes its claim, so it carries the number in its own argv
+# (`--lane-slots N`), put there by re-execing itself once it has chosen a size. Argv, not an
+# environment variable, precisely so this function can read it back out of `ps`. A unit gate seen
+# WITHOUT the flag is in the few milliseconds before that re-exec; it is counted at the maximum it
+# could pick, because under-counting a gate that is about to get large over-subscribes the box.
+rask_lane_cost_of() {
+  pid="${1:-}"
+  cmd="$(rask_e2e_command_of "$pid")"
+  script="$(rask_lane_script_of "$cmd")"
+
+  declared="$(rask_lane_declared_cost_of "$pid")"
+  if [ -n "$declared" ]; then
+    printf '%s' "$declared"
+    return 0
+  fi
+
+  case "$script" in
+    run-e2e-local.sh) rask_lane_build_cost ;;
+    run-unit-local.sh)
+      case "$cmd" in
+        *--lane-slots\ *)
+          slots="${cmd#*--lane-slots }"
+          slots="${slots%% *}"
+          case "$slots" in
+            "" | *[!0-9]*) rask_lane_unit_max ;;
+            *) printf '%s' "$slots" ;;
+          esac
+          ;;
+        *) rask_lane_unit_max ;;
+      esac
+      ;;
+    *) printf '0' ;;
+  esac
+}
+
+# Every OTHER live gate on this machine, of any kind. Prints pids, one per line.
+rask_lane_other_gates() {
+  self_pid="${1:-$$}"
+  parent_pid="${2:-$PPID}"
+
+  candidates="$(
+    if [ -n "${RASK_LANE_PGREP_OVERRIDE:-}" ]; then
+      printf '%s\n' $RASK_LANE_PGREP_OVERRIDE
+    else
+      pgrep -f 'run-(e2e|unit)-local\.sh' 2>/dev/null || true
+    fi
+  )"
+
+  for pid in $candidates; do
+    [ "$pid" = "$self_pid" ] && continue
+    [ "$pid" = "$parent_pid" ] && continue
+    case "$(rask_lane_script_of "$(rask_e2e_command_of "$pid")")" in
+      run-e2e-local.sh | run-unit-local.sh) printf '%s\n' "$pid" ;;
+    esac
+  done
+  return 0
+}
+
+# The gates that outrank us, for the message a waiting gate prints. One "pid cost" per line.
+#
+# Kept separate from the arithmetic below rather than folded into it, because naming WHO is holding
+# the machine is the half that actually helps: "there is contention" says there is a problem, while a
+# pid and an elapsed time is what lets someone decide whether to wait for it or go and look at it.
+rask_lane_senior_gates() {
+  self_pid="${1:-$$}"
+  parent_pid="${2:-$PPID}"
+
+  self_age="$(rask_etime_seconds "$(rask_e2e_etime_of "$self_pid")")"
+
+  for pid in $(rask_lane_other_gates "$self_pid" "$parent_pid"); do
+    age="$(rask_etime_seconds "$(rask_e2e_etime_of "$pid")")"
+    if [ "$age" -gt "$self_age" ] || { [ "$age" -eq "$self_age" ] && [ "$pid" -lt "$self_pid" ]; }; then
+      printf '%s %s\n' "$pid" "$(rask_lane_cost_of "$pid")"
+    fi
+  done
+  return 0
+}
+
+# Slots claimed by gates that outrank us. See the header: only OLDER gates count, ties on pid.
+#
+# The age is the GATE's, never its marker's. A marker is re-spawned when a claim changes, so ordering
+# on marker age would make a gate surrender its seniority every time it declared a new phase -- it
+# would go to the back of the queue for doing work, which is a starvation generator. Ordering on the
+# owner means a gate never loses its place.
+rask_lane_claimed_by_seniors() {
+  self_pid="${1:-$$}"
+  parent_pid="${2:-$PPID}"
+
+  self_age="$(rask_etime_seconds "$(rask_e2e_etime_of "$self_pid")")"
+  total=0
+
+  for pid in $(rask_lane_other_gates "$self_pid" "$parent_pid"); do
+    age="$(rask_etime_seconds "$(rask_e2e_etime_of "$pid")")"
+    senior=0
+    if [ "$age" -gt "$self_age" ]; then
+      senior=1
+    elif [ "$age" -eq "$self_age" ] && [ "$pid" -lt "$self_pid" ]; then
+      senior=1
+    fi
+    if [ "$senior" = "1" ]; then
+      total=$((total + $(rask_lane_cost_of "$pid")))
+    fi
+  done
+
+  printf '%s' "$total"
+}
+
+# Slots left for us. Never negative: seniors can over-commit the box between two polls -- an E2E gate
+# declaring its exclusive claim on top of a unit gate that is already running -- and a negative
+# headroom would propagate straight into `-m:-3`, which MSBuild rejects.
+rask_lane_headroom() {
+  headroom=$(( $(rask_lane_budget) - $(rask_lane_claimed_by_seniors "${1:-$$}" "${2:-$PPID}") ))
+  if [ "$headroom" -lt 0 ]; then
+    headroom=0
+  fi
+  printf '%s' "$headroom"
+}
+
+# "How big may I be?" -- answers now, never waits.
+#
+# The floor is load-bearing, and is why this takes a minimum at all. A gate handed 0 slots would pass
+# `-m:0` to MSBuild, which means "use every core" -- so the BUSIEST possible machine would produce
+# the LEAST bounded run, silently, in exactly the circumstances where that does the most damage.
+# Clamped low rather than refused: a slow gate is a working gate, and this is what lets the unit gate
+# keep .githooks/pre-commit's promise never to block a commit.
+rask_lane_fit() {
+  min="${1:-2}"
+  max="${2:-8}"
+
+  if [ "${RASK_LANE_DISABLE:-}" = "1" ]; then
+    printf '%s' "$max"
+    return 0
+  fi
+
+  fit="$(rask_lane_headroom "${3:-$$}" "${4:-$PPID}")"
+
+  if [ "$fit" -lt "$min" ]; then
+    fit="$min"
+  fi
+  if [ "$fit" -gt "$max" ]; then
+    fit="$max"
+  fi
+  printf '%s' "$fit"
+}
+
+# "Does this much fit right now?" -- the predicate a blocking caller polls. The wait LOOP lives in the
+# calling script, not here, so the waiting message can name what is being waited for; same split as
+# e2e-concurrency.sh, where the predicate is testable and run-e2e-local.sh owns the queue.
+#
+# A cost larger than the whole budget is clamped rather than refused. Without that, setting
+# RASK_LANE_SLOTS=6 while some caller still asks for 10 would block every browser suite on the
+# machine forever, and nothing would say why.
+rask_lane_fits() {
+  cost="${1:-1}"
+
+  [ "${RASK_LANE_DISABLE:-}" = "1" ] && return 0
+
+  budget="$(rask_lane_budget)"
+  [ "$cost" -gt "$budget" ] && cost="$budget"
+
+  [ "$(rask_lane_headroom "${2:-$$}" "${3:-$PPID}")" -ge "$cost" ]
+}
+
+# Publish a claim: start a lane-claim.sh child advertising <cost> for <phase>, replacing any claim
+# this process already had. Returns immediately -- claiming is not waiting.
+#
+# The redirections are not cosmetic. .githooks/pre-push runs the gate as `... | tee "$gate_log"`, and
+# a background child that inherits stdout holds the pipe's write end open, so `tee` cannot exit while
+# the marker lives. Without </dev/null and the output redirects, a marker outliving its gate by even
+# a few seconds would hang the push.
+rask_lane_claim() {
+  cost="${1:-1}"
+  phase="${2:-work}"
+
+  [ "${RASK_LANE_DISABLE:-}" = "1" ] && return 0
+
+  rask_lane_release
+
+  bash "${BASH_SOURCE%/*}/lane-claim.sh" "$$" "$cost" "$phase" \
+    >/dev/null 2>&1 </dev/null &
+  RASK_LANE_MARKER_PID=$!
+}
+
+# Drop this process's claim. Safe to call when there is none, and safe to call twice.
+rask_lane_release() {
+  [ -n "${RASK_LANE_MARKER_PID:-}" ] || return 0
+  kill "$RASK_LANE_MARKER_PID" 2>/dev/null || true
+  wait "$RASK_LANE_MARKER_PID" 2>/dev/null || true
+  RASK_LANE_MARKER_PID=""
+}

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -19,128 +19,169 @@ fi
 root="$(git rev-parse --show-toplevel)"
 cd "$root"
 
-# Is another copy of this gate already running?
+# How much of this machine may this gate take?
 #
 # The port collision was fixed in #626, but two suites on one machine still contend for resources, and
 # the way that surfaces is the expensive one: a plausible-looking red in one or both runs, minutes after
 # the contention, with nothing in the log pointing back at it. It has already cost one unexplained
 # timeout across two worktrees that were coordinating and still both believed the machine was idle.
 #
-# REFUSE by default, with an override. This runs from .githooks/pre-push, which prints thousands of
-# build lines, and a warning in the middle of that is a warning nobody reads — which would leave the
-# contention to be discovered later as a red that looks real. Refusing also matches how every other
-# opt-out here already works (RASK_SKIP_E2E, RASK_SKIP_CLI_BUILD_E2E, RASK_SKIP_WATCH_E2E), so it needs
-# no new convention.
+# The answer is no longer one all-or-nothing lane held for the whole run. This gate spends most of its
+# time building and publishing — measured at 9m30s of a 10m12s run before `dotnet test` even started —
+# and that work shares a machine perfectly well; it is the browser suite that cannot. So the budget in
+# scripts/lib/machine-lane.sh is claimed in two steps: the build and publishes below run alongside
+# whatever else is going on, and rask_e2e_await_slots (further down, just before the suite) is the one
+# point that waits. Everything about HOW that waiting is ordered, and why it is decided by process
+# rather than by a lockfile, lives in machine-lane.sh and lane-claim.sh rather than being restated here.
 #
-# The argument against — that a blocked push with a false positive becomes "I cannot push and I do not
-# know why" — is real, and is answered in two places rather than by warning instead. The match is
-# decided on the EXECUTABLE POSITION in the other process's argv (rask_is_e2e_gate_command), because a
-# bare name matched a shell whose argv merely mentioned the script the first time this was tested — and
-# an anchor on the scripts/ path, which was the first fix, then silently missed the relative invocation
-# the docs actually tell you to use. And the refusal prints the offending pid, its elapsed time, its full
-# command line, and the exact variable that overrides it, so it can never be the unexplained kind.
+# The two anchored lines it prints — "run-e2e-local: still queued after …" and "run-e2e-local: refused
+# to start …" — are contracts: scripts/lib/build-failure.sh greps for them to tell a busy machine from
+# a broken branch, and rewording either silently reclassifies a contended run as a genuine failure.
 #
-# Detected by PROCESS, never by a lockfile: a lockfile survives kill -9 and a laptop sleep and then
-# wedges the gate until someone works out what to delete. Process detection is self-healing — a run
-# someone Ctrl-C'd leaves nothing behind. This repo has enough gates that failed quietly without adding
-# one that fails loudly at the worst moment.
-#
-# Printing WHICH run and HOW LONG is the useful half — "there is a conflict" tells you there is a
-# problem, `ps -o etime=` is what lets you decide whether to wait for it or investigate your own red.
-#
-# Skipped under CI purely so this can never be the thing that breaks an automated run. Nothing in
-# .github/workflows runs the browser E2E or the benchmarks today — GitHub only publishes (release.yml,
-# pages.yml, nightly.yml) and lints commit messages — so this is insurance against a future parallel
-# path, not protection of a known one.
-# Sourced unconditionally, though only the REFUSAL below is skipped under CI: the contention hint on a
-# failing suite at the end of this script needs rask_other_heavy_builds either way, and a helper that
-# exists only on one branch of an `if` is a "command not found" waiting for the first CI run.
+# Sourced unconditionally, though the WAIT itself is skipped under CI: the contention hint on a failing
+# suite at the end of this script needs rask_other_heavy_builds either way, and a helper that exists
+# only on one branch of an `if` is a "command not found" waiting for the first CI run.
 # shellcheck source=lib/e2e-concurrency.sh
 . "$root/scripts/lib/e2e-concurrency.sh"
+# The slot budget this gate now claims against, rather than taking the whole machine for its whole
+# run. Sources e2e-concurrency.sh itself, so the line above is redundant in effect and kept in place
+# because the contention hint at the end of this script names that file as where its helper lives.
+# shellcheck source=lib/machine-lane.sh
+. "$root/scripts/lib/machine-lane.sh"
 
-if [ -z "${CI:-}" ]; then
-  others="$(rask_e2e_lane_holders | tr '\n' ' ')"
+# Wait until this machine has room for the browser suite.
+#
+# MOVED, in the change that split this gate by phase. This block used to run at the top of the script,
+# so a gate held the whole machine from its very first line. Measured on a live run: 9m30s of build
+# and publish before `dotnet test` appeared at all — roughly a quarter of the ~40m norm, during which
+# seven other worktrees were blocked while this one used a SINGLE core (the build below is -m:1, and
+# stays that way). Builds are throughput work and tolerate sharing; the browser suite genuinely does
+# not. So the build and publish phases now take a partial claim, several worktrees may build at once,
+# and only this function serialises. A gate that queues here has already done its building.
+#
+# The claim is PUBLISHED BEFORE THE WAIT, and that ordering is load-bearing rather than tidy. A gate
+# queued here has not started `dotnet test` yet, so nothing in its own process tree says what it is
+# about to need; without an explicit claim its juniors would read it as merely building, under-count
+# it, and start work it is about to need the whole machine for. See scripts/lib/lane-claim.sh.
+#
+# Everything #934 established is kept: ordering by process age, the deadline, the poll interval, and
+# every override. So are the two ANCHORED output lines below — scripts/lib/build-failure.sh greps for
+# them to decide whether a red gate means "your branch is broken" or "your machine was busy", and a
+# reworded line there silently reclassifies a contended run as a genuine failure.
+rask_e2e_await_slots() {
+  # Skipped under CI purely so this can never be the thing that breaks an automated run. Nothing in
+  # .github/workflows runs the browser E2E today, so this is insurance against a future parallel path.
+  [ -n "${CI:-}" ] && return 0
 
-  if [ -n "${others// /}" ]; then
-    echo "run-e2e-local: another browser E2E gate holds this machine."
-    for pid in $others; do
-      elapsed="$(ps -o etime= -p "$pid" 2>/dev/null | tr -d ' ')"
-      cmd="$(ps -o command= -p "$pid" 2>/dev/null | cut -c1-120)"
-      [ -n "$elapsed" ] && echo "               pid $pid, running for ${elapsed}: $cmd"
-    done
-    echo
-    echo "            Two suites on one machine contend for resources. The port collision was fixed in"
-    echo "            #626, but contention still surfaces as a plausible-looking red in one or both runs,"
-    echo "            minutes later, with nothing in the log pointing back at it. It has already cost one"
-    echo "            unexplained timeout between two worktrees that were coordinating and still both"
-    echo "            believed the machine was idle."
-    echo
+  slots_needed="$(rask_lane_budget)"
+  rask_lane_claim "$slots_needed" test
 
-    if [ "${RASK_E2E_ALLOW_CONCURRENT:-}" = "1" ]; then
-      echo "run-e2e-local: RASK_E2E_ALLOW_CONCURRENT=1 — starting alongside it anyway."
-      echo "            Treat any failure as suspect until you have re-run it alone."
-    else
-      # QUEUE, rather than refuse.
-      #
-      # Refusing was right about the contention and wrong about what to do with it. The lane is a
-      # machine-wide singleton shared by several worktrees, so "wait for it and push again" was the
-      # standing advice — which meant every caller hand-rolled a waiter, and the ones that did not got
-      # a failed push for a machine state that had nothing to do with their branch. A queue keeps the
-      # serialization guarantee (still exactly one suite at a time) and spends the wait automatically.
-      #
-      # The refusal is kept as the TIMEOUT, so nothing waits forever: past the deadline this exits 1
-      # with the same guidance it always printed. RASK_E2E_QUEUE=0 restores the old refuse-immediately
-      # behaviour for anyone who wants the push back rather than the wait.
-      #
-      # Note the ordering is computed FRESH each poll rather than once up front. A waiter that cached
-      # its seniors would keep waiting for a pid that had already exited, and — worse — would miss a
-      # gate that started later but outranks it after a tie-break.
-      queue_deadline_s="${RASK_E2E_QUEUE_TIMEOUT:-5400}"
-      queue_poll_s="${RASK_E2E_QUEUE_POLL:-20}"
-      queue_waited_s=0
+  rask_lane_fits "$slots_needed" && return 0
 
-      if [ "${RASK_E2E_QUEUE:-1}" = "0" ]; then
-        echo "            Wait for the run above to finish, then push again. To run anyway:"
-        echo "                RASK_E2E_ALLOW_CONCURRENT=1 git push        (or set it for this script)"
-        echo "            and treat any failure as suspect until you have re-run it alone."
-        # A distinct, anchored line for rask_build_failure_kind. It cannot classify on the "holds this
-        # machine" banner above: that now prints on runs which go on to QUEUE AND SUCCEED, so keying on
-        # it would relabel a genuine failure hours later as contention.
-        echo "run-e2e-local: refused to start — RASK_E2E_QUEUE=0 and the lane is held."
-        exit 1
-      fi
+  echo "run-e2e-local: this machine's slots are taken, and the browser suite needs all $slots_needed."
+  rask_e2e_name_seniors
+  echo
+  echo "            Two suites on one machine contend for resources. The port collision was fixed in"
+  echo "            #626, but contention still surfaces as a plausible-looking red in one or both runs,"
+  echo "            minutes later, with nothing in the log pointing back at it. It has already cost one"
+  echo "            unexplained timeout between two worktrees that were coordinating and still both"
+  echo "            believed the machine was idle."
+  echo
 
-      echo "run-e2e-local: queued behind it — waiting up to $((queue_deadline_s / 60))m for the lane."
-      echo "            Ctrl-C to give up; RASK_E2E_QUEUE=0 to refuse immediately instead of waiting;"
-      echo "            RASK_SKIP_E2E=1 to skip the gate entirely."
+  if [ "${RASK_E2E_ALLOW_CONCURRENT:-}" = "1" ]; then
+    # Now strictly better than it used to be: the claim above stays published, so this run is at least
+    # honest about the load it is adding and everyone else accounts for it. It still buys a result you
+    # cannot trust.
+    echo "run-e2e-local: RASK_E2E_ALLOW_CONCURRENT=1 — starting alongside it anyway."
+    echo "            Treat any failure as suspect until you have re-run it alone."
+    return 0
+  fi
 
-      while [ -n "$(rask_e2e_lane_holders | tr -d '\n ')" ]; do
-        if [ "$queue_waited_s" -ge "$queue_deadline_s" ]; then
-          echo
-          echo "run-e2e-local: still queued after $((queue_waited_s / 60))m — giving up rather than waiting silently."
-          echo "            The lane is held by:"
-          for pid in $(rask_e2e_lane_holders); do
-            elapsed="$(ps -o etime= -p "$pid" 2>/dev/null | tr -d ' ')"
-            cmd="$(ps -o command= -p "$pid" 2>/dev/null | cut -c1-120)"
-            [ -n "$elapsed" ] && echo "                pid $pid, running for ${elapsed}: $cmd"
-          done
-          echo "            A gate that has outlived the ~40m norm is usually a wedged run, not a busy"
-          echo "            machine — check it before assuming you are merely unlucky."
-          exit 1
-        fi
-        sleep "$queue_poll_s"
-        queue_waited_s=$((queue_waited_s + queue_poll_s))
-        # One line a minute: enough to show the wait is alive inside a hook printing thousands of build
-        # lines, quiet enough not to become the noise it is reporting on.
-        if [ "$((queue_waited_s % 60))" -eq 0 ]; then
-          echo "run-e2e-local: still queued ($((queue_waited_s / 60))m)…"
-        fi
-      done
+  queue_deadline_s="${RASK_E2E_QUEUE_TIMEOUT:-5400}"
+  queue_poll_s="${RASK_E2E_QUEUE_POLL:-20}"
+  queue_waited_s=0
 
-      echo "run-e2e-local: lane free after $((queue_waited_s / 60))m $((queue_waited_s % 60))s — starting."
+  if [ "${RASK_E2E_QUEUE:-1}" = "0" ]; then
+    echo "            Wait for the run above to finish, then push again. To run anyway:"
+    echo "                RASK_E2E_ALLOW_CONCURRENT=1 git push        (or set it for this script)"
+    echo "            and treat any failure as suspect until you have re-run it alone."
+    # A distinct, anchored line for rask_build_failure_kind. It cannot classify on the banner above:
+    # that now prints on runs which go on to QUEUE AND SUCCEED, so keying on it would relabel a
+    # genuine failure hours later as contention.
+    echo "run-e2e-local: refused to start — RASK_E2E_QUEUE=0 and the lane is held."
+    exit 1
+  fi
+
+  echo "run-e2e-local: queued behind it — waiting up to $((queue_deadline_s / 60))m for the slots."
+  echo "            The build and publishes above are already done, so this wait is the suite only."
+  echo "            Ctrl-C to give up; RASK_E2E_QUEUE=0 to refuse immediately instead of waiting;"
+  echo "            RASK_SKIP_E2E=1 to skip the gate entirely."
+
+  # Recomputed FRESH each poll rather than cached. A waiter holding a stale list would keep waiting
+  # for a pid that had already exited and — worse — would miss a gate that started later but outranks
+  # it after a tie-break.
+  while ! rask_lane_fits "$slots_needed"; do
+    if [ "$queue_waited_s" -ge "$queue_deadline_s" ]; then
+      echo
+      echo "run-e2e-local: still queued after $((queue_waited_s / 60))m — giving up rather than waiting silently."
+      echo "            The slots are held by:"
+      rask_e2e_name_seniors
+      echo "            A gate that has outlived the ~40m norm is usually a wedged run, not a busy"
+      echo "            machine — check it before assuming you are merely unlucky."
+      exit 1
     fi
+    sleep "$queue_poll_s"
+    queue_waited_s=$((queue_waited_s + queue_poll_s))
+    # One line a minute: enough to show the wait is alive inside a hook printing thousands of build
+    # lines, quiet enough not to become the noise it is reporting on.
+    if [ "$((queue_waited_s % 60))" -eq 0 ]; then
+      echo "run-e2e-local: still queued ($((queue_waited_s / 60))m)…"
+    fi
+  done
+
+  echo "run-e2e-local: slots free after $((queue_waited_s / 60))m $((queue_waited_s % 60))s — starting the suite."
+}
+
+# Printing WHICH run and HOW LONG is the useful half — "there is a conflict" tells you there is a
+# problem, `ps -o etime=` is what lets you decide whether to wait for it or investigate your own red.
+rask_e2e_name_seniors() {
+  rask_lane_senior_gates | while read -r pid slots; do
+    # Through the same indirected accessors the ordering uses, not a bare `ps`. Two reasons, and the
+    # second is the one that matters: it keeps this testable, and it stops the list going silently
+    # empty. A senior can exit between being ranked and being named, and a bare `ps` then prints
+    # nothing for it — so a refusal could name NOBODY, which is precisely the unexplained kind this
+    # gate has always gone out of its way not to be. The pid is printed either way.
+    elapsed="$(rask_e2e_etime_of "$pid")"
+    cmd="$(rask_e2e_command_of "$pid" | cut -c1-110)"
+    [ -n "$elapsed" ] || elapsed="(exited)"
+    echo "               pid $pid, $slots slot(s), running for ${elapsed}: $cmd"
+  done
+  return 0
+}
+
+# RASK_E2E_QUEUE=0 means "give me my push back rather than the wait", so it has to be answered BEFORE
+# the build, not after it.
+#
+# Splitting this gate by phase moved the only slot check to just above the suite — roughly ten minutes
+# in, by this file's own measurement. That is right for waiting (the wait is then spent having already
+# built) and wrong for refusing: someone who set QUEUE=0 precisely to avoid a delay would have paid the
+# entire build first and only then been told no. The refusal is therefore asked twice, once here where
+# it can still save the ten minutes, and once below for a lane that fills up while we build.
+#
+# Same anchored line both times — scripts/lib/build-failure.sh greps for it to tell a busy machine from
+# a broken branch.
+if [ -z "${CI:-}" ] && [ "${RASK_E2E_QUEUE:-1}" = "0" ] && [ "${RASK_E2E_ALLOW_CONCURRENT:-}" != "1" ]; then
+  if ! rask_lane_fits "$(rask_lane_budget)"; then
+    echo "run-e2e-local: this machine's slots are taken, and the browser suite needs all $(rask_lane_budget)."
+    rask_e2e_name_seniors
+    echo "            Wait for the run above to finish, then push again. To run anyway:"
+    echo "                RASK_E2E_ALLOW_CONCURRENT=1 git push        (or set it for this script)"
+    echo "            and treat any failure as suspect until you have re-run it alone."
+    echo "run-e2e-local: refused to start — RASK_E2E_QUEUE=0 and the lane is held."
+    exit 1
   fi
 fi
+
 
 # shellcheck source=lib/build-failure.sh
 . "$root/scripts/lib/build-failure.sh"
@@ -176,7 +217,11 @@ echo "==> Build the E2E graph once (Release, serial, prebuilt WASM runtime)"
 # browser targets, and reporting that as a broken journey sends people to debug a test that is fine
 # (#718). `set -o pipefail` above is what makes the pipeline report dotnet's status rather than tee's.
 build_log="$(mktemp -t rask-e2e-build.XXXXXX)"
-trap 'rm -f "$build_log"' EXIT
+# rask_lane_release rides along here rather than in a second trap, because a bare `trap ... EXIT`
+# REPLACES any handler already installed — a separate release trap added later would silently destroy
+# this one and leak the build log, or vice versa. Releasing is harmless when no claim was ever made,
+# so this is safe on every exit path including the early ones above.
+trap 'rm -f "$build_log"; rask_lane_release' EXIT
 
 build_status=0
 dotnet build Rask.slnx -c Release -m:1 -p:WasmBuildNative=false 2>&1 | tee "$build_log" || build_status=$?
@@ -290,6 +335,10 @@ fi
 # setting the pre-push hook should ever use.
 #
 #   RASK_E2E_FILTER='FullyQualifiedName~PlaygroundExampleTests' scripts/run-e2e-local.sh
+# The one point in this gate that serialises. Everything above — the preflight, the solution build,
+# the eight sample publishes — ran with a partial claim alongside whatever else the machine was doing.
+rask_e2e_await_slots
+
 e2e_filter="${RASK_E2E_FILTER:-FullyQualifiedName~Rask.Examples.E2E.Tests}"
 if [ -n "${RASK_E2E_FILTER:-}" ]; then
   echo "==> Browser journey E2E (FILTERED: $e2e_filter)"

--- a/scripts/run-unit-local.sh
+++ b/scripts/run-unit-local.sh
@@ -33,6 +33,48 @@ fi
 root="$(git rev-parse --show-toplevel)"
 cd "$root"
 
+# Sourced at the TOP, not inside the failure branch below where the contention hint used to reach for
+# it. A helper that only exists on one branch of an `if` is the shape run-e2e-local.sh argues against:
+# it is loaded exactly when things are already going wrong, which is the worst moment to discover that
+# the load itself is broken.
+# shellcheck source=lib/machine-lane.sh
+. "$root/scripts/lib/machine-lane.sh"
+
+# How much of this machine may we take?
+#
+# This gate NEVER WAITS, and that is a deliberate inheritance from .githooks/pre-commit, which runs it
+# on every commit and decided that a blocked commit costs more than a slow one -- "the person
+# committing is usually not the person who can decide to wait". So instead of queueing, it asks how
+# much room is left and SHRINKS INTO IT. On an idle box that is the full eight slots and nothing has
+# changed; on a box with two other gates running it is two, and the commit still starts immediately.
+#
+# The count goes into ARGV via a one-time re-exec rather than into the environment, because the whole
+# point is that a gate in ANOTHER worktree can read it back out of `ps` and account for it. An
+# environment variable is invisible there. The re-exec happens before any work, so nothing is
+# repeated; the guard is the presence of the flag itself.
+case "${1:-}" in
+  --lane-slots)
+    # ${2:?} rather than $2: with `set -u` a bare $2 aborts with "unbound variable" and no hint, and
+    # this is the one flag the script now advertises in its own argv.
+    lane_slots="${2:?run-unit-local: --lane-slots needs a number}"
+    shift 2
+    ;;
+  *)
+    # An ABSOLUTE path, not "$0". `cd "$root"` above has already moved us, so a relative $0 — which is
+    # what `bash ../scripts/run-unit-local.sh` from a subdirectory gives — no longer resolves, and a
+    # failed exec kills the shell outright rather than falling through. Verified: it dies with
+    # "No such file or directory" and the gate never runs.
+    #
+    # The ceiling comes from rask_lane_unit_max, because that is the number every OTHER gate credits a
+    # unit gate with before this re-exec lands. Hardcoding 8 here meant RASK_LANE_UNIT_MAX=4 would make
+    # readers account for 4 while this took 8 — over-subscribing the box silently, which is the
+    # direction the library says is unsafe.
+    exec "$root/scripts/run-unit-local.sh" --lane-slots "$(rask_lane_fit 2 "$(rask_lane_unit_max)")" "$@"
+    ;;
+esac
+
+echo "run-unit-local: taking $lane_slots of $(rask_lane_budget) slots on this machine."
+
 # Cheap and first: the gates' own shared logic. rask_build_failure_kind decides whether a red gate tells
 # you your branch is broken or your machine is busy, and it is plain bash, so nothing else would catch a
 # regression in it.
@@ -43,7 +85,13 @@ for t in scripts/tests/*.test.sh; do
 done
 
 echo "==> Build once (Release, no WASM bundle: -p:RaskWasm=false -p:WasmBuildNative=false)"
-dotnet build Rask.slnx -c Release -p:RaskWasm=false -p:WasmBuildNative=false -p:MinVerSkip=true
+# -m:$lane_slots is the lever that actually bounds this gate. Left at MSBuild's default it takes every
+# logical core, and three of these running from three worktrees is how the machine reached 35 worker
+# nodes on 14 cores, load average 98, 0.0% idle -- at which point every timing-sensitive test in all
+# three runs was untrustworthy. This was the only gate in the repo without an -m cap; the others all
+# pass -m:1.
+dotnet build Rask.slnx -c Release -m:"$lane_slots" \
+  -p:RaskWasm=false -p:WasmBuildNative=false -p:MinVerSkip=true
 
 echo "==> Source generators in Debug (dotnet format resolves analyzers from the default configuration)"
 for proj in src/*.Generators/*.csproj; do
@@ -80,7 +128,14 @@ echo "==> Unit & integration tests (excludes the browser E2E)"
 # sequence file naming the test in flight and collects a dump, so the next occurrence is diagnosable
 # instead of merely observed. It costs nothing on a green run.
 set +e
-dotnet test Rask.slnx -c Release --no-build \
+# Half the slots here, not all of them, because the other half is spent INSIDE each assembly:
+# tests/xunit.runner.json caps a single assembly at 2 concurrent tests, so (assemblies in flight) x
+# (threads each) lands back on the slot count this gate was granted. Passing the full count to both
+# would square it, which is the shape of the original bug rather than a fix for it.
+test_slots=$((lane_slots / 2))
+[ "$test_slots" -lt 1 ] && test_slots=1
+
+dotnet test Rask.slnx -c Release --no-build -m:"$test_slots" \
   --filter "FullyQualifiedName!~Rask.Examples.E2E$tsc_filter" \
   --blame-crash \
   --results-directory "$root/artifacts/test-blame" \

--- a/scripts/run-watch-e2e.sh
+++ b/scripts/run-watch-e2e.sh
@@ -35,7 +35,20 @@ export RASK_WATCH_E2E=1
 echo "==> Build the test project (MinVer must stamp a real version — the feed is read off the nupkg name)"
 dotnet build tests/Rask.Cli.Tests/Rask.Cli.Tests.csproj -c Release -m:1
 
+# A package cache of the gate's OWN, for the reason run-cli-build-e2e.sh:50-63 spells out: turning on
+# RASK_CLI_BUILD_E2E above also turns on CliBuildE2E.EvictFromGlobalCache, which DELETES
+# ~/.nuget/packages/<pkg>/<version> for all 22 Rask packages. MinVer stamps the same version for the
+# same commit in every worktree, so without this the gate reaches outside its own sandbox and deletes
+# packages another worktree's build is restoring at that moment.
+#
+# That gate got the fix when it was written; this one shares its switch and its feed and was simply
+# missed — the eviction is in the fixture, not in either script, so nothing here named the hazard.
+# Same directory on purpose: the two gates then share what they have already downloaded.
+gate_packages="$root/artifacts/cli-gate-packages"
+mkdir -p "$gate_packages"
+
 echo "==> Watch hot-reload gate (real dotnet watch + a real live session)"
+NUGET_PACKAGES="$gate_packages" \
 dotnet test tests/Rask.Cli.Tests/Rask.Cli.Tests.csproj -c Release --no-build \
   --filter "FullyQualifiedName~WatchHotReloadE2ETests" \
   --logger "console;verbosity=normal"

--- a/scripts/tests/e2e-await-slots.test.sh
+++ b/scripts/tests/e2e-await-slots.test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Table test for run-e2e-local.sh's rask_e2e_await_slots — the one point in the browser gate that
+# decides whether a push proceeds, waits, or stops.
+#
+# scripts/tests/machine-lane.test.sh covers the arithmetic underneath this. What it cannot cover is the
+# WIRING: which branch a given machine state and set of overrides actually reaches, and whether the two
+# output lines scripts/lib/build-failure.sh greps for still come out spelled the way it expects. That
+# last one is worth a test on its own, because getting it wrong is invisible — nothing fails, a
+# contended run is simply relabelled as a genuine failure and someone spends an afternoon on a red that
+# was never in their branch.
+#
+# The function is LIFTED out of the gate rather than sourced, because sourcing run-e2e-local.sh would
+# run it. The lift is checked below, so a rename cannot leave this file passing vacuously.
+#
+# Usage:  scripts/tests/e2e-await-slots.test.sh   (run by scripts/run-unit-local.sh)
+set -uo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+# shellcheck source=../lib/machine-lane.sh
+. "$root/scripts/lib/machine-lane.sh"
+# shellcheck source=../lib/build-failure.sh
+. "$root/scripts/lib/build-failure.sh"
+
+gate="$root/scripts/run-e2e-local.sh"
+lifted="$(sed -n '/^rask_e2e_await_slots() {/,/^}/p' "$gate")"
+lifted_seniors="$(sed -n '/^rask_e2e_name_seniors() {/,/^}/p' "$gate")"
+
+if [ -z "$lifted" ] || [ -z "$lifted_seniors" ]; then
+  echo "e2e-await-slots: could not lift the wait functions out of $gate — were they renamed?" >&2
+  echo "                 This test would otherwise pass without testing anything." >&2
+  exit 1
+fi
+eval "$lifted"
+eval "$lifted_seniors"
+
+# Gate DETECTION is stubbed throughout, and it has to be: this box really does run several gates at
+# once, and an exclusive claim equals the whole budget, so it is admissible only when there are no
+# seniors at all. That is the design rather than something a test can wish away.
+#
+# Note RASK_LANE_PGREP_OVERRIDE="" does NOT mean "no gates" — the library tests it with -n, so an empty
+# value falls through to a real pgrep, deliberately (an unset override must never blind a gate). With
+# the command stub on, pgrep may still return real pids and none of them resolves to a gate, which is
+# what gives a genuinely empty machine.
+#
+# The CLAIM side is real: rask_lane_claim starts an actual scripts/lib/lane-claim.sh child here.
+export RASK_E2E_COMMAND_STUB=1
+export RASK_LANE_SLOTS=10
+eval "export RASK_E2E_ETIME_$$=00:01"
+
+failures=0
+checked=0
+
+assert_eq() {
+  name="$1"
+  actual="$2"
+  expected="$3"
+  checked=$((checked + 1))
+  if [ "$actual" = "$expected" ]; then
+    printf '  ok   %-58s -> [%s]\n' "$name" "$actual"
+  else
+    printf '  FAIL %-58s -> [%s] (expected [%s])\n' "$name" "$actual" "$expected" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+assert_says() {
+  name="$1"
+  haystack="$2"
+  needle="$3"
+  checked=$((checked + 1))
+  if printf '%s' "$haystack" | grep -q -- "$needle"; then
+    printf '  ok   %s\n' "$name"
+  else
+    printf '  FAIL %s (no match for: %s)\n' "$name" "$needle" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+echo "==> rask_e2e_await_slots"
+
+rask_e2e_await_slots >/dev/null 2>&1
+assert_eq "an empty machine admits immediately" "$?" "0"
+rask_lane_release
+
+# Under CI nothing must wait and nothing must be published — this gate has never run there, and a
+# scheduling mechanism is not allowed to be the thing that breaks a future automated path.
+CI=1 rask_e2e_await_slots >/dev/null 2>&1
+assert_eq "CI returns without waiting" "$?" "0"
+assert_eq "CI publishes no claim" "${RASK_LANE_MARKER_PID:-none}" "none"
+
+# One senior holding the entire budget: an exclusive claim cannot fit beside it.
+export RASK_E2E_CMD_31000="bash /repo/scripts/run-e2e-local.sh"
+export RASK_E2E_ETIME_31000="59:00"
+export RASK_LANE_CHILDREN_31000="31001"
+export RASK_E2E_CMD_31001="bash /repo/scripts/lib/lane-claim.sh 31000 10 test"
+
+RASK_LANE_COMMAND_STUB=1 RASK_LANE_DISABLE=1 RASK_LANE_PGREP_OVERRIDE="31000" \
+  rask_e2e_await_slots >/dev/null 2>&1
+assert_eq "RASK_LANE_DISABLE admits even when held" "$?" "0"
+
+out="$(RASK_LANE_COMMAND_STUB=1 RASK_LANE_PGREP_OVERRIDE="31000" RASK_E2E_QUEUE=0 \
+        rask_e2e_await_slots 2>&1)"
+rc=$?
+rask_lane_release
+assert_eq "RASK_E2E_QUEUE=0 refuses rather than waiting" "$rc" "1"
+# Anchored at column 0 and word-for-word: rask_build_failure_kind greps for exactly this.
+assert_says "the refusal prints the anchored line" "$out" '^run-e2e-local: refused to start'
+# A refusal that names nobody is the unexplained kind this gate has always avoided being.
+assert_says "the refusal names the senior and its slots" "$out" 'pid 31000, 10 slot'
+
+out="$(RASK_LANE_COMMAND_STUB=1 RASK_LANE_PGREP_OVERRIDE="31000" RASK_E2E_ALLOW_CONCURRENT=1 \
+        rask_e2e_await_slots 2>&1)"
+rc=$?
+rask_lane_release
+assert_eq "RASK_E2E_ALLOW_CONCURRENT proceeds" "$rc" "0"
+assert_says "and says the result is suspect" "$out" 'starting alongside it anyway'
+
+echo "==> the classifier contract"
+
+# The whole point of the anchored lines. If either is reworded, a contended run stops being reported as
+# 'busy' and starts reading as a real failure, whose advice — look for a failing assertion, a timeout,
+# a host that exited early — is actively wrong about a suite that never started.
+log="$(mktemp -t e2e-await-slots.XXXXXX)"
+printf '%s\n' "run-e2e-local: refused to start — RASK_E2E_QUEUE=0 and the lane is held." > "$log"
+assert_eq "a refusal classifies as busy" "$(rask_build_failure_kind "$log")" "busy"
+printf '%s\n' "run-e2e-local: still queued after 90m — giving up rather than waiting silently." > "$log"
+assert_eq "a queue timeout classifies as busy" "$(rask_build_failure_kind "$log")" "busy"
+rm -f "$log"
+
+echo
+if [ "$failures" -ne 0 ]; then
+  echo "e2e-await-slots: $failures of $checked checks FAILED." >&2
+  exit 1
+fi
+echo "e2e-await-slots: $checked checks passed."

--- a/scripts/tests/e2e-concurrency.test.sh
+++ b/scripts/tests/e2e-concurrency.test.sh
@@ -205,74 +205,9 @@ etime "empty (pid already exited)"    0      ""
 etime "garbage"                       0      "not-a-time"
 etime "partial garbage"               0      "12:ab"
 
-echo
-echo "==> rask_e2e_lane_holders (the FIFO that makes waiting safe)"
-
-# The failure this ordering exists to prevent: a WAITING gate is itself a run-e2e-local.sh process, so
-# it is indistinguishable from the run holding the machine. Two waiters that each "wait until no other
-# gate exists" deadlock; two that each proceed when the holder exits start simultaneously, which is the
-# contention the guard was written to stop. Waiting only for OLDER gates orders them without shared
-# state, so exactly one is released at a time.
-lane() {
-  name="$1"
-  expected="$2"
-  self="$3"
-  actual="$(rask_e2e_lane_holders "$self" 0 | tr '\n' ' ' | sed 's/ *$//')"
-  checked=$((checked + 1))
-  if [ "$actual" = "$expected" ]; then
-    printf '  ok   %-52s -> [%s]\n' "$name" "$actual"
-  else
-    printf '  FAIL %-52s -> [%s] (expected [%s])\n' "$name" "$actual" "$expected" >&2
-    failures=$((failures + 1))
-  fi
-}
-
-export RASK_E2E_COMMAND_STUB=1
-
-# A holder running 5m, and us just started: we wait for it.
-export RASK_E2E_PGREP_OVERRIDE="400"
-export RASK_E2E_CMD_400="bash /repo/scripts/run-e2e-local.sh"
-export RASK_E2E_ETIME_400="05:00"
-export RASK_E2E_ETIME_500="00:02"
-lane "a younger gate waits for the holder" "400" 500
-
-# The holder exits; we are alone. Our turn.
-export RASK_E2E_PGREP_OVERRIDE=""
-lane "nothing older means it is our turn" "" 500
-
-# Two waiters behind one holder. The OLDER waiter (500, 2m) waits only for the holder; the YOUNGER
-# waiter (600, 10s) waits for both. So when the holder exits exactly one is released.
-export RASK_E2E_PGREP_OVERRIDE="400 500 600"
-export RASK_E2E_CMD_500="bash /repo/scripts/run-e2e-local.sh"
-export RASK_E2E_CMD_600="bash /repo/scripts/run-e2e-local.sh"
-export RASK_E2E_ETIME_500="02:00"
-export RASK_E2E_ETIME_600="00:10"
-lane "senior waiter waits only for the holder" "400" 500
-lane "junior waiter waits for holder and senior" "400 500" 600
-
-# Holder gone: the senior is released, the junior still waits for the senior. This is the row that
-# would fail if the ordering were "wait until no other gate exists" (both hang) or "proceed when the
-# holder exits" (both start at once).
-export RASK_E2E_PGREP_OVERRIDE="500 600"
-lane "senior is released when the holder exits" "" 500
-lane "junior still waits for the senior" "500" 600
-
-# A tie on the whole second is plausible when a merge train fires several pushes at once. It breaks on
-# pid so the order is TOTAL — without a tiebreak each would see the other as not-older and both start.
-export RASK_E2E_PGREP_OVERRIDE="700"
-export RASK_E2E_CMD_700="bash /repo/scripts/run-e2e-local.sh"
-export RASK_E2E_ETIME_700="01:00"
-export RASK_E2E_ETIME_800="01:00"
-lane "equal age: lower pid wins" "700" 800
-export RASK_E2E_ETIME_650="01:00"
-lane "equal age: higher pid does not block us" "" 650
-
-# A process that merely mentions the gate is not a holder, so the queue inherits the argv-position
-# rule rather than re-deriving it — an editor open on the script must not stall a push for 90 minutes.
-export RASK_E2E_PGREP_OVERRIDE="900"
-export RASK_E2E_CMD_900="vim /repo/scripts/run-e2e-local.sh"
-export RASK_E2E_ETIME_900="30:00"
-lane "an editor is not a lane holder" "" 500
+# The FIFO ordering rows that used to live here moved to scripts/tests/machine-lane.test.sh along
+# with rask_e2e_lane_holders itself, when the gates moved from one lane to a slot budget. They test
+# rask_lane_senior_gates now -- same rule, same rows, against the implementation that is still live.
 
 unset RASK_E2E_COMMAND_STUB RASK_E2E_PGREP_OVERRIDE
 

--- a/scripts/tests/machine-lane.test.sh
+++ b/scripts/tests/machine-lane.test.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# Table test for scripts/lib/machine-lane.sh.
+#
+# This decides how large every gate on the machine is allowed to be, so both directions cost real
+# money and neither is self-announcing. Handing out too much reproduces the bug the library exists to
+# fix -- 35 MSBuild worker nodes on 14 cores, and a suite whose reds cannot be trusted. Handing out
+# too little makes every gate on a quiet box crawl for no reason, which is how a gate ends up
+# permanently RASK_SKIP'd. Neither shows up as a failure; both show up as "the machine feels wrong".
+# So every row is stated here rather than left to whatever someone happened to try, the same way
+# e2e-concurrency.test.sh and build-failure-kind.test.sh state theirs.
+#
+# Usage:  scripts/tests/machine-lane.test.sh   (run by scripts/run-unit-local.sh)
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+# shellcheck source=../lib/machine-lane.sh
+. "$root/scripts/lib/machine-lane.sh"
+
+# Both stubs on: no real `ps` or `pgrep` is consulted anywhere below, so the table is the whole world
+# and the test cannot be perturbed by whatever else this machine happens to be running -- which
+# matters unusually much here, because the thing under test is a reading of that machine. Nothing in
+# this file spawns a process.
+export RASK_E2E_COMMAND_STUB=1
+export RASK_LANE_COMMAND_STUB=1
+export RASK_LANE_SLOTS=10
+
+failures=0
+checked=0
+
+assert_eq() {
+  name="$1"
+  actual="$2"
+  expected="$3"
+  checked=$((checked + 1))
+
+  if [ "$actual" = "$expected" ]; then
+    printf '  ok   %-58s -> [%s]\n' "$name" "$actual"
+  else
+    printf '  FAIL %-58s -> [%s] (expected [%s])\n' "$name" "$actual" "$expected" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+echo "==> rask_lane_script_of (argv position, never substring)"
+
+assert_eq "the documented invocation, relative" \
+  "$(rask_lane_script_of 'bash scripts/run-e2e-local.sh')" "run-e2e-local.sh"
+assert_eq "absolute, as .githooks/pre-push execs it" \
+  "$(rask_lane_script_of '/bin/bash /repo/scripts/run-unit-local.sh')" "run-unit-local.sh"
+assert_eq "the unit gate after its re-exec" \
+  "$(rask_lane_script_of '/bin/bash /repo/scripts/run-unit-local.sh --lane-slots 4')" "run-unit-local.sh"
+assert_eq "under bash -x, plausible while debugging a gate" \
+  "$(rask_lane_script_of 'bash -x scripts/run-e2e-local.sh')" "run-e2e-local.sh"
+assert_eq "a claim marker" \
+  "$(rask_lane_script_of 'bash /repo/scripts/lib/lane-claim.sh 400 10 test')" "lane-claim.sh"
+# The false positives that made the sibling file exist. An editor and a log are not gates, and
+# counting them would shrink every real gate for as long as the editor stayed open.
+assert_eq "an editor holding the file open" \
+  "$(rask_lane_script_of 'vim scripts/run-e2e-local.sh')" ""
+assert_eq "a tee of the gate's own log" \
+  "$(rask_lane_script_of 'tee /var/folders/T/rask-pre-push-9562/run-e2e-local.log')" ""
+assert_eq "a wrapper shell whose -c text merely names it" \
+  "$(rask_lane_script_of "/bin/zsh -c source /home/u/snap.sh && bash /tmp/x/run-e2e-local.sh")" ""
+assert_eq "an unrelated process" \
+  "$(rask_lane_script_of 'dotnet build Rask.slnx -c Release')" ""
+
+echo "==> rask_lane_declared_cost_of (a claim is read from the marker's argv)"
+
+RASK_LANE_CHILDREN_400="401"
+RASK_E2E_CMD_401="bash /repo/scripts/lib/lane-claim.sh 400 10 test"
+assert_eq "an exclusive claim" "$(rask_lane_declared_cost_of 400)" "10"
+
+RASK_LANE_CHILDREN_402="403"
+RASK_E2E_CMD_403="/bin/bash /r/.claude/worktrees/a/scripts/lib/lane-claim.sh 402 4 build"
+assert_eq "a partial claim from another worktree" "$(rask_lane_declared_cost_of 402)" "4"
+
+# A marker naming somebody else must never be credited here, or one gate's claim would be counted
+# twice and a second gate would be shrunk for a claim it does not hold.
+RASK_LANE_CHILDREN_404="405"
+RASK_E2E_CMD_405="bash /repo/scripts/lib/lane-claim.sh 999 10 test"
+assert_eq "a marker owned by a different gate is ignored" "$(rask_lane_declared_cost_of 404)" ""
+
+RASK_LANE_CHILDREN_406="407"
+RASK_E2E_CMD_407="bash /repo/scripts/lib/lane-claim.sh 406 four test"
+assert_eq "a non-numeric cost is ignored" "$(rask_lane_declared_cost_of 406)" ""
+
+# The phase that used to hold the whole lane for nothing: nine and a half minutes of build and
+# publish before the suite starts at all. No marker, so the gate is on its phase default.
+RASK_LANE_CHILDREN_410="411"
+RASK_E2E_CMD_411="dotnet publish samples/Rask.Example.Playground -c Release -nodeReuse:false"
+assert_eq "a building gate declares nothing" "$(rask_lane_declared_cost_of 410)" ""
+
+assert_eq "a gate with no children declares nothing" "$(rask_lane_declared_cost_of 430)" ""
+
+echo "==> rask_lane_cost_of"
+
+RASK_E2E_CMD_400="bash /repo/scripts/run-e2e-local.sh"
+assert_eq "a declared claim wins over the phase default" "$(rask_lane_cost_of 400)" "10"
+
+RASK_E2E_CMD_410="bash /repo/scripts/run-e2e-local.sh"
+assert_eq "a building gate claims a share, not the box" "$(rask_lane_cost_of 410)" "4"
+
+RASK_E2E_CMD_440="bash /repo/scripts/run-unit-local.sh --lane-slots 3"
+assert_eq "a unit gate reports the size it chose" "$(rask_lane_cost_of 440)" "3"
+
+# The few milliseconds between launch and the re-exec. Counted high, because a gate about to get
+# large is the direction that over-subscribes.
+RASK_E2E_CMD_450="bash /repo/scripts/run-unit-local.sh"
+assert_eq "a unit gate before its re-exec counts as its max" "$(rask_lane_cost_of 450)" "8"
+
+RASK_E2E_CMD_460="bash /repo/scripts/run-unit-local.sh --lane-slots banana"
+assert_eq "a malformed slot count falls back to the max" "$(rask_lane_cost_of 460)" "8"
+
+RASK_E2E_CMD_470="dotnet build Rask.slnx"
+assert_eq "a non-gate claims nothing" "$(rask_lane_cost_of 470)" "0"
+
+echo "==> rask_lane_claimed_by_seniors (only OLDER gates count -- the no-deadlock rule)"
+
+# self = pid 100, aged 60s.
+RASK_E2E_ETIME_100="01:00"
+
+RASK_E2E_CMD_500="bash /repo/scripts/run-unit-local.sh --lane-slots 4"
+RASK_E2E_ETIME_500="05:00"
+assert_eq "one older unit gate" \
+  "$(RASK_LANE_PGREP_OVERRIDE='500' rask_lane_claimed_by_seniors 100 999)" "4"
+
+# A younger gate is invisible to us and we are visible to it. That asymmetry is the whole reason two
+# waiters cannot hang against each other.
+RASK_E2E_CMD_510="bash /repo/scripts/run-unit-local.sh --lane-slots 4"
+RASK_E2E_ETIME_510="00:10"
+assert_eq "a younger gate is not counted" \
+  "$(RASK_LANE_PGREP_OVERRIDE='510' rask_lane_claimed_by_seniors 100 999)" "0"
+
+assert_eq "older and younger together, only the older counts" \
+  "$(RASK_LANE_PGREP_OVERRIDE='500 510' rask_lane_claimed_by_seniors 100 999)" "4"
+
+# Same whole second -- plausible when a merge train fires several pushes at once. Broken on pid so
+# both sides compute the same order and neither concludes it outranks the other.
+RASK_E2E_CMD_50="bash /repo/scripts/run-unit-local.sh --lane-slots 5"
+RASK_E2E_ETIME_50="01:00"
+assert_eq "an equal-aged gate with a lower pid outranks us" \
+  "$(RASK_LANE_PGREP_OVERRIDE='50' rask_lane_claimed_by_seniors 100 999)" "5"
+
+RASK_E2E_CMD_150="bash /repo/scripts/run-unit-local.sh --lane-slots 5"
+RASK_E2E_ETIME_150="01:00"
+assert_eq "an equal-aged gate with a higher pid does not" \
+  "$(RASK_LANE_PGREP_OVERRIDE='150' rask_lane_claimed_by_seniors 100 999)" "0"
+
+assert_eq "self and parent are never counted against us" \
+  "$(RASK_LANE_PGREP_OVERRIDE='100 999' rask_lane_claimed_by_seniors 100 999)" "0"
+
+# A pid that has already exited: ps prints nothing, so it is not a gate and claims nothing. This is
+# exactly the case a lockfile gets wrong, wedging the machine until someone works out what to delete.
+assert_eq "a pid that has already exited claims nothing" \
+  "$(RASK_LANE_PGREP_OVERRIDE='777' rask_lane_claimed_by_seniors 100 999)" "0"
+
+# A senior that is QUEUED for the browser suite has published its claim but has not started
+# `dotnet test` yet. It must already count for the full amount, or a junior slips in and starts work
+# the senior is about to need the whole machine for.
+RASK_E2E_CMD_520="bash /repo/scripts/run-e2e-local.sh"
+RASK_E2E_ETIME_520="09:00"
+RASK_LANE_CHILDREN_520="521"
+RASK_E2E_CMD_521="bash /repo/scripts/lib/lane-claim.sh 520 10 test"
+assert_eq "a senior queued for the browser suite counts in full" \
+  "$(RASK_LANE_PGREP_OVERRIDE='520' rask_lane_claimed_by_seniors 100 999)" "10"
+
+echo "==> rask_lane_headroom"
+
+assert_eq "an empty machine offers the whole budget" \
+  "$(RASK_LANE_PGREP_OVERRIDE='' rask_lane_headroom 100 999)" "10"
+assert_eq "one older build-phase gate leaves six" \
+  "$(RASK_LANE_PGREP_OVERRIDE='500' rask_lane_headroom 100 999)" "6"
+
+# Over-commitment is reachable: an E2E gate declares the whole budget on top of a unit gate that is
+# already running. Clamped at zero, because a negative would propagate into `-m:-3`.
+assert_eq "an over-committed box floors at zero, never negative" \
+  "$(RASK_LANE_PGREP_OVERRIDE='500 520' rask_lane_headroom 100 999)" "0"
+
+echo "==> rask_lane_fit (answers now; never waits, never returns zero)"
+
+assert_eq "a quiet machine, clamped to the caller's max" \
+  "$(RASK_LANE_PGREP_OVERRIDE='' rask_lane_fit 2 8 100 999)" "8"
+assert_eq "a busy machine hands back what is left" \
+  "$(RASK_LANE_PGREP_OVERRIDE='500' rask_lane_fit 2 8 100 999)" "6"
+
+# The row this file exists for. -m:0 means "use every core", so a zero here would make the BUSIEST
+# machine produce the LEAST bounded run -- silently, and in exactly the circumstances where that does
+# the most damage.
+assert_eq "a saturated machine returns the floor, never zero" \
+  "$(RASK_LANE_PGREP_OVERRIDE='500 520' rask_lane_fit 2 8 100 999)" "2"
+assert_eq "the floor is honoured even when asked for one slot" \
+  "$(RASK_LANE_PGREP_OVERRIDE='500 520' rask_lane_fit 1 8 100 999)" "1"
+
+# The global off switch. A new machine-wide gate needs one, and it is the first thing anyone will
+# reach for when it misbehaves.
+assert_eq "RASK_LANE_DISABLE hands back the caller's max" \
+  "$(RASK_LANE_DISABLE=1 RASK_LANE_PGREP_OVERRIDE='500 520' rask_lane_fit 2 8 100 999)" "8"
+
+echo "==> rask_lane_fits (the blocking caller's predicate)"
+
+if RASK_LANE_PGREP_OVERRIDE='' rask_lane_fits 10 100 999; then r=yes; else r=no; fi
+assert_eq "an exclusive claim fits on an empty machine" "$r" "yes"
+
+if RASK_LANE_PGREP_OVERRIDE='500' rask_lane_fits 10 100 999; then r=yes; else r=no; fi
+assert_eq "an exclusive claim does not fit beside a senior" "$r" "no"
+
+if RASK_LANE_PGREP_OVERRIDE='500' rask_lane_fits 6 100 999; then r=yes; else r=no; fi
+assert_eq "exactly the remaining headroom fits" "$r" "yes"
+
+if RASK_LANE_PGREP_OVERRIDE='500' rask_lane_fits 7 100 999; then r=yes; else r=no; fi
+assert_eq "one slot more than the headroom does not" "$r" "no"
+
+# Only juniors are present, so an exclusive claim is admissible: this is the FIFO guarantee, and the
+# reason a full-budget claim can ever be granted at all on a machine that is never idle.
+if RASK_LANE_PGREP_OVERRIDE='510' rask_lane_fits 10 100 999; then r=yes; else r=no; fi
+assert_eq "juniors never block an exclusive claim" "$r" "yes"
+
+# A cost above the budget is clamped, not refused. Without this, lowering RASK_LANE_SLOTS while some
+# caller still asks for 10 would block every browser suite on the machine forever, saying nothing.
+if RASK_LANE_SLOTS=6 RASK_LANE_PGREP_OVERRIDE='' rask_lane_fits 10 100 999; then r=yes; else r=no; fi
+assert_eq "a cost above the budget is clamped, not wedged" "$r" "yes"
+
+if RASK_LANE_DISABLE=1 RASK_LANE_PGREP_OVERRIDE='500 520' rask_lane_fits 10 100 999; then r=yes; else r=no; fi
+assert_eq "RASK_LANE_DISABLE admits everything" "$r" "yes"
+
+echo "==> rask_lane_senior_gates (the FIFO release order)"
+
+# These rows moved here from e2e-concurrency.test.sh with rask_e2e_lane_holders, which they used to
+# cover. The rule is unchanged and so are the cases; only the implementation they exercise is new.
+#
+# The failure this ordering exists to prevent: a WAITING gate is itself a gate process, so it is
+# indistinguishable from the run holding the machine. Two waiters that each "wait until no other gate
+# exists" deadlock; two that each proceed when the holder exits start simultaneously, which is the
+# contention the whole mechanism was written to stop. Waiting only for OLDER gates orders them
+# without shared state, so exactly one is released at a time.
+seniors() {
+  name="$1"
+  expected="$2"
+  self="$3"
+  actual="$(rask_lane_senior_gates "$self" 0 | awk '{print $1}' | tr '\n' ' ' | sed 's/ *$//')"
+  checked=$((checked + 1))
+  if [ "$actual" = "$expected" ]; then
+    printf '  ok   %-58s -> [%s]\n' "$name" "$actual"
+  else
+    printf '  FAIL %-58s -> [%s] (expected [%s])\n' "$name" "$actual" "$expected" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+# A holder running 5m, and us just started: we wait for it.
+export RASK_LANE_PGREP_OVERRIDE="400"
+export RASK_E2E_CMD_400="bash /repo/scripts/run-e2e-local.sh"
+export RASK_E2E_ETIME_400="05:00"
+export RASK_E2E_ETIME_500="00:02"
+seniors "a younger gate waits for the holder" "400" 500
+
+# The holder exits; we are alone. Our turn.
+export RASK_LANE_PGREP_OVERRIDE=""
+seniors "nothing older means it is our turn" "" 500
+
+# Two waiters behind one holder. The OLDER waiter (500, 2m) waits only for the holder; the YOUNGER
+# waiter (600, 10s) waits for both. So when the holder exits exactly one is released.
+export RASK_LANE_PGREP_OVERRIDE="400 500 600"
+export RASK_E2E_CMD_500="bash /repo/scripts/run-e2e-local.sh"
+export RASK_E2E_CMD_600="bash /repo/scripts/run-e2e-local.sh"
+export RASK_E2E_ETIME_500="02:00"
+export RASK_E2E_ETIME_600="00:10"
+seniors "senior waiter waits only for the holder" "400" 500
+seniors "junior waiter waits for holder and senior" "400 500" 600
+
+# Holder gone: the senior is released, the junior still waits for the senior. This is the row that
+# would fail if the ordering were "wait until no other gate exists" (both hang) or "proceed when the
+# holder exits" (both start at once).
+export RASK_LANE_PGREP_OVERRIDE="500 600"
+seniors "senior is released when the holder exits" "" 500
+seniors "junior still waits for the senior" "500" 600
+
+# A tie on the whole second is plausible when a merge train fires several pushes at once. It breaks on
+# pid so the order is TOTAL — without a tiebreak each would see the other as not-older and both start.
+export RASK_LANE_PGREP_OVERRIDE="700"
+export RASK_E2E_CMD_700="bash /repo/scripts/run-e2e-local.sh"
+export RASK_E2E_ETIME_700="01:00"
+export RASK_E2E_ETIME_800="01:00"
+seniors "equal age: lower pid wins" "700" 800
+export RASK_E2E_ETIME_650="01:00"
+seniors "equal age: higher pid does not block us" "" 650
+
+# A process that merely mentions a gate is not one, so the ordering inherits the argv-position rule
+# rather than re-deriving it — an editor open on the script must not stall a push for 90 minutes.
+export RASK_LANE_PGREP_OVERRIDE="900"
+export RASK_E2E_CMD_900="vim /repo/scripts/run-e2e-local.sh"
+export RASK_E2E_ETIME_900="30:00"
+seniors "an editor is not a senior" "" 500
+
+# Mixed kinds: the budget is machine-wide, so a unit gate and a browser gate queue in ONE order. This
+# is the case the old per-script lane could not express at all, and the reason three unit gates could
+# pile onto a live browser suite without anything noticing.
+export RASK_LANE_PGREP_OVERRIDE="400 910"
+export RASK_E2E_CMD_910="bash /repo/scripts/run-unit-local.sh --lane-slots 4"
+export RASK_E2E_ETIME_910="03:00"
+seniors "unit and browser gates share one order" "400 910" 500
+
+unset RASK_LANE_PGREP_OVERRIDE
+
+echo
+if [ "$failures" -ne 0 ]; then
+  echo "machine-lane.test.sh: $failures of $checked checks FAILED." >&2
+  exit 1
+fi
+echo "machine-lane.test.sh: $checked checks passed."

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,36 @@
+<Project>
+
+  <!-- MUST come first, and must not be deleted as redundant. MSBuild stops at the NEAREST
+       Directory.Build.props, so without this import every test project silently loses the repo-root
+       one — warnings-as-errors, the analyzer set, the target framework, all of it — and the build goes
+       green while checking far less than it did. -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFileName)$(MSBuildThisFileExtension), $(MSBuildThisFileDirectory)../))" />
+
+  <!-- Bound how many tests one assembly runs at once.
+
+       This is the second half of the machine's slot budget (scripts/lib/machine-lane.sh). That budget
+       caps how many ASSEMBLIES are in flight, via -m on the gate's `dotnet test`; without a cap in
+       here, each of those assemblies is still free to start a thread per core. xUnit's default
+       maxParallelThreads is the processor count, so the product on this 14-core box was 14 x 14, and
+       three worktrees running the gate at once reached load average 98 at 0.0% idle — at which point
+       every timing-sensitive test in all three runs was untrustworthy.
+
+       Two, not one: the gate halves its slot count for -m and leaves the other half here, so
+       (assemblies in flight) x (threads each) lands back on the budget. One would have serialised the
+       large suites — Rask.Core.Tests alone is ~1,780 facts — and spent the whole gate waiting on its
+       tail. It is a static number because xunit.runner.json is read from beside the assembly, long
+       after the gate has chosen its size; the dynamic half is the -m the gate passes.
+
+       'conservative' matches what tests/Rask.Examples.E2E.Tests already chose: it does not spin up
+       extra threads when a test blocks, which is the behaviour that makes the ceiling mean something.
+
+       Skipped for any project that ships its own file, so the E2E suite keeps its 4 — a browser
+       collection is a published host plus a Chromium page, and it is tuned against the exclusive claim
+       that suite takes rather than against this budget. -->
+  <ItemGroup Condition="'$(MSBuildProjectName)' != '' And !Exists('$(MSBuildProjectDirectory)/xunit.runner.json')">
+    <None Include="$(MSBuildThisFileDirectory)xunit.runner.json"
+          Link="xunit.runner.json"
+          CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppFixture.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace Rask.Examples.E2E.Tests.Infrastructure;
@@ -237,17 +238,39 @@ public abstract class ExampleAppFixture : IAsyncLifetime
         }
 
         // Local-dev fallback: no CI prebuild present, so publish the host on demand into a temp folder.
-        // Keyed on the app alone — it used to carry the port too, which was harmless while ports were
+        // Keyed on the app — it used to carry the port too, which was harmless while ports were
         // constants and would now leave a fresh multi-hundred-megabyte publish behind on every run. Two
         // fixtures booting the same app therefore share one folder, so the publish is serialised: MSBuild
         // writing the same output directory from two processes corrupts it.
-        var publishDir = Path.Combine(Path.GetTempPath(), "rask-e2e-publish", appName);
+        //
+        // And keyed on the WORKTREE as well, because that serialisation is a `lock` and a lock only
+        // reaches the fixtures inside one process. Several worktrees run this suite on one machine, each
+        // its own process, all previously resolving to the same $TMPDIR/rask-e2e-publish/<app> — so the
+        // corruption the comment above rules out within a run was reachable across two runs, publishing
+        // different commits into one directory. The path is what has to differ, since the lock cannot.
+        var publishDir = Path.Combine(Path.GetTempPath(), "rask-e2e-publish", WorktreeKey(repoRoot), appName);
         lock (PublishLocks.GetOrAdd(appName, static _ => new Lock()))
         {
             PublishInto(repoRoot, publishDir);
         }
 
         return RunPublishedDllStartInfo(publishDir, appName);
+    }
+
+    // A short, stable name for the checkout this suite is running from, so two worktrees never share a
+    // publish directory. Hashed rather than derived from the folder name: worktree names are chosen by
+    // whoever created them and can repeat across clones, while the absolute path cannot. Eight hex
+    // characters is far more than enough to separate the handful of checkouts on one machine, and keeps
+    // the path short enough to stay readable when someone goes looking in $TMPDIR.
+    internal static string WorktreeKey(string repoRoot)
+    {
+        // TrimEndingDirectorySeparator before hashing: Path.GetFullPath PRESERVES a trailing separator,
+        // so "/x/Rask" and "/x/Rask/" would otherwise hash differently and one checkout would publish
+        // into two directories. Today's only caller hands over a DirectoryInfo.FullName and never
+        // trails, which is exactly why this would have gone unnoticed until a second caller appeared.
+        var normalized = Path.TrimEndingDirectorySeparator(Path.GetFullPath(repoRoot));
+        var digest = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
+        return Convert.ToHexStringLower(digest)[..8];
     }
 
     // Always re-publishes rather than reusing whatever is in the folder: `dotnet publish` is incremental,

--- a/tests/Rask.Examples.E2E.Tests/WorktreeKeyTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/WorktreeKeyTests.cs
@@ -1,0 +1,71 @@
+using Rask.Examples.E2E.Tests.Infrastructure;
+
+namespace Rask.Examples.E2E.Tests;
+
+// Several worktrees run this suite on one machine, each in its own process, and the on-demand publish
+// directory under $TMPDIR used to be keyed on the app name alone — so they all resolved to the same
+// folder and could publish different commits into it. The in-process `lock` in ExampleAppFixture cannot
+// reach across processes, so the PATH is what has to differ. These pin that it does.
+public class WorktreeKeyTests
+{
+    [Fact]
+    public void Two_checkouts_never_share_a_publish_directory()
+    {
+        var main = ExampleAppFixture.WorktreeKey("/Users/x/RiderProjects/Rask");
+        var linked = ExampleAppFixture.WorktreeKey("/Users/x/RiderProjects/Rask/.claude/worktrees/a");
+
+        Assert.NotEqual(main, linked);
+    }
+
+    // Worktree folder names are chosen by whoever created them and repeat freely across clones, which is
+    // why the key is derived from the absolute path rather than the last segment.
+    [Fact]
+    public void Same_worktree_name_under_different_clones_still_differs()
+    {
+        var first = ExampleAppFixture.WorktreeKey("/Users/x/one/.claude/worktrees/feature");
+        var second = ExampleAppFixture.WorktreeKey("/Users/x/two/.claude/worktrees/feature");
+
+        Assert.NotEqual(first, second);
+    }
+
+    // Stable across calls and across processes: the fallback publish is reused between runs from the same
+    // checkout, so a key that moved would strand a multi-hundred-megabyte publish in $TMPDIR every time.
+    [Fact]
+    public void The_key_is_stable_for_one_checkout()
+    {
+        Assert.Equal(
+            ExampleAppFixture.WorktreeKey("/Users/x/RiderProjects/Rask"),
+            ExampleAppFixture.WorktreeKey("/Users/x/RiderProjects/Rask"));
+    }
+
+    // A "." segment is the same checkout, and must not produce a second copy.
+    [Fact]
+    public void Equivalent_spellings_of_one_path_agree()
+    {
+        Assert.Equal(
+            ExampleAppFixture.WorktreeKey("/Users/x/RiderProjects/Rask"),
+            ExampleAppFixture.WorktreeKey("/Users/x/RiderProjects/./Rask"));
+    }
+
+    // So is a trailing separator — and this one needs its own row rather than riding along with the
+    // "." case, because Path.GetFullPath does NOT normalise it away. Asserting only the "." spelling
+    // let the comment claim a property the code did not have.
+    [Fact]
+    public void A_trailing_separator_is_the_same_checkout()
+    {
+        Assert.Equal(
+            ExampleAppFixture.WorktreeKey("/Users/x/RiderProjects/Rask"),
+            ExampleAppFixture.WorktreeKey("/Users/x/RiderProjects/Rask/"));
+    }
+
+    // Short enough that $TMPDIR stays readable when someone goes looking, and hex so it is always a legal
+    // path segment on every platform.
+    [Fact]
+    public void The_key_is_eight_lowercase_hex_characters()
+    {
+        var key = ExampleAppFixture.WorktreeKey("/Users/x/RiderProjects/Rask");
+
+        Assert.Equal(8, key.Length);
+        Assert.All(key, c => Assert.True(char.IsAsciiDigit(c) || (c >= 'a' && c <= 'f'), $"'{c}' is not lowercase hex"));
+    }
+}

--- a/tests/xunit.runner.json
+++ b/tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "maxParallelThreads": 2,
+  "parallelAlgorithm": "conservative"
+}


### PR DESCRIPTION
## Summary

Eight worktrees share one box here, and the gates went wrong in **both directions at once**.

**Too much at once.** Nothing throttled `run-unit-local.sh` — it was the only gate in the repo without
an `-m` cap, so each run took every core. Three of them running from three worktrees put **35 MSBuild
worker nodes on 14 cores, load average 98 at 0.0% idle, 41 of 48 GB resident**. That is not merely
slow: under that load this repo's timing-sensitive tests fail in ways indistinguishable from real
bugs, so the standing rule is that a green under contention is trustworthy and a red is not. Every
contended run costs a re-run at minimum, and one previously cost an investigation into a test the
change under review could not reach (#850).

**Too little at once.** `run-e2e-local.sh` took the whole machine from its *first line* — before the
build. Measured on a live run: **9m30s of its first 10m12s was build and publish**, roughly a quarter
of the ~40m norm, spent blocking every other worktree while using a single core (that build is
`-m:1`, and stays that way — three targets files shell out to nested `dotnet publish` of the same
projects, so raising it races on output paths rather than speeding anything up).

## What changed

The box publishes **10 slots** — the performance cores, not all 14, so the efficiency cores stay free
and no timing-sensitive test lands somewhere slower than the run that set its timeout.

| gate | claim | blocks? |
|---|---|---|
| `run-unit-local.sh` | whatever is left, floor 2, and **shrinks into it** | **never** |
| `run-e2e-local.sh` — build + publishes | a partial claim | **never** |
| `run-e2e-local.sh` — the browser suite | the whole budget | **yes** — see the exact guarantee below |

The unit gate never waits, because `.githooks/pre-commit` decided long ago that a blocked commit costs
more than a slow one and that still holds — it just gets smaller on a busy box, and says so. Only the
browser suite serialises, and a gate queued for it has already finished building.

**Exactly what "exclusive" buys**, since an earlier draft of this PR over-promised it: two browser
suites never overlap. It does *not* mean an empty machine — a unit gate that started while the browser
gate was **building** is younger, so it is not waited for and keeps its slots. That falls out of the
unit gate never blocking a commit: making the suite wait on unit gates too would let a stream of
commits starve it, since unit gates never queue. The test suite already pinned the real behaviour
(*"juniors never block an exclusive claim"*); it was the prose that was wrong.

Ordering is #934's, generalised to every gate: **you wait only for claims older than yours**, which is
what stops two waiters deadlocking (a waiter is itself a gate process) and what stops anything starving
(a gate's age only grows, so nobody can be inserted ahead of you). Claims are **processes, not files**
(`scripts/lib/lane-claim.sh`) — a file survives `kill -9` and a laptop sleep and then wedges every gate
until someone works out what to delete. A gate *queued* for the suite publishes its claim **before** it
waits: it has not started `dotnet test` yet, so nothing in its process tree would otherwise say what it
is about to need, and a junior would start work the waiter is about to need the whole machine for.

The per-assembly half is a shared `tests/xunit.runner.json`. xUnit defaults to a thread per core, so
bounding assemblies alone still allowed 14 × 14; the gate now spends half its slots across assemblies
and half inside them. The E2E suite keeps its own file — a browser collection is a published host plus
a Chromium page, tuned against the exclusive claim that suite takes.

`rask_e2e_lane_holders` is gone, replaced by the budget's ordering. Two copies of an ordering rule that
must agree is a bug waiting for the day they stop agreeing; its FIFO rows moved to
`machine-lane.test.sh`, against the implementation that is still live.

## Two cross-worktree faults fixed on the way

Both are independent of the above and would be worth landing on their own.

- **`scripts/run-watch-e2e.sh` deleted packages out of the machine-global NuGet cache.** It exports
  `RASK_CLI_BUILD_E2E=1` to share the CLI gate's feed, and that switch also arms
  `CliBuildE2E.EvictFromGlobalCache`, which removes `~/.nuget/packages/<pkg>/<version>` for all 22
  `Rask.*` packages. The eviction is load-bearing (#534) — but MinVer stamps the *same* version for the
  same commit in every worktree, so the deletion reached straight into every other one.
  `run-cli-build-e2e.sh` was given a private `NUGET_PACKAGES` for exactly this and documents it at
  length; the watch gate shares its switch and its feed and was simply missed, because the eviction
  lives in the fixture rather than in either script.
- **Two worktrees published different commits into one directory.** `ExampleAppFixture`'s on-demand
  publish resolved to `$TMPDIR/rask-e2e-publish/<app>`, keyed on the app alone. The comment there
  already stated that two processes writing one MSBuild output directory corrupts it, and guarded with
  a `lock` — but a lock only reaches inside one process, and each worktree's suite is its own. The path
  now carries a hash of the checkout, since the lock cannot be made to reach and the path can.

## Testing

- **Unit gate green on a contended box**, on this branch rebased onto current `main` — 51 assemblies,
  **6,814 cases, 6,764 passed, 50 env-gated skips, 0 failures**, while taking 2 of 10 slots.
- **The cap observed binding**: the gate's build spawned **one** MSBuild worker node, while the
  un-migrated gates on the same box held 28 between them.
- **The budget observed adapting**: `taking 2 of 10 slots` with two seniors, `taking 6 of 10` with one
  senior in its build phase.
- **65 new gate-script checks** — `machine-lane.test.sh` (54) and `e2e-await-slots.test.sh` (11),
  both run by `run-unit-local.sh`. Every `ps`/`pgrep` call is stubbed, so the tables are the whole
  world and cannot be perturbed by what the machine happens to be running.
- Included in those: that `build-failure.sh` **still classifies both anchored queue lines as `busy`**.
  That is the contract deciding whether a red gate reads as a broken branch or a busy machine, and
  breaking it is invisible — nothing fails, the wrong paragraph just prints.
- The claim marker verified against **real processes**: publish, lower, release, and an orphan whose
  owner is gone exiting on its own.
- `tests/Directory.Build.props` verified not to break inheritance —
  `TreatWarningsAsErrors=true`, `EnforceCodeStyleInBuild=true`, `TargetFramework=net10.0` still reach
  test projects — and verified not to shadow the E2E suite's own runner config.

**The push itself is the end-to-end proof.** `pre-push` on this branch, with three older gates on the
box, did exactly what the design intends — note the order:

```
==> Build the E2E graph once (Release, serial, prebuilt WASM runtime)
==> Publish the samples the E2E fixtures boot
==> Ensure Playwright browsers are installed
run-e2e-local: this machine's slots are taken, and the browser suite needs all 10.
run-e2e-local: queued behind it — waiting up to 90m for the slots.
run-e2e-local: still queued (1m)…
run-e2e-local: slots free after 0m 40s — starting the suite.
==> Browser journey E2E (Rask.Examples.E2E.Tests)
     Passed: 77
==> Benchmark gates passed (both payload-bytes baselines + the capacity smokes).
pre-push: CLI build gate SKIPPED — nothing in this push matches the generator paths.
pre-push: watch hot-reload gate SKIPPED — …
pre-push: deploy gate SKIPPED — …
pre-push: install gate SKIPPED — …
```

It **built, published and installed browsers first**, and only then queued — for 8 minutes, for the one
phase that needs the machine. Before this change the same run would have blocked at line 61 and done
nothing at all for those minutes, while the three seniors finished. E2E **77/77**, benchmarks green,
and the four path-filtered gates each said out loud that they skipped and why.

One re-run was needed on the way: a pre-push gate went red on
`SqliteExampleTests.Bulk_import_lands_every_row_on_both_paths` at load 24.8 with another browser gate
live — `#import-result` stuck at "Rows imported so far: 0." for 5s, i.e. **zero progress, not a wrong
value**. Diagnosed per this repo's own checklist rather than assumed: the class passed 4/4 alone, the
assembly 77/77, and the diff's only C# (`WorktreeKey`, which keys the *fallback* publish directory)
provably never executed — `$TMPDIR/rask-e2e-publish` still held the old un-keyed layout, so the
prebuilt publish was used. Contention, not a defect; the retry was clean.

Benchmarks: not applicable — this is gate tooling, no framework or render-hotpath code is touched.

## Review round

`/code-review high` raised ten items; each was reproduced before being fixed, and two were rejected
with reasons rather than silently dropped.

Fixed:

- **`lane-claim.sh` slept in the foreground**, so bash deferred its `TERM` handler and
  `rask_lane_release` blocked for up to a full poll on every gate exit. Measured **28,982 ms** with a
  30 s poll; **4 ms** after backgrounding the sleep and `wait`-ing on it. The comment claiming it
  already terminated promptly was false.
- **`exec "$0"` ran after `cd "$root"`**, so `bash ../scripts/run-unit-local.sh` from a subdirectory
  died with `No such file or directory` — and a failed `exec` takes the shell with it. Absolute path now.
- **The re-exec hardcoded a ceiling of 8** while every reader credited a pre-exec unit gate with
  `rask_lane_unit_max`, so `RASK_LANE_UNIT_MAX=4` would have under-counted a gate still taking 8.
- **`RASK_E2E_QUEUE=0` refused only after the ~10-minute build.** It means "give me my push back", so
  it is now asked once up front as well, with the same anchored line.
- **`WorktreeKey` did not normalise a trailing separator** though a test comment claimed it did —
  `Path.GetFullPath` preserves one, so one checkout could have published into two directories.
- **`--lane-slots` with no value** aborted with `unbound variable` under `set -u`.

Not actionable, with reasons:

- *"`-m` cuts idle-machine concurrency from ~40 assemblies to 4"* — that reduction **is** the fix;
  40 × 14 threads on 10 cores was the oversubscription being removed. But idle-box wall time was never
  measured here (every run was on a contended box), so the constants deserve a measured tune later.
- *"the E2E build phase declares 4 slots but does not bound itself"* — true, and newly reachable, since
  N parallel E2E builds were impossible under the old exclusive lane. Bounded in practice by `-m:1`,
  but a genuine new exposure worth revisiting if it bites.

`/security-review`: **no HIGH or MEDIUM findings.** No network, auth, rendering or user-input surface;
`eval` is confined to the test stubs, keyed on numeric pids, matching the pattern already in
`e2e-concurrency.sh`.

## Follow-ups, filed separately

Three pre-existing faults surfaced while getting this branch green on a rebased tree. None is caused by
this change and none is fixed here:

- **#964** — `Directory.Build.targets:59-68` runs `git config core.hooksPath .githooks` with no
  `--worktree`, so every worktree's build writes the **main checkout's** `.git/config`. Under concurrent
  builds they collide on the lock: `could not lock config file .../.git/config: File exists` →
  `warning MSB3073 ... exited with code 255`, reported against an unrelated project.
- **#965** — a rebase that changes `Rask.External.targets` leaves the gitignored
  `Rask.External.Tasks.dll` stale, and **it blocks its own rebuild** (building the task project loads the
  stale task). The escape is `rm` on the DLL, which nothing in the error suggests.
- **#966** — the island deps check tests whether the `node_modules` *directory* exists, not whether the
  declared packages are in it, so a pull that adds a dependency fails as **19 `TS7026` errors** in a file
  nobody edited, none mentioning npm.

The last two cost two full failed gate runs here, and `git status` stays clean throughout both.

One more, too small to file: `samples/Rask.Example.Server/package-lock.json` mirrors
`"typescript": "~5.9.3"` while its `package.json` declares `"^5.9.3"`, so any `npm install` dirties the
tree with a one-line correction. Functionally inert — `package.json` is authoritative for resolution —
and reverted here rather than smuggled into a gates PR, but worth a one-line commit of its own.
