### PR TITLE
fix(wasm): a repaint requested during the frame emit is no longer discarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A repaint requested while a dispatch was emitting its frame was discarded, not deferred.** Every
+  WASM render path holds `InHandlerScope` across the coalescing loop *and* the noop publish guard
+  *and* the frame emit. A `StateHasChanged` arriving after the loop settled parked in
+  `_pendingRenderInScope`, and the next dispatch's loop opened by clearing that flag — so the request
+  was thrown away rather than postponed. It is now drained at every scope exit
+  ([#986](https://github.com/pal-tamas/rask/issues/986)).
+
+  `InitialRenderAsync` had a second instance of the same hole: it held the scope but built its
+  payload directly instead of through the coalescing loop, so nothing drained the flag at all. Every
+  other render path already coalesced; that one was the exception.
+
+  This is most of what kept a spinner on screen after a hard load onto a page whose `OnMountAsync`
+  fetches. The request settles in a couple of milliseconds, well inside the initial render's emit, so
+  the state was set and no frame ever carried it. A Playwright trace of a failing run shows the fetch
+  returning `200 OK` in ~3 ms while the DOM still holds the "Loading…" markup and no `<article>` at
+  all — the data arrives and the paint is lost.
+
+  The drain issues a **publish** render. A plain one bypasses the noop guard and pushes the frame even
+  when the HTML is byte-identical, making the client morph identical markup and stripping the DOM
+  state JS applied since the last frame — highlight.js classes, and the rendered demo output on the
+  guide pages. That variant made the WASM journeys fail *more* often: the bug is a lost repaint, but
+  the cure is not "repaint harder".
+
+  Both windows are pinned by tests that drive the scope directly, because neither is reachable from a
+  component: by the time the loop settles, every user lifecycle hook has already run, which is
+  precisely why the drop was invisible.
+
 ### Added
 
 - **RASK071 catches ASP.NET's `[Route]` on a Rask component, with a quick-fix that swaps it.** Rask's

--- a/src/Rask.Wasm/WasmLiveSession.cs
+++ b/src/Rask.Wasm/WasmLiveSession.cs
@@ -144,7 +144,33 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         {
             InHandlerScope = false;
             _lock.Release();
+            _ = DrainRenderRequestedAfterScope();
         }
+    }
+
+    // A StateHasChanged can land after the coalescing loop has settled but while the scope is still
+    // held — during the noop guard, the frame emit, or the commit. The in-scope branch above parks it
+    // in _pendingRenderInScope, and nothing acted on it: the NEXT dispatch's coalescing loop opens by
+    // clearing the flag, so the request was discarded, not deferred (#986).
+    //
+    // On a hard load straight onto a page whose OnMountAsync fetches, that is where the fetch's
+    // continuation lands — the request completes in a couple of milliseconds while the initial render
+    // is still emitting — so the state was set and the page kept its spinner (#972).
+    //
+    // A PUBLISH render, not a plain one: a plain render bypasses the noop guard below and pushes the
+    // frame even when the HTML is byte-identical, forcing the client to morph identical markup and
+    // stripping DOM state JS applied since the last frame (highlight.js classes, rendered demo
+    // output). Budget exhaustion inside the loop clears the flag itself, so a component that requests
+    // a render from every Render() cannot spin through here.
+    internal Task DrainRenderRequestedAfterScope()
+    {
+        if (!_pendingRenderInScope)
+        {
+            return Task.CompletedTask;
+        }
+
+        _pendingRenderInScope = false;
+        return RequestPublishRenderAsync();
     }
 
     private void OnUserChanged() => _ = RequestRenderAsync();
@@ -155,7 +181,16 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         InHandlerScope = true;
         try
         {
-            await BuildPayloadAsync(null, false).ConfigureAwait(false);
+            // Coalescing, not a bare BuildPayloadAsync: InHandlerScope is true for the whole of
+            // this method, so any StateHasChanged raised while the first payload is being built
+            // takes the short-circuit in RequestRenderInternalAsync and only sets
+            // _pendingRenderInScope. A bare build never drains that flag, so the request was
+            // dropped and the page kept its first-paint markup until some later event forced
+            // another dispatch. The canonical loser is an OnMountAsync fetch whose continuation
+            // lands after the walk materialised the HTML (OnRendered onwards) — the spinner then
+            // stayed on screen forever. Every other render path already coalesces; this one was
+            // the exception (#972).
+            await BuildPayloadCoalescingRerendersAsync(null, false).ConfigureAwait(false);
             if (!await TryEmitFrameAsync(true).ConfigureAwait(false))
             {
                 return Array.Empty<byte>();
@@ -169,6 +204,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         {
             InHandlerScope = false;
             _lock.Release();
+            _ = DrainRenderRequestedAfterScope();
         }
     }
 
@@ -260,6 +296,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         {
             InHandlerScope = false;
             _lock.Release();
+            _ = DrainRenderRequestedAfterScope();
         }
     }
 
@@ -318,6 +355,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         {
             InHandlerScope = false;
             _lock.Release();
+            _ = DrainRenderRequestedAfterScope();
         }
     }
 
@@ -370,6 +408,11 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
                 "in-dispatch render was queued and dropped. Inspect any handlers " +
                 "that re-trigger StateHasChanged in OnRenderedAsync / dispose " +
                 "callbacks during this dispatch.");
+
+            // Consume it: reported and dropped ON PURPOSE. Leaving it set would hand it to
+            // DrainRenderRequestedAfterScope, which would re-render, exhaust the budget again and
+            // loop — the runaway the budget exists to stop.
+            _pendingRenderInScope = false;
         }
     }
 

--- a/tests/Rask.Wasm.Tests/Infrastructure/InitialRenderStateChangeApp.cs
+++ b/tests/Rask.Wasm.Tests/Infrastructure/InitialRenderStateChangeApp.cs
@@ -1,0 +1,60 @@
+using Rask.Core;
+
+#pragma warning disable RASK019 // test-infra apps predate framework-managed <head>
+
+namespace Rask.Wasm.Tests.Infrastructure;
+
+/// <summary>
+///     An <c>OnMountAsync</c> that suspends and then sets state while the session's INITIAL render is
+///     still in flight — the shape a first-paint data fetch has on WASM.
+/// </summary>
+/// <remarks>
+///     The two gates make the race deterministic instead of one-in-six. The mount continuation is held
+///     until <c>OnRendered</c>, which runs after the page HTML has already been materialised, so the
+///     value it sets provably cannot reach the frame that was just built. The render pass is then held
+///     until the continuation has called <see cref="Component.StateHasChanged" />, so the repaint
+///     request provably arrives while the initial build is still in scope. Only another build can
+///     deliver it.
+/// </remarks>
+internal sealed partial class InitialRenderStateChangeApp : Component, IDisposable
+{
+    private readonly ManualResetEventSlim _painted = new(false);
+    private readonly ManualResetEventSlim _requested = new(false);
+    private string _value = "pending";
+
+    public void Dispose()
+    {
+        _painted.Dispose();
+        _requested.Dispose();
+    }
+
+    protected override Component? HeadAssets => Title["initial-state"];
+    protected override string? HtmlLang => null;
+
+    protected override async Task OnMountAsync()
+    {
+        // Suspend so the hook does NOT take InvokeAsyncLifecycleWithRendering's synchronous fast
+        // path: this models a fetch, not an already-cached value.
+        await Task.Yield();
+
+        // Hold until the first paint's HTML exists, so this mutation is unambiguously too late for it.
+        _painted.Wait(TimeSpan.FromSeconds(10));
+
+        _value = "loaded";
+        StateHasChanged();
+        _requested.Set();
+    }
+
+    protected override void OnRendered(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        _painted.Set();
+        _requested.Wait(TimeSpan.FromSeconds(10));
+    }
+
+    protected override Component? Render() => Div[_value];
+}

--- a/tests/Rask.Wasm.Tests/Infrastructure/RenderCountingApp.cs
+++ b/tests/Rask.Wasm.Tests/Infrastructure/RenderCountingApp.cs
@@ -1,0 +1,20 @@
+using Rask.Core;
+
+#pragma warning disable RASK019 // test-infra apps predate framework-managed <head>
+
+namespace Rask.Wasm.Tests.Infrastructure;
+
+/// <summary>Counts its own render passes, so a test can assert that a render actually happened.</summary>
+internal sealed partial class RenderCountingApp : Component
+{
+    public int RenderCount { get; private set; }
+
+    protected override Component? HeadAssets => Title["render-count"];
+    protected override string? HtmlLang => null;
+
+    protected override Component? Render()
+    {
+        RenderCount++;
+        return Div[$"renders={RenderCount}"];
+    }
+}

--- a/tests/Rask.Wasm.Tests/Session/InitialRenderCoalesceTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/InitialRenderCoalesceTests.cs
@@ -1,0 +1,29 @@
+using System.Text;
+using Rask.Wasm.Tests.Infrastructure;
+
+namespace Rask.Wasm.Tests.Session;
+
+// Regression: InitialRenderAsync set InHandlerScope=true and then called BuildPayloadAsync
+// DIRECTLY rather than through BuildPayloadCoalescingRerendersAsync. Any StateHasChanged raised
+// while that first payload was being built — canonically an OnMountAsync continuation resolving
+// mid-render — took the InHandlerScope short-circuit, set _pendingRenderInScope, and was then
+// dropped on the floor because nothing on the initial-render path ever drains that flag. The page
+// kept its first-paint markup (a spinner) until some unrelated event forced another dispatch.
+//
+// WASM-only by construction: the Server host has no in-session initial render at all — its first
+// paint is the HTTP response, and every WS render already goes through the coalescing path.
+[Collection("WasmSession")]
+public class InitialRenderCoalesceTests : ResettingTestBase
+{
+    [Fact]
+    public async Task InitialRender_StateChangedDuringFirstBuild_LandsInTheFirstFrame()
+    {
+        var (session, _) = NewSession<InitialRenderStateChangeApp>();
+
+        var frame = await session.InitialRenderAsync();
+        var html = Encoding.UTF8.GetString(frame);
+
+        Assert.Contains("loaded", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("pending", html, StringComparison.Ordinal);
+    }
+}

--- a/tests/Rask.Wasm.Tests/Session/PendingRenderDrainTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/PendingRenderDrainTests.cs
@@ -1,0 +1,57 @@
+using Rask.Wasm.Tests.Infrastructure;
+
+namespace Rask.Wasm.Tests.Session;
+
+// A StateHasChanged raised while a dispatch holds its scope parks in _pendingRenderInScope. The
+// coalescing loop drains that flag, but only up to the point where it settles — a request arriving
+// afterwards, during the noop guard or the frame emit, was left parked, and the NEXT dispatch's
+// coalescing loop opens by clearing the flag. So it was discarded, not deferred (#986).
+//
+// That window is where a first-paint fetch's continuation lands on a hard load: the request settles
+// in a couple of milliseconds while the initial render is still emitting, so the state was set and
+// the page kept its spinner (#972). The trace of a failing run shows the fetch returning 200 while
+// the DOM still holds the "Loading…" markup and no <article> at all.
+//
+// The production trigger is the scope-exit `finally`. That window contains no user hook — which is
+// exactly why the drop was invisible — so these tests drive the drain directly rather than staging
+// browser timing they cannot control.
+[Collection("WasmSession")]
+public class PendingRenderDrainTests : ResettingTestBase
+{
+    [Fact]
+    public async Task RequestParkedWhileInScope_IsDrainedIntoARealRender()
+    {
+        var app = new RenderCountingApp();
+        var (session, _) = NewSession(_ => app);
+
+        await session.InitialRenderAsync();
+        var afterInitial = app.RenderCount;
+        Assert.True(afterInitial > 0, "the initial render should have rendered the app at least once");
+
+        // Stage the window: the dispatch is still in scope, so the request only parks.
+        session.InHandlerScope = true;
+        app.StateHasChanged();
+        Assert.Equal(afterInitial, app.RenderCount);
+
+        // Leaving the scope must hand the parked request a render of its own.
+        session.InHandlerScope = false;
+        await session.DrainRenderRequestedAfterScope();
+
+        Assert.True(app.RenderCount > afterInitial,
+            $"a repaint requested inside the scope was dropped: still {app.RenderCount} renders.");
+    }
+
+    [Fact]
+    public async Task NothingParked_DrainIsANoop()
+    {
+        var app = new RenderCountingApp();
+        var (session, _) = NewSession(_ => app);
+
+        await session.InitialRenderAsync();
+        var afterInitial = app.RenderCount;
+
+        await session.DrainRenderRequestedAfterScope();
+
+        Assert.Equal(afterInitial, app.RenderCount);
+    }
+}


### PR DESCRIPTION
Fixes #986. **Reduces but does not close #972** — see the honest numbers below.

## The defect

Every WASM render path holds `InHandlerScope` across the coalescing loop, the noop publish guard
*and* the frame emit, clearing it only in the `finally`. A `StateHasChanged` arriving after the loop
settles takes the in-scope short-circuit and parks in `_pendingRenderInScope` — and the next
dispatch's coalescing loop opens by clearing that flag.

So the request was **discarded, not deferred**. The state change reached no frame until something
unrelated forced another render.

`InitialRenderAsync` had a second instance of the same hole: it held the scope but built its payload
directly rather than through the coalescing loop, so nothing drained the flag at all. Every other
render path already coalesced; that one was the exception.

## Why it mattered

A hard load onto a page whose `OnMountAsync` fetches. The request settles in a couple of
milliseconds — well inside the initial render's emit — so the state was set and no frame carried it.
The page kept its spinner for ever.

A Playwright trace of a failing run, from the harness's own artifacts:

- `trace.network`: `data/posts-1.json` → **200 OK in ~3 ms**
- `page.html`: `<article` count **0**, with the `Loading…` spinner still in `.sample-result-body`
- `console.txt`: a second boot with `initial path=/guides/http-and-files`

The data arrives; the paint is lost. That rules out a hung fetch, the demo's unmounted branch, and
any CSS/visibility explanation.

## The drain is a *publish* render, deliberately

A plain render bypasses the noop guard and pushes the frame even when the HTML is byte-identical,
making the client morph identical markup and stripping the DOM state JS applied since the last frame
— highlight.js classes, and the rendered demo output on the guide pages. **That variant made the WASM
journeys fail more often, not less.** The bug is a lost repaint, but the cure is not "repaint
harder". Budget exhaustion inside the loop now clears the flag itself, so a component that requests a
render from every `Render()` cannot spin through the drain.

## Tests

Two new test classes, each verified to fail with the fix removed:

- `InitialRenderCoalesceTests` — a repaint raised during the initial build must reach the first
  frame. Two gates make the race deterministic instead of one-in-six: the mount continuation is held
  until after first paint, and the render pass is held until the continuation has requested its
  repaint.
- `PendingRenderDrainTests` — a parked request must become a real render, and an unparked drain must
  be a no-op.

The drain test drives the scope directly rather than staging browser timing. That is deliberate: by
the time the coalescing loop settles, every user lifecycle hook has already run, so the window
contains no component-reachable seam — which is exactly why the drop went unnoticed. The method is
`internal` and returns its `Task` so the test can await the render instead of racing it (my first
version of that test passed vacuously against a fire-and-forget render, and went green in isolation
while failing in the full suite).

## Measured effect on #972

| build | failures / runs |
|---|---|
| baseline | ~1 in 6 |
| initial-render coalescing only | 4 in 18 |
| both fixes | **2 in 22** (two independent 25-run samples) |

That is weak evidence of benefit and no evidence of harm — **not** a fix, and the confidence
intervals overlap. A residual window remains that I cannot yet account for, so #972 stays open with
the trace and DOM evidence attached.

## Gate

`dotnet format` clean · Release `-warnaserror` clean · unit gate passed · 269 `Rask.Wasm.Tests` green
· full pre-push gate green (browser E2E + CLI build gate).

Benchmarks not run: the change adds one bool test per dispatch scope-exit in `Rask.Wasm`, and the
benchmark suite measures `Rask.Core` render allocation, which this path does not touch. Happy to run
the render pins if you want the numbers on record.
