### PR TITLE
feat(ui): the kit ships every daisyUI theme, typed, with a picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,26 @@ them until tagged releases begin.
 
 ### Added
 
+- **The kit ships every daisyUI theme, and a picker for them.** It carried two — `light` and `dark` —
+  while the vendored bundle already contained all 35, so 33 palettes were being compiled away.
+
+  Costed before it was taken, because the sheet is inlined into every document: the whole set is
+  **+6.2 KB gzipped** (30.6 KB → 36.8 KB, 205 KB → 241 KB raw). A theme is a block of custom properties
+  rather than a second copy of the component rules, which is why thirty-three of them cost so little.
+
+  `UiThemeName` names them, so choosing one is checked by the compiler rather than spelled into a
+  string — an unmatched `data-theme` is not an error anywhere, it simply selects nothing and the palette
+  stays where it was. `UiThemeTests` holds the enum and the compiled sheet to each other in **both**
+  directions, since one is a C# file and the other is daisyUI's `themes:` option and nothing else keeps
+  them in step.
+
+  `UiThemePicker` is the whole set as a radio group of `theme-controller` inputs, which daisyUI matches
+  in CSS — so it switches the palette with no JavaScript, like `UiThemeController` before it. Radios
+  rather than a `<select>` for exactly that reason: a select's value is only readable from a script, and
+  there is none. Nothing persists the choice; an app that wants it remembered should render `data-theme`
+  from its own stored preference.
+
+
 - **Email confirmation and password reset, over the mail battery.** Registering now sends a
   confirmation link, `/forgot-password` emails a reset link, and `/reset-password` and `/confirm-email`
   are where those links land — three more built-in pages, overridable the same way `/login` is, and

--- a/src/Rask.Ui/PublicAPI/net10.0-browser/PublicAPI.Unshipped.txt
+++ b/src/Rask.Ui/PublicAPI/net10.0-browser/PublicAPI.Unshipped.txt
@@ -1183,6 +1183,7 @@ Rask.Ui.UiTextarea.Tone.set -> void
 Rask.Ui.UiTextarea.UiTextarea() -> void
 Rask.Ui.UiTextarea.Value.get -> string?
 Rask.Ui.UiTextarea.Value.set -> void
+Rask.Ui.UiTheme
 Rask.Ui.UiThemeController
 Rask.Ui.UiThemeController.Class.get -> string?
 Rask.Ui.UiThemeController.Class.set -> void
@@ -1193,6 +1194,50 @@ Rask.Ui.UiThemeController.Size.set -> void
 Rask.Ui.UiThemeController.Theme.get -> string?
 Rask.Ui.UiThemeController.Theme.set -> void
 Rask.Ui.UiThemeController.UiThemeController() -> void
+Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Abyss = 2 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Acid = 3 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Aqua = 4 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Autumn = 5 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Black = 6 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Bumblebee = 7 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Business = 8 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Caramellatte = 9 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Cmyk = 10 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Coffee = 11 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Corporate = 12 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Cupcake = 13 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Cyberpunk = 14 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Dark = 1 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Dim = 15 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Dracula = 16 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Emerald = 17 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Fantasy = 18 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Forest = 19 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Garden = 20 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Halloween = 21 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Lemonade = 22 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Light = 0 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Lofi = 23 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Luxury = 24 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Night = 25 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Nord = 26 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Pastel = 27 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Retro = 28 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Silk = 29 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Sunset = 30 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Synthwave = 31 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Valentine = 32 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Winter = 33 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Wireframe = 34 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemePicker
+Rask.Ui.UiThemePicker.Class.get -> string?
+Rask.Ui.UiThemePicker.Class.set -> void
+Rask.Ui.UiThemePicker.GroupName.get -> string!
+Rask.Ui.UiThemePicker.GroupName.set -> void
+Rask.Ui.UiThemePicker.Themes.get -> System.Collections.Generic.IReadOnlyList<Rask.Ui.UiThemeName>?
+Rask.Ui.UiThemePicker.Themes.set -> void
+Rask.Ui.UiThemePicker.UiThemePicker() -> void
 Rask.Ui.UiTimeline
 Rask.Ui.UiTimeline.Class.get -> string?
 Rask.Ui.UiTimeline.Class.set -> void
@@ -1280,6 +1325,8 @@ const Rask.Ui.UiStyles.Quiet = "inline-flex min-h-11 items-center rounded-lg px-
 const Rask.Ui.UiStyles.Value = "mt-2 text-2xl font-semibold tabular-nums tracking-tight text-base-content sm:text-3xl" -> string!
 const Rask.Ui.UiStylesheet.ThemeScopeAttribute = "data-rask-ui" -> string!
 static Rask.Ui.UiStylesheet.Css.get -> string!
+static Rask.Ui.UiTheme.All.get -> System.Collections.Generic.IReadOnlyList<Rask.Ui.UiThemeName>!
+static Rask.Ui.UiTheme.Value(Rask.Ui.UiThemeName theme) -> string!
 static RaskBuilderSettersRask_Ui.AccessibleLabel(this Rask.Core.Build<Rask.Ui.UiSearch!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiSearch!>
 static RaskBuilderSettersRask_Ui.AccessibleLabel(this Rask.Core.Build<Rask.Ui.UiSwap!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiSwap!>
 static RaskBuilderSettersRask_Ui.Action(this Rask.Core.Build<Rask.Ui.UiCard!> __b, Rask.Core.Component? value) -> Rask.Core.Build<Rask.Ui.UiCard!>
@@ -1358,6 +1405,7 @@ static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiSteps!> __
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiSwap!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiSwap!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiTextarea!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiTextarea!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiThemeController!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiThemeController!>
+static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiThemePicker!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiThemePicker!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiTimeline!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiTimeline!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiToggle!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiToggle!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiTooltip!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiTooltip!>
@@ -1382,6 +1430,7 @@ static RaskBuilderSettersRask_Ui.Footer(this Rask.Core.Build<Rask.Ui.UiModal!> _
 static RaskBuilderSettersRask_Ui.Group(this Rask.Core.Build<Rask.Ui.UiCollapse!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiCollapse!>
 static RaskBuilderSettersRask_Ui.Group(this Rask.Core.Build<Rask.Ui.UiRadio!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiRadio!>
 static RaskBuilderSettersRask_Ui.Group(this Rask.Core.Build<Rask.Ui.UiRating!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiRating!>
+static RaskBuilderSettersRask_Ui.GroupName(this Rask.Core.Build<Rask.Ui.UiThemePicker!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiThemePicker!>
 static RaskBuilderSettersRask_Ui.Grow(this Rask.Core.Build<Rask.Ui.UiListRow!> __b, Rask.Core.Component! value) -> Rask.Core.Build<Rask.Ui.UiListRow!>
 static RaskBuilderSettersRask_Ui.HandleLabel(this Rask.Core.Build<Rask.Ui.UiDiff!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiDiff!>
 static RaskBuilderSettersRask_Ui.Heading(this Rask.Core.Build<Rask.Ui.UiCard!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiCard!>
@@ -1509,6 +1558,7 @@ static RaskBuilderSettersRask_Ui.Text(this Rask.Core.Build<Rask.Ui.UiRadio!> __b
 static RaskBuilderSettersRask_Ui.Text(this Rask.Core.Build<Rask.Ui.UiStep!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiStep!>
 static RaskBuilderSettersRask_Ui.Text(this Rask.Core.Build<Rask.Ui.UiToggle!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiToggle!>
 static RaskBuilderSettersRask_Ui.Theme(this Rask.Core.Build<Rask.Ui.UiThemeController!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiThemeController!>
+static RaskBuilderSettersRask_Ui.Themes(this Rask.Core.Build<Rask.Ui.UiThemePicker!> __b, System.Collections.Generic.IReadOnlyList<Rask.Ui.UiThemeName>? value) -> Rask.Core.Build<Rask.Ui.UiThemePicker!>
 static RaskBuilderSettersRask_Ui.Tip(this Rask.Core.Build<Rask.Ui.UiTooltip!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiTooltip!>
 static RaskBuilderSettersRask_Ui.Title(this Rask.Core.Build<Rask.Ui.UiCollapse!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiCollapse!>
 static RaskBuilderSettersRask_Ui.Title(this Rask.Core.Build<Rask.Ui.UiModal!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiModal!>
@@ -1629,6 +1679,7 @@ static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiSwap(Rask.Core.Compo
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiTab(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiTextarea(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiThemeController(Rask.Core.Component! __c0) -> void
+static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiThemePicker(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiTimeline(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiToast(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiToggle(Rask.Core.Component! __c0) -> void
@@ -1701,6 +1752,7 @@ static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiSwap(Rask.Core.Com
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiTab(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiTextarea(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiThemeController(Rask.Core.Component! __c0, ulong __p) -> void
+static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiThemePicker(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiTimeline(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiToast(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiToggle(Rask.Core.Component! __c0, ulong __p) -> void
@@ -1781,6 +1833,7 @@ static RaskEntriesRask_Ui.UiTable.get -> Rask.Core.Build<Rask.Ui.UiTable!>
 static RaskEntriesRask_Ui.UiTabs.get -> Rask.Core.Build<Rask.Ui.UiTabs!>
 static RaskEntriesRask_Ui.UiTextarea.get -> Rask.Ui.RaskSeed_UiTextarea
 static RaskEntriesRask_Ui.UiThemeController.get -> Rask.Ui.RaskSeed_UiThemeController
+static RaskEntriesRask_Ui.UiThemePicker.get -> Rask.Core.Build<Rask.Ui.UiThemePicker!>
 static RaskEntriesRask_Ui.UiTimeline.get -> Rask.Core.Build<Rask.Ui.UiTimeline!>
 static RaskEntriesRask_Ui.UiToast.get -> Rask.Ui.RaskSeed_UiToast
 static RaskEntriesRask_Ui.UiToggle.get -> Rask.Ui.RaskSeed_UiToggle

--- a/src/Rask.Ui/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Rask.Ui/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1183,6 +1183,7 @@ Rask.Ui.UiTextarea.Tone.set -> void
 Rask.Ui.UiTextarea.UiTextarea() -> void
 Rask.Ui.UiTextarea.Value.get -> string?
 Rask.Ui.UiTextarea.Value.set -> void
+Rask.Ui.UiTheme
 Rask.Ui.UiThemeController
 Rask.Ui.UiThemeController.Class.get -> string?
 Rask.Ui.UiThemeController.Class.set -> void
@@ -1193,6 +1194,50 @@ Rask.Ui.UiThemeController.Size.set -> void
 Rask.Ui.UiThemeController.Theme.get -> string?
 Rask.Ui.UiThemeController.Theme.set -> void
 Rask.Ui.UiThemeController.UiThemeController() -> void
+Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Abyss = 2 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Acid = 3 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Aqua = 4 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Autumn = 5 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Black = 6 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Bumblebee = 7 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Business = 8 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Caramellatte = 9 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Cmyk = 10 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Coffee = 11 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Corporate = 12 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Cupcake = 13 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Cyberpunk = 14 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Dark = 1 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Dim = 15 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Dracula = 16 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Emerald = 17 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Fantasy = 18 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Forest = 19 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Garden = 20 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Halloween = 21 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Lemonade = 22 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Light = 0 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Lofi = 23 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Luxury = 24 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Night = 25 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Nord = 26 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Pastel = 27 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Retro = 28 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Silk = 29 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Sunset = 30 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Synthwave = 31 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Valentine = 32 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Winter = 33 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemeName.Wireframe = 34 -> Rask.Ui.UiThemeName
+Rask.Ui.UiThemePicker
+Rask.Ui.UiThemePicker.Class.get -> string?
+Rask.Ui.UiThemePicker.Class.set -> void
+Rask.Ui.UiThemePicker.GroupName.get -> string!
+Rask.Ui.UiThemePicker.GroupName.set -> void
+Rask.Ui.UiThemePicker.Themes.get -> System.Collections.Generic.IReadOnlyList<Rask.Ui.UiThemeName>?
+Rask.Ui.UiThemePicker.Themes.set -> void
+Rask.Ui.UiThemePicker.UiThemePicker() -> void
 Rask.Ui.UiTimeline
 Rask.Ui.UiTimeline.Class.get -> string?
 Rask.Ui.UiTimeline.Class.set -> void
@@ -1280,6 +1325,8 @@ const Rask.Ui.UiStyles.Quiet = "inline-flex min-h-11 items-center rounded-lg px-
 const Rask.Ui.UiStyles.Value = "mt-2 text-2xl font-semibold tabular-nums tracking-tight text-base-content sm:text-3xl" -> string!
 const Rask.Ui.UiStylesheet.ThemeScopeAttribute = "data-rask-ui" -> string!
 static Rask.Ui.UiStylesheet.Css.get -> string!
+static Rask.Ui.UiTheme.All.get -> System.Collections.Generic.IReadOnlyList<Rask.Ui.UiThemeName>!
+static Rask.Ui.UiTheme.Value(Rask.Ui.UiThemeName theme) -> string!
 static RaskBuilderSettersRask_Ui.AccessibleLabel(this Rask.Core.Build<Rask.Ui.UiSearch!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiSearch!>
 static RaskBuilderSettersRask_Ui.AccessibleLabel(this Rask.Core.Build<Rask.Ui.UiSwap!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiSwap!>
 static RaskBuilderSettersRask_Ui.Action(this Rask.Core.Build<Rask.Ui.UiCard!> __b, Rask.Core.Component? value) -> Rask.Core.Build<Rask.Ui.UiCard!>
@@ -1358,6 +1405,7 @@ static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiSteps!> __
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiSwap!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiSwap!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiTextarea!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiTextarea!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiThemeController!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiThemeController!>
+static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiThemePicker!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiThemePicker!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiTimeline!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiTimeline!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiToggle!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiToggle!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiTooltip!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiTooltip!>
@@ -1382,6 +1430,7 @@ static RaskBuilderSettersRask_Ui.Footer(this Rask.Core.Build<Rask.Ui.UiModal!> _
 static RaskBuilderSettersRask_Ui.Group(this Rask.Core.Build<Rask.Ui.UiCollapse!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiCollapse!>
 static RaskBuilderSettersRask_Ui.Group(this Rask.Core.Build<Rask.Ui.UiRadio!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiRadio!>
 static RaskBuilderSettersRask_Ui.Group(this Rask.Core.Build<Rask.Ui.UiRating!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiRating!>
+static RaskBuilderSettersRask_Ui.GroupName(this Rask.Core.Build<Rask.Ui.UiThemePicker!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiThemePicker!>
 static RaskBuilderSettersRask_Ui.Grow(this Rask.Core.Build<Rask.Ui.UiListRow!> __b, Rask.Core.Component! value) -> Rask.Core.Build<Rask.Ui.UiListRow!>
 static RaskBuilderSettersRask_Ui.HandleLabel(this Rask.Core.Build<Rask.Ui.UiDiff!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiDiff!>
 static RaskBuilderSettersRask_Ui.Heading(this Rask.Core.Build<Rask.Ui.UiCard!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiCard!>
@@ -1509,6 +1558,7 @@ static RaskBuilderSettersRask_Ui.Text(this Rask.Core.Build<Rask.Ui.UiRadio!> __b
 static RaskBuilderSettersRask_Ui.Text(this Rask.Core.Build<Rask.Ui.UiStep!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiStep!>
 static RaskBuilderSettersRask_Ui.Text(this Rask.Core.Build<Rask.Ui.UiToggle!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiToggle!>
 static RaskBuilderSettersRask_Ui.Theme(this Rask.Core.Build<Rask.Ui.UiThemeController!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiThemeController!>
+static RaskBuilderSettersRask_Ui.Themes(this Rask.Core.Build<Rask.Ui.UiThemePicker!> __b, System.Collections.Generic.IReadOnlyList<Rask.Ui.UiThemeName>? value) -> Rask.Core.Build<Rask.Ui.UiThemePicker!>
 static RaskBuilderSettersRask_Ui.Tip(this Rask.Core.Build<Rask.Ui.UiTooltip!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiTooltip!>
 static RaskBuilderSettersRask_Ui.Title(this Rask.Core.Build<Rask.Ui.UiCollapse!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiCollapse!>
 static RaskBuilderSettersRask_Ui.Title(this Rask.Core.Build<Rask.Ui.UiModal!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiModal!>
@@ -1629,6 +1679,7 @@ static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiSwap(Rask.Core.Compo
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiTab(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiTextarea(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiThemeController(Rask.Core.Component! __c0) -> void
+static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiThemePicker(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiTimeline(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiToast(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiToggle(Rask.Core.Component! __c0) -> void
@@ -1701,6 +1752,7 @@ static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiSwap(Rask.Core.Com
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiTab(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiTextarea(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiThemeController(Rask.Core.Component! __c0, ulong __p) -> void
+static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiThemePicker(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiTimeline(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiToast(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiToggle(Rask.Core.Component! __c0, ulong __p) -> void
@@ -1781,6 +1833,7 @@ static RaskEntriesRask_Ui.UiTable.get -> Rask.Core.Build<Rask.Ui.UiTable!>
 static RaskEntriesRask_Ui.UiTabs.get -> Rask.Core.Build<Rask.Ui.UiTabs!>
 static RaskEntriesRask_Ui.UiTextarea.get -> Rask.Ui.RaskSeed_UiTextarea
 static RaskEntriesRask_Ui.UiThemeController.get -> Rask.Ui.RaskSeed_UiThemeController
+static RaskEntriesRask_Ui.UiThemePicker.get -> Rask.Core.Build<Rask.Ui.UiThemePicker!>
 static RaskEntriesRask_Ui.UiTimeline.get -> Rask.Core.Build<Rask.Ui.UiTimeline!>
 static RaskEntriesRask_Ui.UiToast.get -> Rask.Ui.RaskSeed_UiToast
 static RaskEntriesRask_Ui.UiToggle.get -> Rask.Ui.RaskSeed_UiToggle

--- a/src/Rask.Ui/Styles/ui.css
+++ b/src/Rask.Ui/Styles/ui.css
@@ -87,7 +87,7 @@
 @source not "./vendor";
 
 @plugin "./vendor/daisyui.mjs" {
-  themes: light --default, dark --prefersdark;
+  themes: all;
   root: "[data-rask-ui]";
   exclude: rootscrollgutter;
 }

--- a/src/Rask.Ui/UiThemeName.cs
+++ b/src/Rask.Ui/UiThemeName.cs
@@ -1,0 +1,89 @@
+namespace Rask.Ui;
+
+/// <summary>
+/// Every theme the kit ships, named as daisyUI names them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The kit enables daisyUI's whole theme set rather than a curated slice of it, and this is what makes
+/// choosing one a compile-time act instead of a string literal. A typo in <c>data-theme="cupacke"</c>
+/// is not an error anywhere — the attribute is simply unmatched and the palette silently stays put,
+/// which is the same class of silent failure the theme scope already causes when it is missing.
+/// </para>
+/// <para>
+/// Costed before it was taken: the whole set is <b>+6.2 KB gzipped</b> over the two the kit used to
+/// ship (30.6 KB → 36.8 KB), because a theme is a block of custom properties rather than a second copy
+/// of the component rules. Thirty-three extra palettes for that is a trade worth making once, centrally,
+/// rather than asking every app to pick.
+/// </para>
+/// <para>
+/// <see cref="Light" /> is the default and <see cref="Dark" /> follows the operating system. Naming any
+/// other theme means saying so — with <see cref="UiThemePicker" />, or with an explicit
+/// <c>data-theme</c> on the element carrying the theme scope.
+/// </para>
+/// </remarks>
+public enum UiThemeName
+{
+    /// <summary>daisyUI's default light palette. What a surface gets when it asks for nothing.</summary>
+    Light = 0,
+
+    /// <summary>daisyUI's default dark palette. Applied by <c>prefers-color-scheme</c> when no theme is named.</summary>
+    Dark,
+
+    Abyss,
+    Acid,
+    Aqua,
+    Autumn,
+    Black,
+    Bumblebee,
+    Business,
+    Caramellatte,
+    Cmyk,
+    Coffee,
+    Corporate,
+    Cupcake,
+    Cyberpunk,
+    Dim,
+    Dracula,
+    Emerald,
+    Fantasy,
+    Forest,
+    Garden,
+    Halloween,
+    Lemonade,
+    Lofi,
+    Luxury,
+    Night,
+    Nord,
+    Pastel,
+    Retro,
+    Silk,
+    Sunset,
+    Synthwave,
+    Valentine,
+    Winter,
+
+    /// <summary>Borders and type only — daisyUI's unstyled wireframe palette.</summary>
+    Wireframe,
+}
+
+/// <summary>
+/// Turns a <see cref="UiThemeName" /> into the string daisyUI matches on.
+/// </summary>
+public static class UiTheme
+{
+    /// <summary>
+    /// The <c>data-theme</c> value for <paramref name="theme" /> — its name, lowercased.
+    /// </summary>
+    /// <remarks>
+    /// daisyUI's own names are all lowercase single words, so the mapping is mechanical rather than a
+    /// table that could drift out of step with the enum. <c>UiThemeTests</c> holds every member to a
+    /// theme the compiled stylesheet actually defines, so a member added here without the sheet
+    /// shipping it fails the build's tests rather than a page.
+    /// </remarks>
+    public static string Value(UiThemeName theme) =>
+        theme.ToString().ToLowerInvariant();
+
+    /// <summary>Every theme the kit ships, in declaration order.</summary>
+    public static IReadOnlyList<UiThemeName> All { get; } = Enum.GetValues<UiThemeName>();
+}

--- a/src/Rask.Ui/UiThemePicker.cs
+++ b/src/Rask.Ui/UiThemePicker.cs
@@ -1,0 +1,70 @@
+namespace Rask.Ui;
+
+/// <summary>
+/// Picks any of the kit's themes, with no JavaScript.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="UiThemeController" /> is one control for one theme — a light/dark toggle. This is the
+/// whole set: a radio group of <c>theme-controller</c> inputs, which daisyUI matches in CSS
+/// (<c>input.theme-controller[value=x]:checked</c>), so choosing one rewrites the palette with no
+/// script involved. That is why it is radios rather than a <c>&lt;select&gt;</c>: a select's value is
+/// only readable from JavaScript, and there is none here.
+/// </para>
+/// <para>
+/// Nothing persists the choice. There is no script, so there is nothing to persist it with, and the
+/// theme resets on navigation — the same honest trade <see cref="UiThemeController" /> makes. An app
+/// that wants it remembered should render <c>data-theme</c> from its own stored preference instead.
+/// </para>
+/// <para>
+/// It only has an effect inside the kit's theme scope — see
+/// <see cref="UiStylesheet.ThemeScopeAttribute" />. Outside it the inputs still render and still check,
+/// and nothing changes colour, which is the same silent failure a missing scope causes everywhere else.
+/// </para>
+/// </remarks>
+public sealed partial class UiThemePicker : Component
+{
+    /// <summary>
+    /// The radio group's name, so two pickers on one page do not fight over the same selection.
+    /// </summary>
+    public string GroupName { get; set; } = "rask-ui-theme";
+
+    /// <summary>
+    /// The themes to offer. Defaults to every theme the kit ships.
+    /// </summary>
+    /// <remarks>
+    /// Narrowing this is a presentation choice and does not make the others unavailable: the stylesheet
+    /// carries all of them either way, because they are compiled together. Listing a handful here is
+    /// for surfaces where thirty-five radio buttons would be the wrong thing to show a reader.
+    /// </remarks>
+    public IReadOnlyList<UiThemeName>? Themes { get; set; }
+
+    public string? Class { get; set; }
+
+    /// <inheritdoc />
+    protected override Component? Render() =>
+        Ul.Class(UiClass.Compose("menu", Class))[
+            (Themes ?? UiTheme.All).Select(theme =>
+            {
+                var value = UiTheme.Value(theme);
+
+                // Keyed by the theme's own name: the list is stable, but RASK022 holds every list to
+                // identity rather than position, and the name is the identity here.
+                return Li.Key(value)[
+                    Label.Class("flex cursor-pointer items-center gap-2")[
+                        Input
+                            .Value(false)
+                            .Type(InputType.Radio)
+                            .Name(GroupName)
+                            .Class("radio radio-sm theme-controller")
+                            // daisyUI keys the palette off the input's `value`, which is a plain
+                            // attribute here rather than the chain's Value — that one carries the
+                            // checked state.
+                            .Attributes(("value", value))
+                            .Aria(new Dictionary<string, string?> { ["label"] = value }),
+                        Span[value]
+                    ]
+                ];
+            })
+        ];
+}

--- a/tests/Rask.Ui.Tests/UiThemeTests.cs
+++ b/tests/Rask.Ui.Tests/UiThemeTests.cs
@@ -1,0 +1,66 @@
+using Rask.Ui;
+
+namespace Rask.Ui.Tests;
+
+/// <summary>
+/// The typed theme names and the stylesheet agree.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="UiThemeName" /> exists so that naming a theme is checked by the compiler rather than
+/// spelled into a string — but the enum and the compiled sheet are produced by two different things
+/// (a C# file and daisyUI's <c>themes:</c> option), so nothing but this keeps them in step.
+/// </para>
+/// <para>
+/// The failure it prevents is silent in the usual way: an unmatched <c>data-theme</c> is not an error
+/// anywhere, the attribute simply selects nothing and the palette stays where it was.
+/// </para>
+/// </remarks>
+public sealed class UiThemeTests
+{
+    [Fact]
+    public void EveryTypedTheme_IsDefinedByTheStylesheet()
+    {
+        var css = UiStylesheet.Css;
+        Assert.False(string.IsNullOrEmpty(css), "the kit shipped no stylesheet to check against.");
+
+        var missing = UiTheme.All
+            .Select(UiTheme.Value)
+            .Where(name => !css.Contains($"[data-theme={name}]", StringComparison.Ordinal))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(
+            missing.Length == 0,
+            "these are named by UiThemeName but not defined in the compiled sheet, so selecting one "
+            + "changes nothing: " + string.Join(", ", missing));
+    }
+
+    [Fact]
+    public void EveryThemeTheStylesheetDefines_HasATypedName()
+    {
+        // The other direction, so a theme daisyUI adds is not left unreachable from C#.
+        var css = UiStylesheet.Css;
+        var shipped = System.Text.RegularExpressions.Regex
+            .Matches(css, @"\[data-theme=([a-z]+)\]")
+            .Select(m => m.Groups[1].Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var typed = UiTheme.All.Select(UiTheme.Value).ToHashSet(StringComparer.Ordinal);
+        var unreachable = shipped.Where(t => !typed.Contains(t)).Order(StringComparer.Ordinal).ToArray();
+
+        Assert.True(
+            unreachable.Length == 0,
+            "the stylesheet ships these themes with no UiThemeName member, so nothing can select them "
+            + "in typed code: " + string.Join(", ", unreachable));
+    }
+
+    [Fact]
+    public void TheValueIsWhatDaisyUiMatchesOn()
+    {
+        // Lowercased member name, mechanically — the mapping is not a table that can drift.
+        Assert.Equal("light", UiTheme.Value(UiThemeName.Light));
+        Assert.Equal("cupcake", UiTheme.Value(UiThemeName.Cupcake));
+        Assert.Equal("caramellatte", UiTheme.Value(UiThemeName.Caramellatte));
+    }
+}


### PR DESCRIPTION
## Summary

The kit takes daisyUI's whole theme set, names it in C#, and gets a picker for it.

It shipped two themes — `light` and `dark` — while the vendored daisyUI bundle already contained all **35**. Thirty-three palettes were being compiled away on every build.

## What it costs, measured before it was taken

The kit's sheet is inlined into every document, so this is the number that decides the change:

| | raw | gzipped | themes |
|---|---|---|---|
| before | 204,950 B | 30,590 B | 2 |
| after | 241,386 B | 36,824 B | 35 |

**+6.2 KB gzipped** for thirty-three extra palettes. A theme is a block of custom properties, not a second copy of the component rules, which is why the marginal cost is so small. (It does not make [#1018](https://github.com/pal-tamas/rask/issues/1018) go away — 36.8 KB per document is still per document — but it is not the blocker it looked like.)

## Typed, because an unmatched theme is silent

`data-theme="cupacke"` is not an error anywhere: the attribute matches nothing and the palette stays where it was. That is the same shape as the missing theme scope that shipped the landing page grey, so themes are named rather than spelled:

- **`UiThemeName`** — 35 members, named as daisyUI names them, following `UiTone`'s rule that the kit keeps daisyUI's vocabulary rather than inventing a second one.
- **`UiTheme.Value`** — the lowercased member name, mechanically, so the mapping is not a table that can drift.
- **`UiThemeTests`** — holds the enum and the compiled stylesheet to each other in **both** directions. One is a C# file and the other is daisyUI's `themes:` option; nothing else keeps them in step, and a mismatch either way is invisible at runtime.

## The picker

`UiThemeController` was one control for one theme. `UiThemePicker` is the set: a radio group of `theme-controller` inputs, which daisyUI matches in CSS, so it switches the palette with **no JavaScript**.

Radios rather than a `<select>` for that exact reason — a select's value is only readable from a script, and there is none. `Themes` narrows what is offered without making the rest unavailable, since they are all compiled in either way.

Nothing persists the choice: there is no script to persist it with, so it resets on navigation. An app that wants it remembered should render `data-theme` from its own stored preference. Both facts are in the component's own docs rather than left to be discovered.

## Testing

Full local gate: `dotnet format`, warnings-as-errors build, unit suite and browser E2E, all green.

Two of the framework's own guards caught mistakes while writing this, which is worth recording: `RASK022` refused the unkeyed list rows, and the PublicAPI gate refused 53 unrecorded members.
