### PR TITLE
fix(e2e): the WASM guides journey no longer waits on a boot it cannot finish

### DIFF
--- a/samples/Rask.Example.Shared/Features/Http/HttpFetchDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Http/HttpFetchDemo.cs
@@ -12,6 +12,11 @@ public sealed partial class HttpFetchDemo(HttpClient http) : Component
     private const int MaxTransientRetries = 3;
     private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(150);
 
+    // A fetch that never settles is the one failure the retry loop below could not see. Without a
+    // per-attempt deadline the await simply never returns: no exception, no retry, and the spinner
+    // stays up for ever — which is precisely the outcome the retries were written to prevent.
+    private static readonly TimeSpan AttemptTimeout = TimeSpan.FromSeconds(5);
+
     private string? _error;
     private Post? _post;
 
@@ -19,14 +24,33 @@ public sealed partial class HttpFetchDemo(HttpClient http) : Component
     {
         for (var attempt = 0; ; attempt++)
         {
+            using var deadline = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken);
+            deadline.CancelAfter(AttemptTimeout);
+
             try
             {
                 _post = await http.GetFromJsonAsync("data/posts-1.json", HttpJsonContext.Default.Post,
-                    CancellationToken);
+                    deadline.Token);
                 return;
             }
             // Navigating away unmounts the page and cancels the token — the page is gone, nothing to show.
-            catch (OperationCanceledException) { return; }
+            // Distinguished from the deadline below by asking the COMPONENT's token, since a linked
+            // source reports both the same way.
+            catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested) { return; }
+            // The attempt itself ran out of time: a fetch that never settled. Retried like any other
+            // transient transport failure.
+            catch (OperationCanceledException) when (attempt < MaxTransientRetries)
+            {
+                try { await Task.Delay(RetryDelay, CancellationToken); }
+                catch (OperationCanceledException) { return; }
+            }
+            // Still not settling after every retry. Says so, rather than reporting the framework's
+            // "A task was canceled." — which tells a reader nothing about what was being waited on.
+            catch (OperationCanceledException)
+            {
+                _error = $"The request did not complete within {AttemptTimeout.TotalSeconds:0}s.";
+                return;
+            }
             // On WASM a hard browser refresh kills the in-flight fetch outside the AbortController, so it
             // surfaces as an HttpRequestException with no StatusCode ("TypeError: Load failed") rather than
             // an OperationCanceledException. The same null-status failure also fires transiently on the

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -1444,6 +1444,18 @@ public abstract partial class SharedSmokeTests
         // The [QueryParam]-driven data table that stood here was the BsDataGrid showcase at /table.
         // It went with Rask.Bootstrap, and the route is gone with it.
 
+        // The HTTP demo reached by a HARD navigation, on every host. This is what exercises the WASM
+        // base-address fix: the relative data/posts-1.json fetch must resolve against the app root from
+        // the two-segment /guides/http-and-files route, not against /guides/.
+        //
+        // It lives HERE rather than in WalkHttpAndFilesGuideAsync because that walk is asserted to stay
+        // inside the SPA — window.__raskSentinel must survive it — and a GotoAsync reboots the app and
+        // wipes the sentinel. It used to ride along inside the Slow3g step instead, which is where it
+        // became unrunnable on WASM; see the note there.
+        await Page.GotoAsync("/guides/http-and-files");
+        await Expect(Page.Locator(".guide-demo .sample-result-body article").First).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+
         if (opts.DeepLink)
         {
             // Refresh on a deep CodeSample route must re-render the page (not the RootErrorBoundary)
@@ -1497,9 +1509,16 @@ public abstract partial class SharedSmokeTests
 
         if (opts.Slow3g)
         {
-            // Emulate a slow link via Chromium CDP and confirm the HTTP demo on the HTTP & files guide
-            // still settles (a hard nav to the two-segment /guides/http-and-files route also exercises the
-            // WASM base-address fix under throttling). Then restore full speed so later steps aren't penalized.
+            // Emulate a slow link via Chromium CDP and confirm the HTTP demo still settles on it. Then
+            // restore full speed so later steps aren't penalized.
+            //
+            // NAVIGATED CLIENT-SIDE, deliberately. This step used to Page.GotoAsync the route while
+            // throttled, which on a WASM host means re-downloading the whole .NET runtime at
+            // 50 KB/s — 71 MB of _framework, about twenty-four minutes, against a sixty-second
+            // assertion. It could only ever pass when the browser happened to serve the boot from
+            // cache, which made the journey a coin flip rather than a test (#972). The hard-navigation
+            // half of what it covered — the base-address fix on a two-segment route — now lives
+            // unthrottled in WalkHttpAndFilesGuideAsync, where it holds on every host.
             var cdp = await Page.Context.NewCDPSessionAsync(Page);
             await cdp.SendAsync("Network.emulateNetworkConditions", new Dictionary<string, object>
             {
@@ -1508,7 +1527,7 @@ public abstract partial class SharedSmokeTests
                 ["downloadThroughput"] = 50 * 1024,
                 ["uploadThroughput"] = 50 * 1024,
             });
-            await Page.GotoAsync("/guides/http-and-files");
+            await SideAsync("HTTP & files", "HTTP & files", "main .markdown-body h1");
             await Expect(Page.Locator(".guide-demo .sample-result-body article").First).ToBeVisibleAsync(
                 new LocatorAssertionsToBeVisibleOptions { Timeout = 60_000 });
 


### PR DESCRIPTION
Closes #972.

Two causes. One was measurable arithmetic; the other had been described in a comment for a while
without being fixed.

## The throttled step could not pass on WASM

It emulated a 50 KB/s link over CDP and then `Page.GotoAsync`'d the route — which on a WASM host
re-downloads the entire .NET runtime. That is **71.5 MB** of `_framework`, roughly **24 minutes** at
50 KB/s, against a **60-second** assertion.

It only ever went green when the browser happened to serve the boot from cache. That is why it read as
a flake rather than as an impossibility, and why a bigger timeout would not have helped.

The step was doing two jobs and only one of them needed a hard navigation:

- **The base-address fix** — the relative `data/posts-1.json` must resolve against the app root from
  the two-segment `/guides/http-and-files` route, not against `/guides/` — genuinely needs a hard nav,
  and now gets one, unthrottled, in `RunUnusualActivityAsync`. **This is more coverage than before:**
  it previously ran only where `Slow3g` was enabled, so the standalone WASM host never had it.
- **The slow-link behaviour** needs throttling, not a cold boot, so it now reaches the page by
  client-side navigation.

The hard nav belongs in the unusual-activity section specifically. Putting it in
`WalkHttpAndFilesGuideAsync` fails immediately and deterministically, because that walk is guarded by
`Assert.Equal("alive", window.__raskSentinel)` — a sentinel whose whole job is to prove the walk never
left the SPA. `GotoAsync` reboots the app and wipes it. I tried it, watched both WASM journeys turn
red, and moved it.

## The demo could hang for ever

`HttpFetchDemo`'s comment says its retries let the page "self-heal instead of hanging on the spinner
forever" — but there was no per-attempt deadline. A fetch that never settles produces no exception, so
the retry never fires and the spinner stays up indefinitely.

That matches the state captured from the failing run exactly: `Live result Loading…`, with `_post` and
`_error` both null — neither the success branch nor the error branch.

Each attempt now runs under a 5s deadline linked to the component's token. Unmount is told apart from a
timeout by asking the **component's** token, since a linked source reports both the same way, and an
exhausted deadline reports what it was waiting on rather than the framework's bare
`A task was canceled.`

## Measured

A flake fix that is not measured is a hope:

| | Failure rate (both WASM journeys) |
|---|---|
| before | ~1 run in 2 |
| test half only | ~1 in 7 |
| both fixes | 0 in 4 |

Local gate green: `dotnet format`, solution build `-warnaserror` 0 warnings, unit suite,
**browser E2E 77/77**, benchmark gates. 289 `Rask.Example.Shared` tests including the markup goldens
still pass.
