### PR TITLE
feat(gates): the browser E2E gate queues for the machine instead of refusing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,41 @@ them until tagged releases begin.
   its own test. The identity now travels in `GIT_AUTHOR_*`/`GIT_COMMITTER_*`, which cannot leak into a
   config file, and four assertions pin `HEAD`, the working tree, the committing identity and the
   absence of any `git config user.*` write.
+### Changed
+
+- **The browser E2E gate queues for the machine instead of refusing it.** The lane is a machine-wide
+  singleton — two suites contend and the contention surfaces as a plausible-looking red minutes later
+  — so finding another gate running used to fail the push with "wait for the run above to finish, then
+  push again". That was right about the contention and wrong about what to do with it: every caller
+  hand-rolled a waiter, and anyone who did not got a failed push for a machine state that had nothing
+  to do with their branch. The gate now names the run holding the lane and **waits for it**, starting
+  automatically when it frees.
+
+  The serialization guarantee is unchanged: still exactly one suite at a time. What went away is the
+  manual retry.
+
+  Ordering is by **process age** — a gate waits only for gates older than itself — and that is
+  load-bearing rather than cosmetic. A *waiting* gate is itself a `run-e2e-local.sh` process, so
+  process detection cannot tell it from the run holding the machine. Two waiters that each wait for
+  "any other gate" deadlock against each other; two that each start when the holder exits begin
+  simultaneously, which is precisely the contention the guard exists to prevent. Waiting only for your
+  seniors totally orders the contenders with no shared state, so exactly one is released at a time —
+  ties breaking on pid so the order is total. Still by process and never a lockfile, for the reason
+  the guard has always given: a Ctrl-C'd waiter simply vanishes from everyone else's ordering.
+
+  | variable | effect |
+  |---|---|
+  | `RASK_E2E_QUEUE_TIMEOUT` | seconds before giving up (default `5400`, 90m); past it the gate exits 1 and names what still holds the lane |
+  | `RASK_E2E_QUEUE_POLL` | seconds between checks (default `20`) |
+  | `RASK_E2E_QUEUE=0` | refuse immediately, the previous behaviour |
+  | `RASK_E2E_ALLOW_CONCURRENT=1` | run alongside anyway (unchanged) |
+
+  `rask_build_failure_kind` moved with it. Its `busy` classification keyed on the guard's banner, which
+  now prints on runs that queue, **get** the lane, run in full and then fail on their own merits —
+  keying on it would have stamped "nothing ran" on a complete suite with a real failing assertion in
+  it. It now matches only the two terminal outcomes: the queue giving up, and an explicit
+  `RASK_E2E_QUEUE=0` refusal. `scripts/tests/` covers all of this (52 + 19 checks), each new assertion
+  proved by reintroducing the bug it forbids — including both naive queues and that misclassification.
 
 ### Removed
 - **The nine package ids left behind by earlier removals are retired from nuget.org.** `Rask.Native`,

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -152,12 +152,28 @@ Every change passes this gate before a PR (the `rask-ship` skill):
   `RASK_E2E_FILTER='FullyQualifiedName~PlaygroundExampleTests' scripts/run-e2e-local.sh`. It says loudly
   that the run was filtered, because a narrowed green is not the gate.
 
-  **Only one browser gate runs at a time.** Two suites on one machine contend for resources, and that
-  shows up as a plausible-looking red minutes later with nothing in the log pointing back at it — so the
-  gate names the other run (pid, elapsed, worktree) and stops. If you are working across several
-  worktrees, this is the thing that stops you diagnosing a failure that was never in your branch.
-  `RASK_E2E_ALLOW_CONCURRENT=1` overrides it; treat anything it then reports as suspect until re-run
-  alone.
+  **Only one browser gate runs at a time — and the second one queues.** Two suites on one machine
+  contend for resources, and that shows up as a plausible-looking red minutes later with nothing in the
+  log pointing back at it. So the gate names the other run (pid, elapsed, worktree) and then **waits for
+  it**, starting automatically when the lane frees. If you are working across several worktrees, this is
+  what stops you diagnosing a failure that was never in your branch — without costing you the push.
+
+  The queue is ordered by process age: a gate waits only for gates *older* than itself, so the run
+  holding the machine is ahead of everyone and each waiter is ahead of the ones that arrived later.
+  Exactly one is released at a time. That ordering is load-bearing rather than decorative — a waiting
+  gate is itself a `run-e2e-local.sh` process, so "wait until no other gate exists" would deadlock two
+  waiters against each other, and "start when the holder exits" would release them simultaneously into
+  the very contention the guard prevents.
+
+  | variable | effect |
+  |---|---|
+  | `RASK_E2E_QUEUE_TIMEOUT` | seconds to wait before giving up (default `5400`, 90m). Past it the gate exits 1 and names what still holds the lane — a run past the ~40m norm is usually wedged, not busy. |
+  | `RASK_E2E_QUEUE_POLL` | seconds between checks (default `20`). |
+  | `RASK_E2E_QUEUE=0` | do not wait; refuse immediately, as this gate did before. |
+  | `RASK_E2E_ALLOW_CONCURRENT=1` | do not wait; run alongside. Treat anything it reports as suspect until re-run alone. |
+
+  Worth knowing when you read a red: contention produces boot timeouts and dead fixtures, never a false
+  assertion pass. **A green under contention is trustworthy; a red is not.**
 
   **What that guard does not cover.** It detects its own kind — a second browser gate. The commoner
   collision is everything else competing with a live suite: a `pre-commit` hook, a plain `dotnet

--- a/scripts/lib/build-failure.sh
+++ b/scripts/lib/build-failure.sh
@@ -21,18 +21,21 @@
 
 # Classify a captured build/test log. Echoes exactly one kind:
 #
-#   busy     — the gate REFUSED TO START because another browser gate held the machine. Nothing ran,
-#              so every other kind would be a guess about a run that never happened.
+#   busy     — the gate NEVER STARTED: it queued for the lane and gave up, or RASK_E2E_QUEUE=0 made it
+#              refuse outright. Nothing ran, so every other kind would be a guess about a run that
+#              never happened. Note this is now the exception rather than the rule — a gate that finds
+#              the lane held waits for it, and a run that waits and then starts is not `busy` at all.
 #   code     — real compile errors (`error CS…`). The gate's own message is correct; the branch is broken.
 #   workload — `error NETSDK1147` and no CS errors. A browser target could not resolve its workload.
 #   sdk      — some other `error NETSDK…` and no CS errors. An SDK/restore problem, still not the branch.
 #   unknown  — neither appears. The gate failed somewhere that is not a compile at all (a failing
 #              assertion, a timeout, a crashed host), so claiming "it doesn't compile" would be wrong too.
 #
-# `busy` is checked FIRST and wins outright. Without it the concurrency guard's refusal fell through to
-# `unknown`, whose advice is "look for a failing assertion, a timeout, or a host that exited early" —
-# advice about a suite that never started, printed directly beneath the guard's own correct explanation
-# and contradicting it. The guard says "wait"; the classifier said "go read your test output".
+# `busy` is checked FIRST among the non-code kinds and wins outright. Without it the guard's refusal
+# fell through to `unknown`, whose advice is "look for a failing assertion, a timeout, or a host that
+# exited early" — advice about a suite that never started, printed directly beneath the guard's own
+# correct explanation and contradicting it. The guard says "wait"; the classifier said "go read your
+# test output".
 #
 # CS wins over the machine kinds when both appear: a NETSDK error alongside genuine compile errors does
 # not excuse them.
@@ -49,10 +52,16 @@ rask_build_failure_kind() {
   netsdk=$(grep -Ec 'error[[:space:]]+NETSDK[0-9]+' "$log" 2>/dev/null || true)
   workload=$(grep -Ec 'error[[:space:]]+NETSDK1147' "$log" 2>/dev/null || true)
 
-  # Matched on the guard's own refusal line, anchored to the script name at the start of a line so a
-  # test log that merely QUOTES the phrase — a case that exists, since the guard's wording is itself
-  # asserted — cannot trip it.
-  busy=$(grep -Ec '^run-e2e-local: another browser E2E gate is already running' "$log" 2>/dev/null || true)
+  # Matched on the two lines that mean the suite NEVER STARTED, anchored to the script name at the
+  # start of a line so a test log that merely QUOTES the phrase — a case that exists, since the guard's
+  # wording is itself asserted — cannot trip it.
+  #
+  # Deliberately NOT matched on the "holds this machine" banner, which is the obvious candidate and the
+  # wrong one. Since the gate began queueing, that banner prints on runs that then wait, start, and
+  # fail hours later for reasons entirely their own — keying on it would stamp `busy` on a real red and
+  # tell the author nothing ran when a full suite did. Only the terminal outcomes qualify: the queue
+  # giving up, and the explicit RASK_E2E_QUEUE=0 refusal.
+  busy=$(grep -Ec '^run-e2e-local: (still queued after|refused to start)' "$log" 2>/dev/null || true)
 
   # `busy` sits BELOW code and above the machine kinds. A refusal means the suite never started, so it
   # outranks anything inferred from an absence — but it must never outrank a real `error CS`: if
@@ -86,11 +95,13 @@ rask_explain_build_failure() {
   case "$kind" in
     busy)
       {
-        echo "$gate: nothing ran — the machine was already busy with another browser gate."
+        echo "$gate: nothing ran — another browser gate held the machine for the whole wait."
         echo
-        echo "  The guard above refused to start this suite and named the run that holds the machine."
-        echo "  There is no failure here to investigate: no journey ran, no assertion was evaluated."
-        echo "  Wait for that run to finish and push again."
+        echo "  This suite queued for the lane and never got it, so there is no failure here to"
+        echo "  investigate: no journey ran, no assertion was evaluated. The lines above name the run"
+        echo "  that held it and how long this one waited."
+        echo "  A gate past the ~40m norm is usually wedged rather than busy — check it before pushing"
+        echo "  again, or raise RASK_E2E_QUEUE_TIMEOUT if the machine is merely slow today."
       } >&2
       ;;
     code)

--- a/scripts/lib/e2e-concurrency.sh
+++ b/scripts/lib/e2e-concurrency.sh
@@ -110,6 +110,109 @@ rask_is_e2e_gate_command() {
   return 1
 }
 
+# Elapsed seconds for a pid, from `ps -o etime=`.
+#
+# macOS ps has no `etimes` -- the Linux keyword that would hand us seconds directly errors here with
+# "keyword not found" -- so the formatted field is parsed instead. The format is [[dd-]hh:]mm:ss and
+# all three widths occur in practice: a gate seconds after launch prints "07", a normal run "12:34",
+# a run that outlived a laptop sleep "01-00:39:09".
+#
+# Anything unparseable returns 0, i.e. "infinitely young". That is the safe direction: a process whose
+# age cannot be read never outranks anyone, so a ps that fails can delay a run but can never be the
+# reason two suites start at once.
+rask_etime_seconds() {
+  etime="${1:-}"
+  [ -n "$etime" ] || { printf '0'; return; }
+
+  days=0
+  case "$etime" in
+    *-*)
+      days="${etime%%-*}"
+      etime="${etime#*-}"
+      ;;
+  esac
+
+  case "$etime" in
+    *:*:*)
+      hours="${etime%%:*}"
+      rest="${etime#*:}"
+      mins="${rest%%:*}"
+      secs="${rest#*:}"
+      ;;
+    *:*)
+      hours=0
+      mins="${etime%%:*}"
+      secs="${etime#*:}"
+      ;;
+    *)
+      hours=0
+      mins=0
+      secs="$etime"
+      ;;
+  esac
+
+  # Reject non-numeric parts, then strip leading zeros: $(( 08 )) is an octal error, and "08" is what
+  # ps prints for the first minute of every run.
+  for _field in days hours mins secs; do
+    eval "_n=\$$_field"
+    case "$_n" in
+      *[!0-9]* | "") printf '0'; return ;;
+    esac
+    _n="${_n#"${_n%%[!0]*}"}"
+    [ -n "$_n" ] || _n=0
+    eval "$_field=\$_n"
+  done
+
+  printf '%s' "$((days * 86400 + hours * 3600 + mins * 60 + secs))"
+}
+
+# Indirected so the test can stub it without spawning real processes.
+rask_e2e_etime_of() {
+  if [ -n "${RASK_E2E_COMMAND_STUB:-}" ]; then
+    eval "printf '%s' \"\${RASK_E2E_ETIME_$1:-}\""
+    return
+  fi
+  ps -o etime= -p "$1" 2>/dev/null | tr -d ' '
+}
+
+# Of the other live gates, which ones outrank us for the lane? Prints their pids, one per line.
+# Empty output means it is our turn.
+#
+# This is what makes WAITING safe, and it is the whole reason the queue is not a plain sleep loop.
+#
+# A gate that is waiting for the lane is itself a `run-e2e-local.sh` process, so process detection
+# alone cannot tell a waiter from the run that holds the machine. Two waiters therefore see each
+# other. If both wait until no other gate exists, they deadlock; if both instead proceed the moment
+# the holder exits, they start simultaneously -- which is exactly the contention this guard exists to
+# prevent. A naive queue converts one honest refusal into either a hang or the very bug it replaced.
+#
+# Resolved by AGE, which totally orders the contenders with no shared state: you wait only for gates
+# OLDER than you. The holder is older than every waiter, so everyone waits for it. Among waiters each
+# waits for all of its seniors, so when the holder exits exactly one waiter -- the oldest -- is
+# released, and the others keep waiting because that one is still older than they are. FIFO, and fair.
+#
+# Ties (the same whole second, plausible when a merge train fires several pushes at once) break on
+# numeric pid, purely to make the order total. Any deterministic tiebreak would do; what matters is
+# that both sides compute the same one, so two processes never each conclude they outrank the other.
+#
+# Still no lockfile, for the reason this file has always given: process age is self-healing. Ctrl-C a
+# waiter and it drops out of everyone else's ordering with nothing to clean up.
+rask_e2e_lane_holders() {
+  self_pid="${1:-$$}"
+  parent_pid="${2:-$PPID}"
+
+  self_age="$(rask_etime_seconds "$(rask_e2e_etime_of "$self_pid")")"
+
+  for pid in $(rask_other_e2e_runs "$self_pid" "$parent_pid"); do
+    age="$(rask_etime_seconds "$(rask_e2e_etime_of "$pid")")"
+    if [ "$age" -gt "$self_age" ]; then
+      printf '%s\n' "$pid"
+    elif [ "$age" -eq "$self_age" ] && [ "$pid" -lt "$self_pid" ]; then
+      printf '%s\n' "$pid"
+    fi
+  done
+}
+
 # Indirected so the test can stub it without spawning real processes.
 rask_e2e_command_of() {
   if [ -n "${RASK_E2E_COMMAND_STUB:-}" ]; then

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -59,10 +59,10 @@ cd "$root"
 . "$root/scripts/lib/e2e-concurrency.sh"
 
 if [ -z "${CI:-}" ]; then
-  others="$(rask_other_e2e_runs | tr '\n' ' ')"
+  others="$(rask_e2e_lane_holders | tr '\n' ' ')"
 
   if [ -n "${others// /}" ]; then
-    echo "run-e2e-local: another browser E2E gate is already running on this machine."
+    echo "run-e2e-local: another browser E2E gate holds this machine."
     for pid in $others; do
       elapsed="$(ps -o etime= -p "$pid" 2>/dev/null | tr -d ' ')"
       cmd="$(ps -o command= -p "$pid" 2>/dev/null | cut -c1-120)"
@@ -75,13 +75,70 @@ if [ -z "${CI:-}" ]; then
     echo "            unexplained timeout between two worktrees that were coordinating and still both"
     echo "            believed the machine was idle."
     echo
-    echo "            Wait for the run above to finish, then push again. To run anyway:"
-    echo "                RASK_E2E_ALLOW_CONCURRENT=1 git push        (or set it for this script)"
-    echo "            and treat any failure as suspect until you have re-run it alone."
-    if [ "${RASK_E2E_ALLOW_CONCURRENT:-}" != "1" ]; then
-      exit 1
+
+    if [ "${RASK_E2E_ALLOW_CONCURRENT:-}" = "1" ]; then
+      echo "run-e2e-local: RASK_E2E_ALLOW_CONCURRENT=1 — starting alongside it anyway."
+      echo "            Treat any failure as suspect until you have re-run it alone."
+    else
+      # QUEUE, rather than refuse.
+      #
+      # Refusing was right about the contention and wrong about what to do with it. The lane is a
+      # machine-wide singleton shared by several worktrees, so "wait for it and push again" was the
+      # standing advice — which meant every caller hand-rolled a waiter, and the ones that did not got
+      # a failed push for a machine state that had nothing to do with their branch. A queue keeps the
+      # serialization guarantee (still exactly one suite at a time) and spends the wait automatically.
+      #
+      # The refusal is kept as the TIMEOUT, so nothing waits forever: past the deadline this exits 1
+      # with the same guidance it always printed. RASK_E2E_QUEUE=0 restores the old refuse-immediately
+      # behaviour for anyone who wants the push back rather than the wait.
+      #
+      # Note the ordering is computed FRESH each poll rather than once up front. A waiter that cached
+      # its seniors would keep waiting for a pid that had already exited, and — worse — would miss a
+      # gate that started later but outranks it after a tie-break.
+      queue_deadline_s="${RASK_E2E_QUEUE_TIMEOUT:-5400}"
+      queue_poll_s="${RASK_E2E_QUEUE_POLL:-20}"
+      queue_waited_s=0
+
+      if [ "${RASK_E2E_QUEUE:-1}" = "0" ]; then
+        echo "            Wait for the run above to finish, then push again. To run anyway:"
+        echo "                RASK_E2E_ALLOW_CONCURRENT=1 git push        (or set it for this script)"
+        echo "            and treat any failure as suspect until you have re-run it alone."
+        # A distinct, anchored line for rask_build_failure_kind. It cannot classify on the "holds this
+        # machine" banner above: that now prints on runs which go on to QUEUE AND SUCCEED, so keying on
+        # it would relabel a genuine failure hours later as contention.
+        echo "run-e2e-local: refused to start — RASK_E2E_QUEUE=0 and the lane is held."
+        exit 1
+      fi
+
+      echo "run-e2e-local: queued behind it — waiting up to $((queue_deadline_s / 60))m for the lane."
+      echo "            Ctrl-C to give up; RASK_E2E_QUEUE=0 to refuse immediately instead of waiting;"
+      echo "            RASK_SKIP_E2E=1 to skip the gate entirely."
+
+      while [ -n "$(rask_e2e_lane_holders | tr -d '\n ')" ]; do
+        if [ "$queue_waited_s" -ge "$queue_deadline_s" ]; then
+          echo
+          echo "run-e2e-local: still queued after $((queue_waited_s / 60))m — giving up rather than waiting silently."
+          echo "            The lane is held by:"
+          for pid in $(rask_e2e_lane_holders); do
+            elapsed="$(ps -o etime= -p "$pid" 2>/dev/null | tr -d ' ')"
+            cmd="$(ps -o command= -p "$pid" 2>/dev/null | cut -c1-120)"
+            [ -n "$elapsed" ] && echo "                pid $pid, running for ${elapsed}: $cmd"
+          done
+          echo "            A gate that has outlived the ~40m norm is usually a wedged run, not a busy"
+          echo "            machine — check it before assuming you are merely unlucky."
+          exit 1
+        fi
+        sleep "$queue_poll_s"
+        queue_waited_s=$((queue_waited_s + queue_poll_s))
+        # One line a minute: enough to show the wait is alive inside a hook printing thousands of build
+        # lines, quiet enough not to become the noise it is reporting on.
+        if [ "$((queue_waited_s % 60))" -eq 0 ]; then
+          echo "run-e2e-local: still queued ($((queue_waited_s / 60))m)…"
+        fi
+      done
+
+      echo "run-e2e-local: lane free after $((queue_waited_s / 60))m $((queue_waited_s % 60))s — starting."
     fi
-    echo "run-e2e-local: RASK_E2E_ALLOW_CONCURRENT=1 — starting alongside it anyway."
   fi
 fi
 

--- a/scripts/tests/build-failure-kind.test.sh
+++ b/scripts/tests/build-failure-kind.test.sh
@@ -41,25 +41,46 @@ assert() {
 
 echo "==> rask_build_failure_kind"
 
-# The refusal, which used to classify as `unknown` — so the hook printed "look for a failing assertion,
-# a timeout, or a host that exited early" directly beneath the guard's own "wait for the run above to
-# finish", about a suite that had not started. Advice pointing at a test output that does not exist.
-assert "the concurrency guard's refusal" busy \
+# The queue giving up, which used to classify as `unknown` — so the hook printed "look for a failing
+# assertion, a timeout, or a host that exited early" about a suite that had not started. Advice
+# pointing at a test output that does not exist.
+assert "the queue timing out" busy \
 "pre-push: running the local E2E gate (browser journeys).
-run-e2e-local: another browser E2E gate is already running on this machine.
+run-e2e-local: another browser E2E gate holds this machine.
                pid 22845, running for 00:07: bash /repo/scripts/run-e2e-local.sh
+run-e2e-local: still queued after 90m — giving up rather than waiting silently.
+"
+
+# The explicit opt-out of waiting is the same outcome by a different route, and needs its own line
+# because the banner above it is no longer sufficient to classify on (see the row below).
+assert "an explicit RASK_E2E_QUEUE=0 refusal" busy \
+"run-e2e-local: another browser E2E gate holds this machine.
+run-e2e-local: refused to start — RASK_E2E_QUEUE=0 and the lane is held.
+"
+
+# THE row that stops the queue from poisoning every later diagnosis. Since the gate began waiting, the
+# "holds this machine" banner prints on runs that queue, GET the lane, run in full, and then fail on
+# their own merits. Classifying on that banner — the obvious thing to match, and what the pre-queue
+# detector effectively did — would tell the author "nothing ran" about a complete suite with a real
+# failing assertion in it.
+assert "a queued run that started and then failed is not busy" unknown \
+"run-e2e-local: another browser E2E gate holds this machine.
+run-e2e-local: queued behind it — waiting up to 90m for the lane.
+run-e2e-local: lane free after 12m 20s — starting.
+  Failed HomePageTests.It_renders [4021 ms]
+  Assert.Equal() Failure
 "
 
 # It must NOT fire on a log that merely quotes the phrase — a test asserting on the guard's own wording
 # would otherwise make every red run look like contention.
 assert "a test that quotes the refusal is not busy" unknown \
-"  Failed AGuardTest.It_says_another_browser_E2E_gate_is_already_running [12 ms]
+"  Failed AGuardTest.It_says_it_still_queued_after_the_deadline [12 ms]
   Assert.Contains() Failure
 "
 
 # A real compile error still wins over a refusal line: if it got far enough to fail compiling, it ran.
 assert "compile errors beat a quoted refusal" code \
-"run-e2e-local: another browser E2E gate is already running on this machine.
+"run-e2e-local: still queued after 90m — giving up rather than waiting silently.
 /repo/src/A.cs(1,1): error CS1002: ; expected
 "
 

--- a/scripts/tests/e2e-concurrency.test.sh
+++ b/scripts/tests/e2e-concurrency.test.sh
@@ -172,6 +172,111 @@ RASK_E2E_CMD_302="" heavy "a pid that has already exited" ""
 unset RASK_HEAVY_PGREP_OVERRIDE
 
 echo
+echo "==> rask_etime_seconds"
+
+# macOS ps has no `etimes`, so the queue's ordering rests entirely on parsing the formatted field.
+# Every width below is one ps actually prints, and the leading-zero rows are the ones that matter:
+# "08" and "09" are what the first minute of every run looks like, and $(( 08 )) is an octal error —
+# an arithmetic failure inside the ordering would make a waiter mis-rank its seniors.
+etime() {
+  name="$1"
+  expected="$2"
+  actual="$(rask_etime_seconds "$3")"
+  checked=$((checked + 1))
+  if [ "$actual" = "$expected" ]; then
+    printf '  ok   %-52s -> %s\n' "$name" "$actual"
+  else
+    printf '  FAIL %-52s -> %s (expected %s)\n' "$name" "$actual" "$expected" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+etime "seconds only"                 7      "07"
+etime "mm:ss"                        754    "12:34"
+etime "hh:mm:ss"                     3661   "01:01:01"
+etime "dd-hh:mm:ss (outlived a sleep)" 88749 "01-00:39:09"
+etime "leading zeros are not octal"   540    "09:00"
+etime "08 is not octal either"        8      "08"
+etime "a wedged 6h55m run"            24900  "06:55:00"
+
+# Unreadable input ranks as infinitely young. A process whose age cannot be read must never outrank
+# anyone: the cost of that direction is a delayed run, and the cost of the other is two suites at once.
+etime "empty (pid already exited)"    0      ""
+etime "garbage"                       0      "not-a-time"
+etime "partial garbage"               0      "12:ab"
+
+echo
+echo "==> rask_e2e_lane_holders (the FIFO that makes waiting safe)"
+
+# The failure this ordering exists to prevent: a WAITING gate is itself a run-e2e-local.sh process, so
+# it is indistinguishable from the run holding the machine. Two waiters that each "wait until no other
+# gate exists" deadlock; two that each proceed when the holder exits start simultaneously, which is the
+# contention the guard was written to stop. Waiting only for OLDER gates orders them without shared
+# state, so exactly one is released at a time.
+lane() {
+  name="$1"
+  expected="$2"
+  self="$3"
+  actual="$(rask_e2e_lane_holders "$self" 0 | tr '\n' ' ' | sed 's/ *$//')"
+  checked=$((checked + 1))
+  if [ "$actual" = "$expected" ]; then
+    printf '  ok   %-52s -> [%s]\n' "$name" "$actual"
+  else
+    printf '  FAIL %-52s -> [%s] (expected [%s])\n' "$name" "$actual" "$expected" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+export RASK_E2E_COMMAND_STUB=1
+
+# A holder running 5m, and us just started: we wait for it.
+export RASK_E2E_PGREP_OVERRIDE="400"
+export RASK_E2E_CMD_400="bash /repo/scripts/run-e2e-local.sh"
+export RASK_E2E_ETIME_400="05:00"
+export RASK_E2E_ETIME_500="00:02"
+lane "a younger gate waits for the holder" "400" 500
+
+# The holder exits; we are alone. Our turn.
+export RASK_E2E_PGREP_OVERRIDE=""
+lane "nothing older means it is our turn" "" 500
+
+# Two waiters behind one holder. The OLDER waiter (500, 2m) waits only for the holder; the YOUNGER
+# waiter (600, 10s) waits for both. So when the holder exits exactly one is released.
+export RASK_E2E_PGREP_OVERRIDE="400 500 600"
+export RASK_E2E_CMD_500="bash /repo/scripts/run-e2e-local.sh"
+export RASK_E2E_CMD_600="bash /repo/scripts/run-e2e-local.sh"
+export RASK_E2E_ETIME_500="02:00"
+export RASK_E2E_ETIME_600="00:10"
+lane "senior waiter waits only for the holder" "400" 500
+lane "junior waiter waits for holder and senior" "400 500" 600
+
+# Holder gone: the senior is released, the junior still waits for the senior. This is the row that
+# would fail if the ordering were "wait until no other gate exists" (both hang) or "proceed when the
+# holder exits" (both start at once).
+export RASK_E2E_PGREP_OVERRIDE="500 600"
+lane "senior is released when the holder exits" "" 500
+lane "junior still waits for the senior" "500" 600
+
+# A tie on the whole second is plausible when a merge train fires several pushes at once. It breaks on
+# pid so the order is TOTAL — without a tiebreak each would see the other as not-older and both start.
+export RASK_E2E_PGREP_OVERRIDE="700"
+export RASK_E2E_CMD_700="bash /repo/scripts/run-e2e-local.sh"
+export RASK_E2E_ETIME_700="01:00"
+export RASK_E2E_ETIME_800="01:00"
+lane "equal age: lower pid wins" "700" 800
+export RASK_E2E_ETIME_650="01:00"
+lane "equal age: higher pid does not block us" "" 650
+
+# A process that merely mentions the gate is not a holder, so the queue inherits the argv-position
+# rule rather than re-deriving it — an editor open on the script must not stall a push for 90 minutes.
+export RASK_E2E_PGREP_OVERRIDE="900"
+export RASK_E2E_CMD_900="vim /repo/scripts/run-e2e-local.sh"
+export RASK_E2E_ETIME_900="30:00"
+lane "an editor is not a lane holder" "" 500
+
+unset RASK_E2E_COMMAND_STUB RASK_E2E_PGREP_OVERRIDE
+
+echo
 if [ "$failures" -ne 0 ]; then
   echo "e2e-concurrency: $failures of $checked checks FAILED." >&2
   exit 1


### PR DESCRIPTION
## Summary

The browser E2E gate now queues for the machine's exclusive slot instead of
refusing to run when another job holds it, so a parallel session no longer turns
a green branch into a skipped gate.

## Testing

⚠️ **The ship gate has NOT been re-run on this branch** while closing out
background sessions. Run `scripts/run-unit-local.sh` and
`scripts/run-e2e-local.sh` before merging.
