### PR TITLE
fix(cli): the first migration no longer runs a production front-end build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ them until tagged releases begin.
 
 ### Fixed
 
+- **`rask new` ran a production front-end build during scaffolding.** With the batteries on, `rask new`
+  creates the first migration, and `dotnet-ef` builds the project to load the `DbContext`. That build
+  took `RaskSpaBuild` / `RaskMetaBuild` at their default of `true`, so scaffolding a front-end template
+  ran the bundler — or, on the meta lane, a full Nuxt/Next/SvelteKit **production** build — behind a
+  line that says "Creating the first migration…" and nothing else
+  ([#991](https://github.com/pal-tamas/rask/issues/991)).
+
+  Minutes of silence for output nobody reads: the next thing anyone does is `rask dev`, which turns
+  both properties off again and lets the framework's own dev server own the front end. Worse, a
+  machine without node failed the migration step for a reason that has nothing to do with the
+  database.
+
+  The first migration now runs with both properties off. MSBuild reads properties from the
+  environment, which is how they reach a build whose command line belongs to `dotnet-ef` — the same
+  channel `rask dev` already uses for `HotReloadAutoRestart` — so `rask db`'s argument surface is
+  untouched and every other invocation of it is unchanged.
+
 - **A repaint requested while a dispatch was emitting its frame was discarded, not deferred.** Every
   WASM render path holds `InHandlerScope` across the coalescing loop *and* the noop publish guard
   *and* the frame emit. A `StateHasChanged` arriving after the loop settled parked in

--- a/src/Rask.Cli/Commands/DbCommand.cs
+++ b/src/Rask.Cli/Commands/DbCommand.cs
@@ -10,9 +10,22 @@ namespace Rask.Cli.Commands;
 /// directory and installing the <c>dotnet-ef</c> tool on first use if it's missing. Anything after
 /// <c>--</c> is forwarded to <c>dotnet ef</c> verbatim (an escape hatch for <c>--verbose</c> etc.).
 /// </summary>
-internal sealed partial class DbCommand(IConsole console, IFileSystem fileSystem, IProcessRunner process, string workingDirectory)
+/// <param name="buildEnvironment">
+///     Overlaid onto the environment of the <c>dotnet-ef</c> child process, which is how MSBuild
+///     properties reach a build this command does not own the command line of. <c>rask new</c> passes
+///     <c>RaskSpaBuild=false</c> / <c>RaskMetaBuild=false</c> so scaffolding's first migration does not
+///     run a production front-end build. Null — no overlay — everywhere else.
+/// </param>
+internal sealed partial class DbCommand(
+    IConsole console,
+    IFileSystem fileSystem,
+    IProcessRunner process,
+    string workingDirectory,
+    IReadOnlyDictionary<string, string>? buildEnvironment = null)
     : CliCommand(console)
 {
+    private readonly IReadOnlyDictionary<string, string>? _buildEnvironment = buildEnvironment;
+
     // These two never touch EF: they copy a file through SQLite (locally) or through a container on
     // the host, so they must not pay for a dotnet-ef install, and must work on an app that has none.
     private static readonly string[] FileSubcommands = ["backup", "restore"];
@@ -238,7 +251,8 @@ internal sealed partial class DbCommand(IConsole console, IFileSystem fileSystem
             return await ListAsJsonAsync(efArgs, cancellationToken).ConfigureAwait(false);
         }
 
-        return await _process.RunAsync("dotnet", efArgs, _workingDirectory, cancellationToken).ConfigureAwait(false);
+        return await _process.RunAsync("dotnet", efArgs, _workingDirectory, cancellationToken, _buildEnvironment)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -255,7 +269,7 @@ internal sealed partial class DbCommand(IConsole console, IFileSystem fileSystem
     private async Task<int> ListAsJsonAsync(IReadOnlyList<string> efArgs, CancellationToken cancellationToken)
     {
         var result = await _process
-            .CaptureAsync("dotnet", [.. efArgs, "--json"], _workingDirectory, cancellationToken)
+            .CaptureAsync("dotnet", [.. efArgs, "--json"], _workingDirectory, cancellationToken, _buildEnvironment)
             .ConfigureAwait(false);
 
         if (result.ExitCode != 0)

--- a/src/Rask.Cli/Commands/NewCommand.cs
+++ b/src/Rask.Cli/Commands/NewCommand.cs
@@ -793,6 +793,17 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
     /// <c>--project</c> is passed explicitly for the reason given on <see cref="PickEfProject"/>.
     /// </para>
     /// </remarks>
+    /// <summary>
+    ///     MSBuild reads properties from the environment, which is how these reach a build whose command
+    ///     line belongs to <c>dotnet-ef</c>. Same channel <c>rask dev</c> uses for
+    ///     <c>HotReloadAutoRestart</c>, and it leaves <c>rask db</c>'s argument surface alone.
+    /// </summary>
+    private static readonly Dictionary<string, string> SkipFrontEndBuild = new(StringComparer.Ordinal)
+    {
+        ["RaskSpaBuild"] = "false",
+        ["RaskMetaBuild"] = "false",
+    };
+
     private async Task<bool> CreateFirstMigrationAsync(
         string targetDirectory, string? efProject, CancellationToken cancellationToken)
     {
@@ -801,7 +812,14 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
             return false;
         }
 
-        var db = new DbCommand(Console, _fileSystem, _process, targetDirectory);
+        // Skip the front-end build for this one build. `dotnet-ef` builds the project to load the
+        // DbContext, and with the batteries on that build defaults to RaskSpaBuild/RaskMetaBuild=true —
+        // so scaffolding a front-end template ran the bundler, or on the meta lane a full Nuxt/Next
+        // production build, behind a line that says "Creating the first migration…". Minutes of silence
+        // for output nobody reads: the next thing anyone does is `rask dev`, which turns both off again
+        // and lets the framework's own dev server own the front end. A missing node then failed the
+        // migration step for a reason that has nothing to do with the database.
+        var db = new DbCommand(Console, _fileSystem, _process, targetDirectory, SkipFrontEndBuild);
 
         Console.WriteLine("Creating the first migration…", ConsoleStyle.Dim);
         if (await db.ExecuteAsync(["add", "Init", "--project", efProject], cancellationToken).ConfigureAwait(false) != 0)

--- a/src/Rask.Cli/IProcessRunner.cs
+++ b/src/Rask.Cli/IProcessRunner.cs
@@ -31,7 +31,12 @@ internal interface IProcessRunner
     /// Run a child process and capture its output (probing commands like <c>rask info</c> that parse
     /// <c>dotnet --version</c>).
     /// </summary>
-    Task<ProcessResult> CaptureAsync(string fileName, IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken);
+    Task<ProcessResult> CaptureAsync(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        string? workingDirectory,
+        CancellationToken cancellationToken,
+        IReadOnlyDictionary<string, string>? environment = null);
 
     /// <summary>
     /// Run a child process whose output the user sees live <em>and</em> the caller reads — every line is
@@ -118,9 +123,14 @@ internal sealed class ProcessRunner(TextWriter? output = null, TextWriter? error
         }
     }
 
-    public async Task<ProcessResult> CaptureAsync(string fileName, IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken)
+    public async Task<ProcessResult> CaptureAsync(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        string? workingDirectory,
+        CancellationToken cancellationToken,
+        IReadOnlyDictionary<string, string>? environment = null)
     {
-        using var process = Start(fileName, arguments, workingDirectory, redirect: true);
+        using var process = Start(fileName, arguments, workingDirectory, redirect: true, environment);
         var stdout = process.StandardOutput.ReadToEndAsync(cancellationToken);
         var stderr = process.StandardError.ReadToEndAsync(cancellationToken);
         await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);

--- a/tests/Rask.Cli.Tests/DeployE2E.cs
+++ b/tests/Rask.Cli.Tests/DeployE2E.cs
@@ -118,7 +118,12 @@ internal sealed class EnvScopedProcessRunner(
         return exit;
     }
 
-    public async Task<ProcessResult> CaptureAsync(string fileName, IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken)
+    public async Task<ProcessResult> CaptureAsync(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        string? workingDirectory,
+        CancellationToken cancellationToken,
+        IReadOnlyDictionary<string, string>? environment = null)
     {
         var (exit, output) = await CaptureCoreAsync(fileName, arguments, workingDirectory, cancellationToken).ConfigureAwait(false);
         return new ProcessResult(exit, output.StandardOutput, output.StandardError);

--- a/tests/Rask.Cli.Tests/NewCommandTests.cs
+++ b/tests/Rask.Cli.Tests/NewCommandTests.cs
@@ -652,6 +652,33 @@ public sealed class NewCommandTests
         Assert.False(fs.FileExists("/proj/Field/Field.csproj"));
     }
 
+    // The first migration builds the project to load the DbContext, and with the batteries on that
+    // build defaulted to RaskSpaBuild/RaskMetaBuild=true — so scaffolding a front-end template ran the
+    // bundler, or on the meta lane a full Nuxt/Next PRODUCTION build, behind a line that reads
+    // "Creating the first migration…". MSBuild reads properties from the environment, so the overlay on
+    // the dotnet-ef child is what turns it off without touching `rask db`'s argument surface.
+    [Fact]
+    public async Task The_first_migration_does_not_build_the_front_end()
+    {
+        var (_, _, runner, command) = Build();
+
+        var exit = await command.ExecuteAsync(["Blog"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+
+        var ef = runner.Invocations
+            .Where(i => i.Arguments.Contains("ef") && i.Arguments.Contains("migrations"))
+            .ToList();
+        Assert.NotEmpty(ef);
+
+        foreach (var invocation in ef)
+        {
+            Assert.NotNull(invocation.Environment);
+            Assert.Equal("false", invocation.Environment!["RaskSpaBuild"]);
+            Assert.Equal("false", invocation.Environment!["RaskMetaBuild"]);
+        }
+    }
+
     private static (StringConsole Console, FakeFileSystem Fs, FakeProcessRunner Runner, NewCommand Command) Build()
     {
         var console = new StringConsole();

--- a/tests/Rask.Cli.Tests/TestDoubles.cs
+++ b/tests/Rask.Cli.Tests/TestDoubles.cs
@@ -236,10 +236,15 @@ internal sealed class FakeProcessRunner : IProcessRunner
         return RunHandler?.Invoke(args) ?? RunExitCode;
     }
 
-    public Task<ProcessResult> CaptureAsync(string fileName, IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken)
+    public Task<ProcessResult> CaptureAsync(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        string? workingDirectory,
+        CancellationToken cancellationToken,
+        IReadOnlyDictionary<string, string>? environment = null)
     {
         var args = arguments.ToArray();
-        _invocations.Enqueue(new ProcessInvocation(fileName, args, Captured: true));
+        _invocations.Enqueue(new ProcessInvocation(fileName, args, Captured: true, environment, workingDirectory));
 
         if (CaptureByExecutable is not null)
         {


### PR DESCRIPTION
Closes #991.

## The defect

With the batteries on, `rask new` creates the first migration, and `dotnet-ef` builds the project to
load the `DbContext`. That build took `RaskSpaBuild` / `RaskMetaBuild` at their default of `true`, so
scaffolding a front-end template ran the bundler — or, on the meta lane, a full Nuxt/Next/SvelteKit
**production** build — behind a line that reads `Creating the first migration…` and nothing else.

Minutes of silence for output nobody reads: the next thing anyone does is `rask dev`, which turns
both properties off again and lets the framework's own dev server own the front end. And a machine
without node failed the migration step for a reason that has nothing to do with the database.

## The fix

MSBuild reads properties from the environment, which is how they reach a build whose command line
belongs to `dotnet-ef` — the same channel `rask dev` already uses for `HotReloadAutoRestart`. So
`DbCommand` takes an optional environment overlay and `rask new` passes both properties off for its
one build.

`rask db`'s argument surface is untouched, and every other invocation of it is unchanged.

**Scope note.** The same waste applies to `rask db add` run by hand — EF never needs the front end
built — but widening it is a behaviour change beyond what #991 asked for, so it is deliberately left
out. Say the word if you want it.

`CaptureAsync` grew the optional `environment` parameter its sibling `RunAsync` already had. The JSON
listing path is not reachable from scaffolding, so there is no live gap, but an overlay silently
ignored on one of two code paths is the exact trap this codebase keeps rediscovering.

## Tests

`The_first_migration_does_not_build_the_front_end` asserts every `ef migrations` invocation carries
both properties. Verified to fail with the fix removed — without that check it would have passed
against a fake that records the environment but is never given one.

## Gate

`dotnet format` clean · Release `-warnaserror` clean · 1216 `Rask.Cli.Tests` pass · full pre-push
gate green: browser E2E, benchmark gates (payload-bytes ×2 + live-session capacity smokes), CLI build
gate and the deploy gate against a container host. The hot-reload and installer gates skipped
themselves, correctly — this push touches neither path.
