### PR TITLE
fix(site): the landing page turns the kit's theme on and copies its palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ them until tagged releases begin.
 
 ### Fixed
 
+- **The landing site shipped to rask.sh with no colour at all.** `Rask.Example.Site` drew with the kit
+  but was wired for neither half of it, and both failures are silent in the same way: the build stays
+  green, the class names in the markup stay correct, and the page arrives unstyled.
+
+  **The theme scope was never turned on.** The kit confines daisyUI's theme to `data-rask-ui` so that
+  referencing the package cannot repaint an app that only wanted a button, and every `--color-ui-*`
+  token is an alias onto `--color-base-*`, which exists only inside that scope. The site's root
+  component had no `Shell` override, so the attribute reached no element and every colour resolved to
+  nothing. The served page carried `data-rask-ui` only inside CSS selectors, never as an attribute.
+
+  **The palette was never copied.** Tailwind emits a utility only where it can see its token, and a
+  `@theme` reached through an `@import` after the Tailwind entry points is not read as theme. The site
+  declared 2 of the kit's 13 tokens, so its stylesheet contained none of `bg-ui-bg`, `text-ui-ink` or
+  `border-ui-line` while its markup used all three — 17,012 bytes of sheet with the layout utilities
+  present and the palette absent.
+
+  Both are fixed, and `UiKitWiringTests` now holds **every** app that references `Rask.Ui` to both rules
+  rather than only the showcase, which is why the second consumer of the kit reproduced a bug the first
+  had already solved. Checked by putting each half of the bug back and watching the guard name the site.
+
+
 - **The SQLite journey's database assertions reported machine load as a product failure.** The bulk
   imports and the concurrent-writer bursts waited on Playwright's default 5s budget for work that
   takes 1–3s idle, so roughly two seconds of headroom stood between a green suite and a red one

--- a/samples/Rask.Example.Site/App.cs
+++ b/samples/Rask.Example.Site/App.cs
@@ -40,5 +40,22 @@ public partial class App : Component
         Link.Rel("stylesheet").Href(LiveOptions.PathBase + "/css/app.css")
     ];
 
+    /// <summary>
+    ///     Turns the kit's theme on for the whole document.
+    /// </summary>
+    /// <remarks>
+    ///     Load-bearing, not decorative — and its absence is what shipped this page to rask.sh with no
+    ///     colour at all. The kit scopes daisyUI's theme to this attribute so that referencing the
+    ///     package cannot repaint an app that only wanted a button, which means every <c>--color-ui-*</c>
+    ///     token resolves to nothing until something in the ancestry carries it. The failure is silent:
+    ///     structure and layout survive, colour does not, and nothing that only reads class names
+    ///     notices. The showcase carries the same override for the same reason.
+    /// </remarks>
+    protected override Component Shell(Component head, Component body) =>
+        Html.Lang(HtmlLang).Dir(HtmlDir).Attributes((UiStylesheet.ThemeScopeAttribute, ""))[
+            head,
+            Body.Class(BodyClass)[body]
+        ];
+
     protected override Component? Render() => Router;
 }

--- a/samples/Rask.Example.Site/Styles/app.css
+++ b/samples/Rask.Example.Site/Styles/app.css
@@ -24,6 +24,29 @@
   greys would be the drift this kit was extracted to stop.
 */
 @theme {
+  /*
+    The kit's palette, COPIED rather than imported. Tailwind emits a utility only where it can see
+    the token, and a `@theme` reached through an `@import` after the Tailwind entry points is not
+    interpreted as theme — so without this copy every `bg-ui-*`, `text-ui-*` and `border-ui-*` class
+    on this page compiles to nothing at all. That is exactly how the landing page shipped unstyled.
+
+    These mirror src/Rask.Ui/Styles/ui.css. They are aliases onto daisyUI's semantic variables, so
+    they resolve only inside the theme scope — see App.Shell, which carries data-rask-ui.
+  */
+  --color-ui-bg: var(--color-base-100);
+  --color-ui-panel: var(--color-base-100);
+  --color-ui-well: var(--color-base-200);
+  --color-ui-line: var(--color-base-300);
+  --color-ui-ink: var(--color-base-content);
+  --color-ui-muted: var(--color-neutral);
+
+  --color-ui-ok: var(--color-success);
+  --color-ui-warn: var(--color-warning);
+  --color-ui-danger: var(--color-error);
+
+  --color-ui-ok-ink: var(--color-success);
+  --color-ui-warn-ink: var(--color-warning);
+
   --color-ui-brand: oklch(0.55 0.22 292);
 
   /* The accent as TEXT on a light ground. The brand above is a fill — on white it measures 4.1:1,

--- a/tests/Rask.Example.Shared.Tests/UiKitWiringTests.cs
+++ b/tests/Rask.Example.Shared.Tests/UiKitWiringTests.cs
@@ -1,0 +1,109 @@
+using System.Text.RegularExpressions;
+
+namespace Rask.Example.Shared.Tests;
+
+/// <summary>
+/// Every app that draws with <c>Rask.Ui</c> is wired for it: it copies the kit's palette into its own
+/// <c>@theme</c>, and it turns the kit's theme scope on.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists because the landing site shipped to rask.sh with neither, and nothing noticed. Both
+/// failures are silent in exactly the same way: the build stays green, the class names in the markup
+/// stay correct, and the page arrives with no colour. <c>UiPaletteTests</c> guarded the showcase's copy
+/// alone, so the second consumer of the kit reproduced the bug the first one had already solved.
+/// </para>
+/// <para>
+/// The two halves are separate failures with the same symptom, which is why both are checked:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// <b>The palette copy.</b> Tailwind emits a utility only where it can see its token, and a
+/// <c>@theme</c> reached through an <c>@import</c> after the Tailwind entry points is not read as
+/// theme. Without the copy the utilities are never generated — the site's sheet had none of
+/// <c>bg-ui-bg</c>, <c>text-ui-ink</c> or <c>border-ui-line</c> while its markup used all three.
+/// </item>
+/// <item>
+/// <b>The theme scope.</b> The kit confines daisyUI's theme to <c>data-rask-ui</c> so that referencing
+/// the package cannot repaint an app that only wanted a button. Every kit token is an alias onto
+/// <c>--color-base-*</c>, which is defined only inside that scope — so without the attribute the
+/// utilities generate and then resolve to nothing.
+/// </item>
+/// </list>
+/// <para>
+/// Values are NOT required to match here: an app may deliberately redefine a token, as the landing site
+/// does for the brand accent. <c>UiPaletteTests</c> holds the showcase to the stricter same-value rule.
+/// What is required is that every token the kit declares is declared, so nothing is silently dropped.
+/// </para>
+/// </remarks>
+public sealed class UiKitWiringTests
+{
+    private static readonly Regex Token =
+        new(@"(?<name>--color-ui-[a-z0-9-]+)\s*:", RegexOptions.Compiled);
+
+    // The sample apps that reference Rask.Ui AND compile a stylesheet of their own. A new one added
+    // without its palette copy fails here rather than on a deployed page.
+    public static TheoryData<string> KitApps() =>
+    [
+        Path.Combine("samples", "Rask.Example.Shared"),
+        Path.Combine("samples", "Rask.Example.Site"),
+    ];
+
+    [Theory]
+    [MemberData(nameof(KitApps))]
+    public void EveryKitApp_CopiesEveryPaletteToken(string appDir)
+    {
+        var kit = Tokens(Path.Combine(RepoRoot(), "src", "Rask.Ui", "Styles", "ui.css"));
+        var app = Tokens(Path.Combine(RepoRoot(), appDir, "Styles", "app.css"));
+
+        // Guard the extractor: a regex that stopped matching would make this vacuous, which is the
+        // exact shape of failure this file is about.
+        Assert.True(kit.Count >= 13, $"only {kit.Count} token(s) parsed out of the kit's palette.");
+
+        var missing = kit.Where(t => !app.Contains(t)).Order(StringComparer.Ordinal).ToArray();
+
+        Assert.True(
+            missing.Length == 0,
+            $"{appDir}/Styles/app.css is missing {string.Join(", ", missing)} from its @theme, so every "
+            + "utility naming them is silently dropped from its stylesheet and the page renders "
+            + "structurally correct with no colour.");
+    }
+
+    [Theory]
+    [MemberData(nameof(KitApps))]
+    public void EveryKitApp_TurnsTheThemeScopeOn(string appDir)
+    {
+        var root = Path.Combine(RepoRoot(), appDir, "App.cs");
+        Assert.True(File.Exists(root), $"{appDir} has no App.cs to carry the theme scope.");
+
+        var source = File.ReadAllText(root);
+
+        Assert.True(
+            source.Contains("ThemeScopeAttribute", StringComparison.Ordinal),
+            $"{appDir}/App.cs never sets UiStylesheet.ThemeScopeAttribute, so daisyUI's theme is out of "
+            + "scope for the whole document and every --color-ui-* token resolves to nothing. Put it on "
+            + "<html> in a Shell override, as the showcase does.");
+    }
+
+    private static HashSet<string> Tokens(string path)
+    {
+        var text = File.ReadAllText(path);
+        return Token.Matches(text).Select(m => m.Groups["name"].Value).ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            if (Directory.Exists(Path.Combine(dir, ".git")) || File.Exists(Path.Combine(dir, "Rask.slnx")))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException("could not locate the repository root from " + AppContext.BaseDirectory);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the live landing page at rask.sh, which is currently serving with **no colour at all**.

`Rask.Example.Site` draws with `Rask.Ui` but was wired for neither half of it. Both failures are silent in exactly the same way: the build stays green, the class names in the markup stay correct, and the page arrives unstyled — so nothing that reads class names could have caught it.

### 1. The theme scope was never turned on

The kit confines daisyUI's theme to `data-rask-ui` so that merely *referencing* the package cannot repaint an app that only wanted a button. Every `--color-ui-*` token is an alias onto `--color-base-*`, which daisyUI defines only inside that scope.

The site's root component had no `Shell` override, so the attribute reached no element. On the served page `data-rask-ui` appears **only inside CSS selectors**, never as an attribute — so the entire palette resolved to nothing. `UiStylesheet.ThemeScopeAttribute`'s own doc says it: *"Nothing in the kit has a colour until something in its ancestry carries this."* The showcase has carried this override all along.

### 2. The palette was never copied

Tailwind emits a utility only where it can see its token, and a `@theme` reached through an `@import` after the Tailwind entry points is not read as theme — the kit's header and `UiPaletteTests` both say so.

The site declared **2 of the kit's 13 tokens**. Its compiled sheet was 17,012 bytes containing the layout utilities and none of the palette: zero occurrences of `bg-ui-bg`, `text-ui-ink` or `border-ui-line`, all three of which its markup uses. The kit's tokens are copied in here, with the site's deliberate brand override kept after them.

## The guard

`UiPaletteTests` held only the **showcase** to the copy rule, which is why the second consumer of the kit reproduced a bug the first had already solved. New `UiKitWiringTests` holds **every** app referencing `Rask.Ui` to both rules — the palette copy and the theme scope — as a `[Theory]` over the app list, so a third consumer fails here rather than on a deployed page.

Values are deliberately *not* required to match: an app may redefine a token, as this page does for the brand accent. `UiPaletteTests` keeps the showcase on the stricter same-value rule.

Verified by negative control: with each half of the fix reverted, the guards fail and name the site.

## Testing

`dotnet format`, warnings-as-errors build, the unit suite, and **browser E2E green**. After the fix the site's sheet is 18,325 bytes and carries `bg-ui-bg`, `text-ui-ink`, `border-ui-line` and `text-ui-brand-ink`.

## Follow-ups agreed separately

The kit's sheet is inlined into every document (~205 KB on the live page — [#1018](https://github.com/pal-tamas/rask/issues/1018)). Moving it to a cacheable asset, and adding a theme picker over daisyUI's full theme set, are queued as their own work.
