### PR TITLE
test(e2e): give the SQLite database assertions a budget that survives gate load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ them until tagged releases begin.
 
 ### Fixed
 
+- **The SQLite journey's database assertions reported machine load as a product failure.** The bulk
+  imports and the concurrent-writer bursts waited on Playwright's default 5s budget for work that
+  takes 1–3s idle, so roughly two seconds of headroom stood between a green suite and a red one
+  ([#962](https://github.com/pal-tamas/rask/issues/962)).
+
+  That is not enough on this machine. The E2E lane serialises browser journeys, but the unit suites
+  and the CLI build gate are not in it, so a journey routinely runs while several other builds
+  saturate the box — and the failure it produced (`Rows imported so far: 0.` after 14 polls) reads
+  exactly like a product bug.
+
+  The six assertions that wait on real database work now get their own 30s budget; the ones that wait
+  on a render keep the default, because raising it globally would slow every genuine failure to the
+  pace of the slowest load-dependent one.
+
+  The cost of leaving this was never the red run — it is that a suite crying wolf under load is how a
+  real regression gets waved through. This repository's own casebook records seven "flakes" that were
+  all real bugs.
+
 - **`rask new` ran a production front-end build during scaffolding.** With the batteries on, `rask new`
   creates the first migration, and `dotnet-ef` builds the project to load the `DbContext`. That build
   took `RaskSpaBuild` / `RaskMetaBuild` at their default of `true`, so scaffolding a front-end template

--- a/tests/Rask.Examples.E2E.Tests/SqliteExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/SqliteExampleTests.cs
@@ -9,6 +9,24 @@ namespace Rask.Examples.E2E.Tests;
 [Collection(SqliteExampleCollection.Name)]
 public sealed class SqliteExampleTests(SqliteExampleAppFixture app, PlaywrightFixture pw) : IAsyncLifetime
 {
+    /// <summary>
+    ///     Budget for the assertions that wait on real database work — the bulk imports and the writer
+    ///     bursts — rather than on a render.
+    /// </summary>
+    /// <remarks>
+    ///     Playwright's default is 5s, and on an idle machine these finish in 1–3s. Two seconds of
+    ///     headroom is not enough here: the machine-wide E2E lane serialises browser journeys but the
+    ///     unit suites and the CLI build gate are not in it, so a journey routinely runs while several
+    ///     other builds saturate the box. A 5s budget for work that takes two reports load as a product
+    ///     failure — and a suite that cries wolf under load is how a real regression gets waved through
+    ///     (#962).
+    ///     <para>
+    ///         Applied to these assertions only, deliberately. Raising the global default would slow
+    ///         every genuine failure in the suite to the pace of its slowest load-dependent one.
+    ///     </para>
+    /// </remarks>
+    private const float DatabaseWorkTimeout = 30_000;
+
     private IBrowserContext _ctx = default!;
     private IPage _page = default!;
 
@@ -45,8 +63,10 @@ public sealed class SqliteExampleTests(SqliteExampleAppFixture app, PlaywrightFi
 
         // With WAL + busy_timeout every writer commits — the success alert reports 25 of 25.
         var result = _page.Locator("[role='status']");
-        await Assertions.Expect(result).ToBeVisibleAsync();
-        await Assertions.Expect(result).ToContainTextAsync("25 of 25 writers committed");
+        await Assertions.Expect(result).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = DatabaseWorkTimeout });
+        await Assertions.Expect(result).ToContainTextAsync("25 of 25 writers committed",
+            new LocatorAssertionsToContainTextOptions { Timeout = DatabaseWorkTimeout });
     }
 
     [Fact]
@@ -58,8 +78,10 @@ public sealed class SqliteExampleTests(SqliteExampleAppFixture app, PlaywrightFi
 
         // The BEGIN IMMEDIATE + non-blocking fair-interval retry commits every writer — 25 of 25.
         var result = _page.Locator("[role='status']:has-text('IMMEDIATE')");
-        await Assertions.Expect(result).ToBeVisibleAsync();
-        await Assertions.Expect(result).ToContainTextAsync("25 of 25 IMMEDIATE writers committed");
+        await Assertions.Expect(result).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = DatabaseWorkTimeout });
+        await Assertions.Expect(result).ToContainTextAsync("25 of 25 IMMEDIATE writers committed",
+            new LocatorAssertionsToContainTextOptions { Timeout = DatabaseWorkTimeout });
     }
 
     [Fact]
@@ -70,14 +92,18 @@ public sealed class SqliteExampleTests(SqliteExampleAppFixture app, PlaywrightFi
         var result = _page.Locator("#import-result");
 
         await _page.ClickAsync("#import-tracked");
-        await Assertions.Expect(result).ToContainTextAsync("Change tracker:");
-        await Assertions.Expect(result).ToContainTextAsync("Rows imported so far: 10,000.");
+        await Assertions.Expect(result).ToContainTextAsync("Change tracker:",
+            new LocatorAssertionsToContainTextOptions { Timeout = DatabaseWorkTimeout });
+        await Assertions.Expect(result).ToContainTextAsync("Rows imported so far: 10,000.",
+            new LocatorAssertionsToContainTextOptions { Timeout = DatabaseWorkTimeout });
 
         // The raw writer has to land the same rows: 10,000 more on top of the tracked import's 10,000.
         // Asserting the running total (rather than each import in isolation) is what would catch a fast
         // path that wrote nothing, or wrote a partial batch, while still reporting a time.
         await _page.ClickAsync("#import-raw");
-        await Assertions.Expect(result).ToContainTextAsync("SkipChangeTracking:");
-        await Assertions.Expect(result).ToContainTextAsync("Rows imported so far: 20,000.");
+        await Assertions.Expect(result).ToContainTextAsync("SkipChangeTracking:",
+            new LocatorAssertionsToContainTextOptions { Timeout = DatabaseWorkTimeout });
+        await Assertions.Expect(result).ToContainTextAsync("Rows imported so far: 20,000.",
+            new LocatorAssertionsToContainTextOptions { Timeout = DatabaseWorkTimeout });
     }
 }


### PR DESCRIPTION
## Summary

Closes #962.

The SQLite journey's six database assertions ran on Playwright's 5s default, which
left roughly 2s of headroom — enough to pass on an idle machine and fail whenever
the gate is under load. They now get their own 30s budget.

## Testing

**The full pre-push gate did run on `81a088fc`.** All four `SqliteExampleTests`
passed, including `Bulk_import_lands_every_row_on_both_paths` — so the change
itself is verified.

The gate still went **red overall**, on
`StandaloneWasmExampleTests.Journey_WalksEveryPageAndUnusualActivity`, waiting on
`.guide-demo .sample-result-body article`. That is #972 and is unrelated to this
diff. Consequence: a plain re-push will keep being blocked by #972 at roughly
3-in-28, so merging needs a human who knows that the red is pre-existing.

Full gate results are in the comment thread below.

## Related

#972 / #989 / #992 track the WASM guides journey flake, which is separate and
still open.
