### PR TITLE
perf(ui): serve the kit's stylesheet as a cached file, and add a theme picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,9 @@ src/Rask.Wasm/Browser/rask-sw.js
 # tree is a build artifact: committing it means a stale stylesheet can be served by a checkout that never
 # ran the build, and every build shows up as a diff.
 **/wwwroot/css/app.css
+# Rask.Ui writes its compiled stylesheet into the consuming app's wwwroot at build, for the same
+# reason: the file in the tree is build output, not source.
+**/wwwroot/css/rask-ui.css
 
 # Island bundles. Vite writes them into wwwroot so the SDK publishes them with no publish target
 # of its own — but they are build output, regenerated on every build, and the chunk names are hashed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,20 @@ them until tagged releases begin.
 
 ### Added
 
+- **The landing site and the showcase carry a theme picker.** `UiThemeDropdown` puts the kit's whole
+  theme set behind one trigger, so a bar with no room for thirty-five radios can still offer them.
+
+  It works on the landing page *because* that page ships no JavaScript: daisyUI matches the checked
+  radio in CSS, so nothing has to swap a class. The showcase's light/dark toggle had been removed when
+  the showcase went light on the kit's palette — there was no second theme to flip to — and it returns
+  as the whole set, still with no `IJSRuntime` injected into the layout.
+
+  Built as a `<details>` rather than on `UiDropdown`, and structurally so: that component supplies its
+  own `<ul class="menu">` for children and the picker is already a `<ul>`, so composing them would nest
+  one list directly inside another. The list scrolls, because thirty-five rows is taller than most
+  viewports.
+
+
 - **The kit ships every daisyUI theme, and a picker for them.** It carried two — `light` and `dark` —
   while the vendored bundle already contained all 35, so 33 palettes were being compiled away.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,26 @@ them until tagged releases begin.
 
 ### Changed
 
+- **The kit's stylesheet is served and cached instead of inlined into every document**
+  ([#1018](https://github.com/pal-tamas/rask/issues/1018)). It was 36.8 KB gzipped in the `<head>` of
+  every page, paid again on each one, which is the cost that issue was filed about.
+
+  The kit's build now writes the compiled sheet to `wwwroot/css/rask-ui.css` and apps link it, with the
+  sheet's own content hash as the cache-buster — so it is cached hard and busts exactly when the bytes
+  change. `UiStylesheet.Href(pathBase)` builds the URL; `Path` and `Version` are there for a surface
+  that wants to place it itself.
+
+  Measured on the landing page's publish: the document went from **268,143 to 63,702 bytes** (−76%),
+  and the sheet is published pre-compressed at **28.9 KB brotli**. It is fetched once.
+
+  The earlier reasoning against this is recorded in `UiStylesheet` and still holds where it applied: a
+  static web asset would need the Razor SDK and a `_content/` path a host has to map. This copies a
+  plain file, so none of that machinery arrives — and `UiStylesheet.Css` stays, because
+  **`Rask.Dashboard` still inlines**, deliberately: the console is mounted into somebody else's host,
+  which references the dashboard rather than the kit and so never gets the build hook. A `<link>` there
+  would point at a file nothing produced.
+
+
 - **`.gitignore` no longer lets a sample's SQLite database be committed.** The runtime-artifact block
   carried a comment claiming it was "no longer a per-sample list" and was exactly that: it named only
   `app.db` and `logs.db`, so a sample whose database has any other filename was never ignored and got

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -52,6 +52,14 @@
   <Import Project="$(MSBuildThisFileDirectory)src\Rask.Tailwind\build\Rask.Tailwind.targets"
           Condition=" Exists('$(MSBuildThisFileDirectory)src\Rask.Tailwind\build\Rask.Tailwind.targets') "/>
 
+  <!--
+    The kit's build hook, which writes its compiled stylesheet into the app's wwwroot so a browser can
+    cache it instead of re-reading 36.8 KB inlined in every document. A package consumer gets this
+    automatically; in-repo a ProjectReference does not carry it, so it is imported here like the rest.
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)src\Rask.Ui\build\Rask.Ui.targets"
+          Condition=" Exists('$(MSBuildThisFileDirectory)src\Rask.Ui\build\Rask.Ui.targets') "/>
+
   <Import Project="$(MSBuildThisFileDirectory)src\Rask.Server\build\Rask.Server.Browser.targets"
           Condition=" Exists('$(MSBuildThisFileDirectory)src\Rask.Server\build\Rask.Server.Browser.targets') "/>
 

--- a/samples/Rask.Example.Shared/App.cs
+++ b/samples/Rask.Example.Shared/App.cs
@@ -60,7 +60,10 @@ public partial class App : Component
         //
         // First, because the tokens below are meant to override the kit's, and an override only wins
         // while it is the copy the cascade reads last.
-        Style[Raw.Value(UiStylesheet.Css)],
+        // Linked rather than inlined: 36.8 KB gzipped on every document of a site read page to
+        // page is the cost #1018 was filed about. The build writes it into wwwroot; the href carries
+        // the sheet's content hash so it caches hard and busts only when it changes.
+        Link.Rel("stylesheet").Href(UiStylesheet.Href(LiveOptions.PathBase)),
         // Tailwind, compiled from Styles/app.css at this project's build. It replaced a three-sheet
         // stack — Bootstrap, the design tokens, then global.css overriding both — where the cascade
         // ORDER was what decided the outcome and a comment was the only thing keeping it right.

--- a/samples/Rask.Example.Shared/App.cs
+++ b/samples/Rask.Example.Shared/App.cs
@@ -63,7 +63,13 @@ public partial class App : Component
         // Linked rather than inlined: 36.8 KB gzipped on every document of a site read page to
         // page is the cost #1018 was filed about. The build writes it into wwwroot; the href carries
         // the sheet's content hash so it caches hard and busts only when it changes.
-        Link.Rel("stylesheet").Href(UiStylesheet.Href(LiveOptions.PathBase)),
+        // Served from the SHARED project, so it lives under _content/{assembly}/ like app.css below —
+        // NOT under /css/, which is this host's own wwwroot. UiStylesheet.Path is the app-root default
+        // and is wrong here for exactly the reason the next comment gives: a 404 stylesheet is
+        // invisible, and the page renders unstyled with nothing failing.
+        Link
+            .Rel("stylesheet")
+            .Href(UiStylesheet.Href(LiveOptions.PathBase + "/_content/Rask.Example.Shared")),
         // Tailwind, compiled from Styles/app.css at this project's build. It replaced a three-sheet
         // stack — Bootstrap, the design tokens, then global.css overriding both — where the cascade
         // ORDER was what decided the outcome and a comment was the only thing keeping it right.

--- a/samples/Rask.Example.Shared/Rask.Example.Shared.csproj
+++ b/samples/Rask.Example.Shared/Rask.Example.Shared.csproj
@@ -103,4 +103,14 @@
     <Using Include="Rask.Ui"/>
   </ItemGroup>
 
+
+  <PropertyGroup>
+    <!--
+      Take the kit's stylesheet as a cached FILE rather than inlining it. Opt-in, because referencing
+      the kit is not the same as wanting a file in wwwroot — see Rask.Ui's build targets. Linked in
+      App.HeadAssets with UiStylesheet.Href().
+    -->
+    <RaskUiWriteStylesheet>true</RaskUiWriteStylesheet>
+  </PropertyGroup>
+
 </Project>

--- a/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
+++ b/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
@@ -113,9 +113,12 @@ public sealed partial class ShowcaseLayout(RouteState route, IEnumerable<Showcas
                     .Class(TopAction + " border border-ui-line bg-ui-bg text-ui-ink hover:bg-ui-well")[
                     UiIcon.Name(UiIconName.Star).Class("size-4 shrink-0"), "GitHub"
                 ]
-                // The light/dark toggle is gone. The showcase is light now, on the palette Rask.Ui
-                // declares, so there is no second theme to flip to — and with it went the only reason
-                // this layout injected IJSRuntime at all.
+                ,
+                // The light/dark toggle that used to sit here went when the showcase became light on
+                // the kit's palette: there was no second theme to flip to. There are thirty-five now,
+                // so it comes back as the whole set — and still with no IJSRuntime, because daisyUI
+                // matches the checked radio in CSS rather than asking a script to swap a class.
+                UiThemeDropdown.Placement("dropdown-end")
             ]
         ],
         Div.Class("flex app-shell")[

--- a/samples/Rask.Example.Site/App.cs
+++ b/samples/Rask.Example.Site/App.cs
@@ -34,9 +34,12 @@ public partial class App : Component
 
         // The kit's sheet FIRST, this page's second. The kit declares the --color-ui-* palette and the
         // page redefines the accent in its own @theme; an override only wins while it is the copy the
-        // cascade reads last. Inlined rather than served because the kit ships no static assets — see
-        // UiStylesheet.
-        Style[Raw.Value(UiStylesheet.Css)],
+        // cascade reads last.
+        //
+        // Linked rather than inlined: the sheet is 36.8 KB gzipped and was being paid on every
+        // document. The build writes it into wwwroot and the href carries its content hash, so it is
+        // cached hard and busts exactly when the bytes change.
+        Link.Rel("stylesheet").Href(UiStylesheet.Href(LiveOptions.PathBase)),
         Link.Rel("stylesheet").Href(LiveOptions.PathBase + "/css/app.css")
     ];
 

--- a/samples/Rask.Example.Site/Pages/HomePage.cs
+++ b/samples/Rask.Example.Site/Pages/HomePage.cs
@@ -87,7 +87,11 @@ public sealed partial class HomePage : Component
                     // stacking over two lines push the hero below the fold on a phone.
                     NavItem("Docs", "docs/", hideOnPhone: true),
                     NavItem("Playground", "playground/", hideOnPhone: true),
-                    NavItem("GitHub", "https://github.com/pal-tamas/rask", hideOnPhone: false)
+                    NavItem("GitHub", "https://github.com/pal-tamas/rask", hideOnPhone: false),
+
+                    // Every theme the kit ships, switched in CSS. It works on this page precisely
+                    // because the page ships no JavaScript — daisyUI matches the checked radio itself.
+                    UiThemeDropdown.Placement("dropdown-end")
                 ]
             ]
         ];

--- a/samples/Rask.Example.Site/Rask.Example.Site.csproj
+++ b/samples/Rask.Example.Site/Rask.Example.Site.csproj
@@ -78,4 +78,14 @@
   </ItemGroup>
 
 
+
+  <PropertyGroup>
+    <!--
+      Take the kit's stylesheet as a cached FILE rather than inlining it. Opt-in, because referencing
+      the kit is not the same as wanting a file in wwwroot — see Rask.Ui's build targets. Linked in
+      App.HeadAssets with UiStylesheet.Href().
+    -->
+    <RaskUiWriteStylesheet>true</RaskUiWriteStylesheet>
+  </PropertyGroup>
+
 </Project>

--- a/src/Rask.Dashboard/Pages/DashboardLayout.cs
+++ b/src/Rask.Dashboard/Pages/DashboardLayout.cs
@@ -86,6 +86,10 @@ public sealed partial class DashboardLayout(
         // the classes these pages write are compiled here — neither build can see the other's markup.
         // Order is the contract: the console's @theme redefines the --color-ui-* tokens the kit declares,
         // and an override only wins while it is the copy the cascade reads last.
+        // INLINED here, unlike the apps, and deliberately. The console is mounted into somebody
+        // else's host at /_rask: that host references Rask.Dashboard, not Rask.Ui, so it never gets
+        // the build target that writes the sheet into wwwroot, and a <link> would point at a file
+        // nothing produced. An app that references the kit directly links the cached copy instead.
         Style[Raw.Value(UiStylesheet.Css)],
         Style[Raw.Value(Css)],
     ];

--- a/src/Rask.Ui/PublicAPI/net10.0-browser/PublicAPI.Unshipped.txt
+++ b/src/Rask.Ui/PublicAPI/net10.0-browser/PublicAPI.Unshipped.txt
@@ -1194,6 +1194,18 @@ Rask.Ui.UiThemeController.Size.set -> void
 Rask.Ui.UiThemeController.Theme.get -> string?
 Rask.Ui.UiThemeController.Theme.set -> void
 Rask.Ui.UiThemeController.UiThemeController() -> void
+Rask.Ui.UiThemeDropdown
+Rask.Ui.UiThemeDropdown.Class.get -> string?
+Rask.Ui.UiThemeDropdown.Class.set -> void
+Rask.Ui.UiThemeDropdown.GroupName.get -> string!
+Rask.Ui.UiThemeDropdown.GroupName.set -> void
+Rask.Ui.UiThemeDropdown.Placement.get -> string?
+Rask.Ui.UiThemeDropdown.Placement.set -> void
+Rask.Ui.UiThemeDropdown.Themes.get -> System.Collections.Generic.IReadOnlyList<Rask.Ui.UiThemeName>?
+Rask.Ui.UiThemeDropdown.Themes.set -> void
+Rask.Ui.UiThemeDropdown.Trigger.get -> string!
+Rask.Ui.UiThemeDropdown.Trigger.set -> void
+Rask.Ui.UiThemeDropdown.UiThemeDropdown() -> void
 Rask.Ui.UiThemeName
 Rask.Ui.UiThemeName.Abyss = 2 -> Rask.Ui.UiThemeName
 Rask.Ui.UiThemeName.Acid = 3 -> Rask.Ui.UiThemeName
@@ -1408,6 +1420,7 @@ static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiSteps!> __
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiSwap!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiSwap!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiTextarea!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiTextarea!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiThemeController!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiThemeController!>
+static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiThemeDropdown!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiThemeDropdown!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiThemePicker!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiThemePicker!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiTimeline!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiTimeline!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiToggle!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiToggle!>
@@ -1433,6 +1446,7 @@ static RaskBuilderSettersRask_Ui.Footer(this Rask.Core.Build<Rask.Ui.UiModal!> _
 static RaskBuilderSettersRask_Ui.Group(this Rask.Core.Build<Rask.Ui.UiCollapse!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiCollapse!>
 static RaskBuilderSettersRask_Ui.Group(this Rask.Core.Build<Rask.Ui.UiRadio!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiRadio!>
 static RaskBuilderSettersRask_Ui.Group(this Rask.Core.Build<Rask.Ui.UiRating!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiRating!>
+static RaskBuilderSettersRask_Ui.GroupName(this Rask.Core.Build<Rask.Ui.UiThemeDropdown!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiThemeDropdown!>
 static RaskBuilderSettersRask_Ui.GroupName(this Rask.Core.Build<Rask.Ui.UiThemePicker!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiThemePicker!>
 static RaskBuilderSettersRask_Ui.Grow(this Rask.Core.Build<Rask.Ui.UiListRow!> __b, Rask.Core.Component! value) -> Rask.Core.Build<Rask.Ui.UiListRow!>
 static RaskBuilderSettersRask_Ui.HandleLabel(this Rask.Core.Build<Rask.Ui.UiDiff!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiDiff!>
@@ -1523,6 +1537,7 @@ static RaskBuilderSettersRask_Ui.Placeholder(this Rask.Core.Build<Rask.Ui.UiSear
 static RaskBuilderSettersRask_Ui.Placeholder(this Rask.Core.Build<Rask.Ui.UiSelect!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiSelect!>
 static RaskBuilderSettersRask_Ui.Placeholder(this Rask.Core.Build<Rask.Ui.UiTextarea!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiTextarea!>
 static RaskBuilderSettersRask_Ui.Placement(this Rask.Core.Build<Rask.Ui.UiDropdown!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiDropdown!>
+static RaskBuilderSettersRask_Ui.Placement(this Rask.Core.Build<Rask.Ui.UiThemeDropdown!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiThemeDropdown!>
 static RaskBuilderSettersRask_Ui.Placement(this Rask.Core.Build<Rask.Ui.UiTooltip!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiTooltip!>
 static RaskBuilderSettersRask_Ui.Round(this Rask.Core.Build<Rask.Ui.UiAvatar!> __b, bool? value) -> Rask.Core.Build<Rask.Ui.UiAvatar!>
 static RaskBuilderSettersRask_Ui.Rows(this Rask.Core.Build<Rask.Ui.UiTextarea!> __b, int? value) -> Rask.Core.Build<Rask.Ui.UiTextarea!>
@@ -1561,6 +1576,7 @@ static RaskBuilderSettersRask_Ui.Text(this Rask.Core.Build<Rask.Ui.UiRadio!> __b
 static RaskBuilderSettersRask_Ui.Text(this Rask.Core.Build<Rask.Ui.UiStep!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiStep!>
 static RaskBuilderSettersRask_Ui.Text(this Rask.Core.Build<Rask.Ui.UiToggle!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiToggle!>
 static RaskBuilderSettersRask_Ui.Theme(this Rask.Core.Build<Rask.Ui.UiThemeController!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiThemeController!>
+static RaskBuilderSettersRask_Ui.Themes(this Rask.Core.Build<Rask.Ui.UiThemeDropdown!> __b, System.Collections.Generic.IReadOnlyList<Rask.Ui.UiThemeName>? value) -> Rask.Core.Build<Rask.Ui.UiThemeDropdown!>
 static RaskBuilderSettersRask_Ui.Themes(this Rask.Core.Build<Rask.Ui.UiThemePicker!> __b, System.Collections.Generic.IReadOnlyList<Rask.Ui.UiThemeName>? value) -> Rask.Core.Build<Rask.Ui.UiThemePicker!>
 static RaskBuilderSettersRask_Ui.Tip(this Rask.Core.Build<Rask.Ui.UiTooltip!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiTooltip!>
 static RaskBuilderSettersRask_Ui.Title(this Rask.Core.Build<Rask.Ui.UiCollapse!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiCollapse!>
@@ -1593,6 +1609,7 @@ static RaskBuilderSettersRask_Ui.Trailing(this Rask.Core.Build<Rask.Ui.UiListRow
 static RaskBuilderSettersRask_Ui.Trailing(this Rask.Core.Build<Rask.Ui.UiTopBar!> __b, Rask.Core.Component? value) -> Rask.Core.Build<Rask.Ui.UiTopBar!>
 static RaskBuilderSettersRask_Ui.Trigger(this Rask.Core.Build<Rask.Ui.UiDropdown!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiDropdown!>
 static RaskBuilderSettersRask_Ui.Trigger(this Rask.Core.Build<Rask.Ui.UiModal!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiModal!>
+static RaskBuilderSettersRask_Ui.Trigger(this Rask.Core.Build<Rask.Ui.UiThemeDropdown!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiThemeDropdown!>
 static RaskBuilderSettersRask_Ui.Type(this Rask.Core.Build<Rask.Ui.UiInput!> __b, Rask.Core.InputType? value) -> Rask.Core.Build<Rask.Ui.UiInput!>
 static RaskBuilderSettersRask_Ui.Underline(this Rask.Core.Build<Rask.Ui.UiLink!> __b, bool? value) -> Rask.Core.Build<Rask.Ui.UiLink!>
 static RaskBuilderSettersRask_Ui.Url(this Rask.Core.Build<Rask.Ui.UiMockupBrowser!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiMockupBrowser!>
@@ -1682,6 +1699,7 @@ static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiSwap(Rask.Core.Compo
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiTab(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiTextarea(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiThemeController(Rask.Core.Component! __c0) -> void
+static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiThemeDropdown(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiThemePicker(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiTimeline(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiToast(Rask.Core.Component! __c0) -> void
@@ -1755,6 +1773,7 @@ static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiSwap(Rask.Core.Com
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiTab(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiTextarea(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiThemeController(Rask.Core.Component! __c0, ulong __p) -> void
+static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiThemeDropdown(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiThemePicker(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiTimeline(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiToast(Rask.Core.Component! __c0, ulong __p) -> void
@@ -1836,6 +1855,7 @@ static RaskEntriesRask_Ui.UiTable.get -> Rask.Core.Build<Rask.Ui.UiTable!>
 static RaskEntriesRask_Ui.UiTabs.get -> Rask.Core.Build<Rask.Ui.UiTabs!>
 static RaskEntriesRask_Ui.UiTextarea.get -> Rask.Ui.RaskSeed_UiTextarea
 static RaskEntriesRask_Ui.UiThemeController.get -> Rask.Ui.RaskSeed_UiThemeController
+static RaskEntriesRask_Ui.UiThemeDropdown.get -> Rask.Core.Build<Rask.Ui.UiThemeDropdown!>
 static RaskEntriesRask_Ui.UiThemePicker.get -> Rask.Core.Build<Rask.Ui.UiThemePicker!>
 static RaskEntriesRask_Ui.UiTimeline.get -> Rask.Core.Build<Rask.Ui.UiTimeline!>
 static RaskEntriesRask_Ui.UiToast.get -> Rask.Ui.RaskSeed_UiToast

--- a/src/Rask.Ui/PublicAPI/net10.0-browser/PublicAPI.Unshipped.txt
+++ b/src/Rask.Ui/PublicAPI/net10.0-browser/PublicAPI.Unshipped.txt
@@ -1323,8 +1323,11 @@ const Rask.Ui.UiStyles.Label = "text-xs font-medium tracking-wide opacity-60" ->
 const Rask.Ui.UiStyles.Mono = "font-mono text-xs" -> string!
 const Rask.Ui.UiStyles.Quiet = "inline-flex min-h-11 items-center rounded-lg px-2 text-xs opacity-60 hover:bg-base-200 hover:text-base-content sm:min-h-0 sm:py-1" -> string!
 const Rask.Ui.UiStyles.Value = "mt-2 text-2xl font-semibold tabular-nums tracking-tight text-base-content sm:text-3xl" -> string!
+const Rask.Ui.UiStylesheet.Path = "/css/rask-ui.css" -> string!
 const Rask.Ui.UiStylesheet.ThemeScopeAttribute = "data-rask-ui" -> string!
 static Rask.Ui.UiStylesheet.Css.get -> string!
+static Rask.Ui.UiStylesheet.Href(string? pathBase = null) -> string!
+static Rask.Ui.UiStylesheet.Version.get -> string!
 static Rask.Ui.UiTheme.All.get -> System.Collections.Generic.IReadOnlyList<Rask.Ui.UiThemeName>!
 static Rask.Ui.UiTheme.Value(Rask.Ui.UiThemeName theme) -> string!
 static RaskBuilderSettersRask_Ui.AccessibleLabel(this Rask.Core.Build<Rask.Ui.UiSearch!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiSearch!>

--- a/src/Rask.Ui/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Rask.Ui/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1194,6 +1194,18 @@ Rask.Ui.UiThemeController.Size.set -> void
 Rask.Ui.UiThemeController.Theme.get -> string?
 Rask.Ui.UiThemeController.Theme.set -> void
 Rask.Ui.UiThemeController.UiThemeController() -> void
+Rask.Ui.UiThemeDropdown
+Rask.Ui.UiThemeDropdown.Class.get -> string?
+Rask.Ui.UiThemeDropdown.Class.set -> void
+Rask.Ui.UiThemeDropdown.GroupName.get -> string!
+Rask.Ui.UiThemeDropdown.GroupName.set -> void
+Rask.Ui.UiThemeDropdown.Placement.get -> string?
+Rask.Ui.UiThemeDropdown.Placement.set -> void
+Rask.Ui.UiThemeDropdown.Themes.get -> System.Collections.Generic.IReadOnlyList<Rask.Ui.UiThemeName>?
+Rask.Ui.UiThemeDropdown.Themes.set -> void
+Rask.Ui.UiThemeDropdown.Trigger.get -> string!
+Rask.Ui.UiThemeDropdown.Trigger.set -> void
+Rask.Ui.UiThemeDropdown.UiThemeDropdown() -> void
 Rask.Ui.UiThemeName
 Rask.Ui.UiThemeName.Abyss = 2 -> Rask.Ui.UiThemeName
 Rask.Ui.UiThemeName.Acid = 3 -> Rask.Ui.UiThemeName
@@ -1408,6 +1420,7 @@ static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiSteps!> __
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiSwap!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiSwap!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiTextarea!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiTextarea!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiThemeController!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiThemeController!>
+static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiThemeDropdown!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiThemeDropdown!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiThemePicker!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiThemePicker!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiTimeline!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiTimeline!>
 static RaskBuilderSettersRask_Ui.Class(this Rask.Core.Build<Rask.Ui.UiToggle!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiToggle!>
@@ -1433,6 +1446,7 @@ static RaskBuilderSettersRask_Ui.Footer(this Rask.Core.Build<Rask.Ui.UiModal!> _
 static RaskBuilderSettersRask_Ui.Group(this Rask.Core.Build<Rask.Ui.UiCollapse!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiCollapse!>
 static RaskBuilderSettersRask_Ui.Group(this Rask.Core.Build<Rask.Ui.UiRadio!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiRadio!>
 static RaskBuilderSettersRask_Ui.Group(this Rask.Core.Build<Rask.Ui.UiRating!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiRating!>
+static RaskBuilderSettersRask_Ui.GroupName(this Rask.Core.Build<Rask.Ui.UiThemeDropdown!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiThemeDropdown!>
 static RaskBuilderSettersRask_Ui.GroupName(this Rask.Core.Build<Rask.Ui.UiThemePicker!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiThemePicker!>
 static RaskBuilderSettersRask_Ui.Grow(this Rask.Core.Build<Rask.Ui.UiListRow!> __b, Rask.Core.Component! value) -> Rask.Core.Build<Rask.Ui.UiListRow!>
 static RaskBuilderSettersRask_Ui.HandleLabel(this Rask.Core.Build<Rask.Ui.UiDiff!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiDiff!>
@@ -1523,6 +1537,7 @@ static RaskBuilderSettersRask_Ui.Placeholder(this Rask.Core.Build<Rask.Ui.UiSear
 static RaskBuilderSettersRask_Ui.Placeholder(this Rask.Core.Build<Rask.Ui.UiSelect!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiSelect!>
 static RaskBuilderSettersRask_Ui.Placeholder(this Rask.Core.Build<Rask.Ui.UiTextarea!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiTextarea!>
 static RaskBuilderSettersRask_Ui.Placement(this Rask.Core.Build<Rask.Ui.UiDropdown!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiDropdown!>
+static RaskBuilderSettersRask_Ui.Placement(this Rask.Core.Build<Rask.Ui.UiThemeDropdown!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiThemeDropdown!>
 static RaskBuilderSettersRask_Ui.Placement(this Rask.Core.Build<Rask.Ui.UiTooltip!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiTooltip!>
 static RaskBuilderSettersRask_Ui.Round(this Rask.Core.Build<Rask.Ui.UiAvatar!> __b, bool? value) -> Rask.Core.Build<Rask.Ui.UiAvatar!>
 static RaskBuilderSettersRask_Ui.Rows(this Rask.Core.Build<Rask.Ui.UiTextarea!> __b, int? value) -> Rask.Core.Build<Rask.Ui.UiTextarea!>
@@ -1561,6 +1576,7 @@ static RaskBuilderSettersRask_Ui.Text(this Rask.Core.Build<Rask.Ui.UiRadio!> __b
 static RaskBuilderSettersRask_Ui.Text(this Rask.Core.Build<Rask.Ui.UiStep!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiStep!>
 static RaskBuilderSettersRask_Ui.Text(this Rask.Core.Build<Rask.Ui.UiToggle!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiToggle!>
 static RaskBuilderSettersRask_Ui.Theme(this Rask.Core.Build<Rask.Ui.UiThemeController!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiThemeController!>
+static RaskBuilderSettersRask_Ui.Themes(this Rask.Core.Build<Rask.Ui.UiThemeDropdown!> __b, System.Collections.Generic.IReadOnlyList<Rask.Ui.UiThemeName>? value) -> Rask.Core.Build<Rask.Ui.UiThemeDropdown!>
 static RaskBuilderSettersRask_Ui.Themes(this Rask.Core.Build<Rask.Ui.UiThemePicker!> __b, System.Collections.Generic.IReadOnlyList<Rask.Ui.UiThemeName>? value) -> Rask.Core.Build<Rask.Ui.UiThemePicker!>
 static RaskBuilderSettersRask_Ui.Tip(this Rask.Core.Build<Rask.Ui.UiTooltip!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiTooltip!>
 static RaskBuilderSettersRask_Ui.Title(this Rask.Core.Build<Rask.Ui.UiCollapse!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiCollapse!>
@@ -1593,6 +1609,7 @@ static RaskBuilderSettersRask_Ui.Trailing(this Rask.Core.Build<Rask.Ui.UiListRow
 static RaskBuilderSettersRask_Ui.Trailing(this Rask.Core.Build<Rask.Ui.UiTopBar!> __b, Rask.Core.Component? value) -> Rask.Core.Build<Rask.Ui.UiTopBar!>
 static RaskBuilderSettersRask_Ui.Trigger(this Rask.Core.Build<Rask.Ui.UiDropdown!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiDropdown!>
 static RaskBuilderSettersRask_Ui.Trigger(this Rask.Core.Build<Rask.Ui.UiModal!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiModal!>
+static RaskBuilderSettersRask_Ui.Trigger(this Rask.Core.Build<Rask.Ui.UiThemeDropdown!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiThemeDropdown!>
 static RaskBuilderSettersRask_Ui.Type(this Rask.Core.Build<Rask.Ui.UiInput!> __b, Rask.Core.InputType? value) -> Rask.Core.Build<Rask.Ui.UiInput!>
 static RaskBuilderSettersRask_Ui.Underline(this Rask.Core.Build<Rask.Ui.UiLink!> __b, bool? value) -> Rask.Core.Build<Rask.Ui.UiLink!>
 static RaskBuilderSettersRask_Ui.Url(this Rask.Core.Build<Rask.Ui.UiMockupBrowser!> __b, string? value) -> Rask.Core.Build<Rask.Ui.UiMockupBrowser!>
@@ -1682,6 +1699,7 @@ static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiSwap(Rask.Core.Compo
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiTab(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiTextarea(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiThemeController(Rask.Core.Component! __c0) -> void
+static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiThemeDropdown(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiThemePicker(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiTimeline(Rask.Core.Component! __c0) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetEager_Rask_Ui_UiToast(Rask.Core.Component! __c0) -> void
@@ -1755,6 +1773,7 @@ static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiSwap(Rask.Core.Com
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiTab(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiTextarea(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiThemeController(Rask.Core.Component! __c0, ulong __p) -> void
+static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiThemeDropdown(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiThemePicker(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiTimeline(Rask.Core.Component! __c0, ulong __p) -> void
 static RaskBuilderSettersRask_Ui.__RaskResetPending_Rask_Ui_UiToast(Rask.Core.Component! __c0, ulong __p) -> void
@@ -1836,6 +1855,7 @@ static RaskEntriesRask_Ui.UiTable.get -> Rask.Core.Build<Rask.Ui.UiTable!>
 static RaskEntriesRask_Ui.UiTabs.get -> Rask.Core.Build<Rask.Ui.UiTabs!>
 static RaskEntriesRask_Ui.UiTextarea.get -> Rask.Ui.RaskSeed_UiTextarea
 static RaskEntriesRask_Ui.UiThemeController.get -> Rask.Ui.RaskSeed_UiThemeController
+static RaskEntriesRask_Ui.UiThemeDropdown.get -> Rask.Core.Build<Rask.Ui.UiThemeDropdown!>
 static RaskEntriesRask_Ui.UiThemePicker.get -> Rask.Core.Build<Rask.Ui.UiThemePicker!>
 static RaskEntriesRask_Ui.UiTimeline.get -> Rask.Core.Build<Rask.Ui.UiTimeline!>
 static RaskEntriesRask_Ui.UiToast.get -> Rask.Ui.RaskSeed_UiToast

--- a/src/Rask.Ui/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Rask.Ui/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1323,8 +1323,11 @@ const Rask.Ui.UiStyles.Label = "text-xs font-medium tracking-wide opacity-60" ->
 const Rask.Ui.UiStyles.Mono = "font-mono text-xs" -> string!
 const Rask.Ui.UiStyles.Quiet = "inline-flex min-h-11 items-center rounded-lg px-2 text-xs opacity-60 hover:bg-base-200 hover:text-base-content sm:min-h-0 sm:py-1" -> string!
 const Rask.Ui.UiStyles.Value = "mt-2 text-2xl font-semibold tabular-nums tracking-tight text-base-content sm:text-3xl" -> string!
+const Rask.Ui.UiStylesheet.Path = "/css/rask-ui.css" -> string!
 const Rask.Ui.UiStylesheet.ThemeScopeAttribute = "data-rask-ui" -> string!
 static Rask.Ui.UiStylesheet.Css.get -> string!
+static Rask.Ui.UiStylesheet.Href(string? pathBase = null) -> string!
+static Rask.Ui.UiStylesheet.Version.get -> string!
 static Rask.Ui.UiTheme.All.get -> System.Collections.Generic.IReadOnlyList<Rask.Ui.UiThemeName>!
 static Rask.Ui.UiTheme.Value(Rask.Ui.UiThemeName theme) -> string!
 static RaskBuilderSettersRask_Ui.AccessibleLabel(this Rask.Core.Build<Rask.Ui.UiSearch!> __b, string! value) -> Rask.Core.Build<Rask.Ui.UiSearch!>

--- a/src/Rask.Ui/Rask.Ui.csproj
+++ b/src/Rask.Ui/Rask.Ui.csproj
@@ -114,7 +114,19 @@
            Text="Rask.Ui: $(RaskTailwindOutput) was not produced. The kit's stylesheet is compiled by _RaskTailwindBuild from $(RaskTailwindInput) and embedded here; shipping without it renders every component unstyled."/>
     <ItemGroup>
       <EmbeddedResource Include="$(RaskTailwindOutput)" LogicalName="Rask.Ui.ui.css"/>
+
+      <!--
+        Packed beside the targets as well, so a consumer's build can COPY it into wwwroot without
+        running code to pull it out of the assembly. Embedding alone is not enough for that: an
+        EmbeddedResource is only reachable at run time, and the copy has to happen at build time.
+      -->
+      <None Include="$(RaskTailwindOutput)" Pack="true" PackagePath="build/ui.css" Visible="false"/>
     </ItemGroup>
   </Target>
+
+  <!-- The build hooks a consumer gets from the package: see build/Rask.Ui.targets. -->
+  <ItemGroup>
+    <None Include="build\**" Pack="true" PackagePath="build\"/>
+  </ItemGroup>
 
 </Project>

--- a/src/Rask.Ui/UiStylesheet.cs
+++ b/src/Rask.Ui/UiStylesheet.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text;
 
 namespace Rask.Ui;
 
@@ -60,6 +61,54 @@ public static class UiStylesheet
     /// Read once into a static: the same bytes on every render, on every request, for the process's life.
     /// </remarks>
     public static string Css { get; } = Read();
+
+    /// <summary>
+    /// Where the build writes the sheet, relative to the app root: <c>/css/rask-ui.css</c>.
+    /// </summary>
+    /// <remarks>
+    /// Matches <c>RaskUiStylesheetOutput</c> in the package's build targets. An app that moves the
+    /// output moves this too, by passing its own href.
+    /// </remarks>
+    public const string Path = "/css/rask-ui.css";
+
+    /// <summary>
+    /// A cache-busting token for <see cref="Path" />: the sheet's own content hash.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The file is meant to be cached hard, which makes staleness the failure to design against — an
+    /// app that upgrades the kit and keeps serving the old bytes looks broken in a way nothing reports.
+    /// A hash of the content changes exactly when the content does.
+    /// </para>
+    /// <para>
+    /// Empty when the sheet did not ship, so the href stays a plain path rather than gaining a
+    /// <c>?v=</c> with nothing after it.
+    /// </para>
+    /// </remarks>
+    public static string Version { get; } = Hash(Css);
+
+    /// <summary>
+    /// <see cref="Path" /> with the cache-busting token, ready for a <c>&lt;link&gt;</c>.
+    /// </summary>
+    /// <param name="pathBase">The app's path base, for a deployment under a sub-path.</param>
+    public static string Href(string? pathBase = null) =>
+        Version.Length == 0
+            ? (pathBase ?? string.Empty) + Path
+            : (pathBase ?? string.Empty) + Path + "?v=" + Version;
+
+    private static string Hash(string css)
+    {
+        if (css.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var bytes = System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(css));
+
+        // Eight hex characters. This is a cache key, not a signature: it only has to change when the
+        // bytes do, and a long one in every URL is noise in the markup.
+        return Convert.ToHexStringLower(bytes)[..8];
+    }
 
     private static string Read()
     {

--- a/src/Rask.Ui/UiThemeDropdown.cs
+++ b/src/Rask.Ui/UiThemeDropdown.cs
@@ -1,0 +1,51 @@
+namespace Rask.Ui;
+
+/// <summary>
+/// <see cref="UiThemePicker" /> behind a trigger, for a bar with no room for thirty-five radios.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <c>&lt;details&gt;</c> rather than a popover or a menu button, because it opens and closes with no
+/// JavaScript — the same constraint the picker itself is built to.
+/// </para>
+/// <para>
+/// It is not built on <see cref="UiDropdown" />, and the reason is structural rather than stylistic:
+/// that component supplies its own <c>&lt;ul class="menu"&gt;</c> to hold children, and the picker is
+/// already a <c>&lt;ul&gt;</c>. Composing them would put one list directly inside another, which is not
+/// valid HTML — so this renders the disclosure itself and hands the picker the content classes.
+/// </para>
+/// <para>
+/// The list scrolls. Thirty-five themes is taller than most viewports, and a dropdown running off the
+/// bottom of the screen hides exactly the half someone is scrolling to find.
+/// </para>
+/// </remarks>
+public sealed partial class UiThemeDropdown : Component
+{
+    /// <summary>The label on the trigger. Defaults to "Theme".</summary>
+    public string Trigger { get; set; } = "Theme";
+
+    /// <summary>Alignment, as one of daisyUI's placement classes (for example <c>dropdown-end</c>).</summary>
+    public string? Placement { get; set; }
+
+    /// <summary>The radio group's name, passed through to the picker.</summary>
+    public string GroupName { get; set; } = "rask-ui-theme";
+
+    /// <summary>The themes to offer. Defaults to every theme the kit ships.</summary>
+    public IReadOnlyList<UiThemeName>? Themes { get; set; }
+
+    public string? Class { get; set; }
+
+    /// <inheritdoc />
+    protected override Component? Render() =>
+        Details.Class(UiClass.Compose("dropdown", Placement, Class))[
+            Summary.Class("btn btn-sm")[
+                UiIcon.Name(UiIconName.Sparkles).Class("size-4 shrink-0"),
+                Span[Trigger]
+            ],
+            UiThemePicker
+                .GroupName(GroupName)
+                .Themes(Themes)
+                .Class("dropdown-content z-1 max-h-96 w-52 flex-nowrap overflow-y-auto rounded-box "
+                       + "bg-base-100 p-2 shadow-sm")
+        ];
+}

--- a/src/Rask.Ui/build/Rask.Ui.targets
+++ b/src/Rask.Ui/build/Rask.Ui.targets
@@ -1,0 +1,102 @@
+<Project>
+
+  <!--
+    Writes the kit's stylesheet into the consuming app's wwwroot, so a browser can cache it.
+
+    The kit used to be inlined into every document with `Style[Raw.Value(UiStylesheet.Css)]`, and the
+    reasoning for that is recorded in UiStylesheet: a <style> is smaller than the machinery a static
+    web asset needs (the Razor SDK, a _content/ path a host has to map), and it let this package ship
+    as a plain assembly with no assets at all.
+
+    What changed is the number. The sheet is 36.8 KB gzipped, and it was being paid on EVERY document
+    of a site read page to page — see #1018. A file the browser caches costs that once. The machinery
+    is avoided anyway: this copies a plain file, so there is still no Razor SDK and no _content/ path.
+
+    UiStylesheet.Css stays. Rask.Dashboard still inlines, deliberately — it is mounted into somebody
+    else's host, which references the dashboard rather than the kit and so never imports this file.
+  -->
+
+  <PropertyGroup>
+    <!-- Where the sheet lands, relative to the consuming project. -->
+    <RaskUiStylesheetOutput Condition="'$(RaskUiStylesheetOutput)' == ''">wwwroot/css/rask-ui.css</RaskUiStylesheetOutput>
+
+    <!--
+      OPT IN, not opt out. Referencing the kit is not the same as wanting a file in your wwwroot: a
+      library that renders kit components into someone else's host wants no such file, and neither
+      does the meta-package that merely re-exports it. Defaulting this on wrote the sheet into six
+      projects, two of them libraries.
+
+      An app that wants the cached sheet says so:
+          <RaskUiWriteStylesheet>true</RaskUiWriteStylesheet>
+      and links it with UiStylesheet.Href(). Everything else keeps UiStylesheet.Css and inlines.
+    -->
+    <RaskUiWriteStylesheet Condition="'$(RaskUiWriteStylesheet)' == ''">false</RaskUiWriteStylesheet>
+  </PropertyGroup>
+
+  <Target Name="_RaskUiResolveStylesheet">
+
+    <!--
+      Only for a project that actually draws with the kit, and decided HERE rather than in a property
+      condition because an item list cannot be read twice at evaluation time (MSB4099).
+
+      In-repo these targets are imported for EVERY project by Directory.Build.targets, since a
+      ProjectReference does not carry a package's build hooks. Without this the sheet is written into
+      the wwwroot of Rask.Core, Rask.Html, Rask.Generators and the rest — it was, on the first run:
+      eleven copies of a 241 KB file, staged for commit. A package consumer reaches this only by
+      referencing Rask.Ui, so the check costs them nothing.
+    -->
+    <ItemGroup>
+      <_RaskUiKitReference Include="@(ProjectReference)"
+                           Condition="$([System.String]::Copy('%(Identity)').Contains('Rask.Ui.csproj'))"/>
+      <_RaskUiKitReference Include="@(PackageReference)" Condition="'%(Identity)' == 'Rask.Ui'"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_RaskUiReferenced>false</_RaskUiReferenced>
+      <_RaskUiReferenced Condition="'@(_RaskUiKitReference)' != ''">true</_RaskUiReferenced>
+      <!-- The kit itself compiles the sheet; it does not consume it. -->
+      <_RaskUiReferenced Condition="'$(MSBuildProjectName)' == 'Rask.Ui'">false</_RaskUiReferenced>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(_RaskUiReferenced)' == 'true'">
+      <!-- From the package: the compiled sheet packed beside these targets. -->
+      <_RaskUiStylesheetSource Include="$(MSBuildThisFileDirectory)ui.css"
+                               Condition="Exists('$(MSBuildThisFileDirectory)ui.css')"/>
+    </ItemGroup>
+
+    <!--
+      In-repo there is no package, so the file above does not exist: a sample references the PROJECT,
+      and the sheet is still in Rask.Ui's own obj/. Conditioned on the packed item being empty so a
+      consumer never evaluates this path — the same shape as Rask.Meta.Hosting's in-repo fallback, and
+      for the same reason: without it the in-repo build silently writes nothing and every page links a
+      stylesheet that was never produced.
+    -->
+    <ItemGroup Condition="'$(_RaskUiReferenced)' == 'true' AND '@(_RaskUiStylesheetSource)' == ''">
+      <_RaskUiStylesheetSource Include="$(MSBuildThisFileDirectory)../obj/net10.0/ui.generated.css"
+                               Condition="Exists('$(MSBuildThisFileDirectory)../obj/net10.0/ui.generated.css')"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="RaskUiWriteStylesheet"
+          Condition="'$(RaskUiWriteStylesheet)' == 'true'"
+          DependsOnTargets="_RaskUiResolveStylesheet"
+          BeforeTargets="BeforeBuild">
+
+    <!--
+      Warns rather than fails. A missing sheet renders the app unstyled, which is bad; failing the
+      build of an app for it would be worse, and this cannot tell a kit consumer that lost its
+      stylesheet from one that never had a wwwroot.
+    -->
+    <Warning Condition="'$(_RaskUiReferenced)' == 'true' AND '@(_RaskUiStylesheetSource)' == ''"
+             Text="Rask.Ui: the kit's stylesheet could not be found, so $(RaskUiStylesheetOutput) was not written and every kit component will render unstyled."/>
+
+    <MakeDir Condition="'@(_RaskUiStylesheetSource)' != ''"
+             Directories="$([System.IO.Path]::GetDirectoryName('$(MSBuildProjectDirectory)/$(RaskUiStylesheetOutput)'))"/>
+
+    <Copy Condition="'@(_RaskUiStylesheetSource)' != ''"
+          SourceFiles="@(_RaskUiStylesheetSource)"
+          DestinationFiles="$(MSBuildProjectDirectory)/$(RaskUiStylesheetOutput)"
+          SkipUnchangedFiles="true"/>
+  </Target>
+
+</Project>

--- a/tests/Rask.Example.Shared.Tests/UiPaletteTests.cs
+++ b/tests/Rask.Example.Shared.Tests/UiPaletteTests.cs
@@ -117,10 +117,12 @@ public sealed class UiPaletteTests
         // nothing fails exactly as the unstyled one did.
         var html = RaskTest.RenderDocument(new Shared.App(), TestServices.Default()).Html;
 
-        Assert.Contains(UiStylesheet.Path, html, StringComparison.Ordinal);
-
-        // With the cache-buster, so an upgrade cannot be served from a stale cache.
-        Assert.Contains(UiStylesheet.Href(), html, StringComparison.Ordinal);
+        // Under _content/, not the app root: this project ships its wwwroot as static web assets, so
+        // /css/rask-ui.css would 404 here — and a 404 stylesheet is invisible, exactly as the app.css
+        // comment beside it warns. The file name and the cache-buster are what must be present; the
+        // prefix is the host's business.
+        Assert.Contains("_content/Rask.Example.Shared/css/rask-ui.css", html, StringComparison.Ordinal);
+        Assert.Contains("?v=" + UiStylesheet.Version, html, StringComparison.Ordinal);
         Assert.NotEmpty(UiStylesheet.Version);
     }
 

--- a/tests/Rask.Example.Shared.Tests/UiPaletteTests.cs
+++ b/tests/Rask.Example.Shared.Tests/UiPaletteTests.cs
@@ -1,6 +1,6 @@
-using Rask.Ui;
 using System.Text.RegularExpressions;
 using Rask.Example.Shared.Tests.Infrastructure;
+using Rask.Ui;
 
 namespace Rask.Example.Shared.Tests;
 

--- a/tests/Rask.Example.Shared.Tests/UiPaletteTests.cs
+++ b/tests/Rask.Example.Shared.Tests/UiPaletteTests.cs
@@ -1,3 +1,4 @@
+using Rask.Ui;
 using System.Text.RegularExpressions;
 using Rask.Example.Shared.Tests.Infrastructure;
 
@@ -103,16 +104,24 @@ public sealed class UiPaletteTests
 
 
     [Fact]
-    public void The_document_inlines_the_kits_stylesheet()
+    public void The_document_links_the_kits_stylesheet()
     {
         // The tokens above are expressed in daisyUI's variables, and those are defined ONLY in the kit's
         // compiled sheet — Tailwind scans the project it runs in, so this app's own build cannot emit
         // them. Without the sheet on the page every colour resolves to nothing: not wrong, absent.
         // Structure and layout survive it, which is exactly why it went unnoticed until a browser test
         // compared --accent with --color-ui-brand and found both empty.
+        //
+        // The sheet used to be inlined and this asserted on its bytes. It is served as a cached file
+        // now (#1018), so what has to be true is that the document REACHES it — a page that links
+        // nothing fails exactly as the unstyled one did.
         var html = RaskTest.RenderDocument(new Shared.App(), TestServices.Default()).Html;
 
-        Assert.Contains("--color-primary", html, StringComparison.Ordinal);
+        Assert.Contains(UiStylesheet.Path, html, StringComparison.Ordinal);
+
+        // With the cache-buster, so an upgrade cannot be served from a stale cache.
+        Assert.Contains(UiStylesheet.Href(), html, StringComparison.Ordinal);
+        Assert.NotEmpty(UiStylesheet.Version);
     }
 
 }


### PR DESCRIPTION
## Summary

Closes [#1018](https://github.com/pal-tamas/rask/issues/1018), and puts the theme picker on the landing site and the docs showcase.

## The stylesheet is served and cached, not inlined

It was 36.8 KB gzipped in the `<head>` of every document, paid again on each page. The kit's build now writes the compiled sheet to `wwwroot/css/rask-ui.css`, and apps link it with the sheet's own content hash as the cache-buster — cached hard, busting exactly when the bytes change.

Measured on the landing page's publish: the document went from **268,143 to 63,702 bytes (−76%)**, and the sheet is published pre-compressed at **28.9 KB brotli**, fetched once.

The original reasoning against this is recorded in `UiStylesheet` and still holds where it applied — a static web asset needs the Razor SDK and a `_content/` path a host has to map. This copies a plain file, so none of that machinery arrives.

**Opt-in, not automatic.** Referencing the kit is not the same as wanting a file in your wwwroot. Defaulting it on wrote the sheet into six projects, two of them libraries (`src/Rask`, `Rask.Dashboard`) that render into someone else's host and want no such file; an earlier pass wrote it into **eleven**, including `Rask.Core` and `Rask.Generators`, because the repo imports package build hooks for every project. An app now says `<RaskUiWriteStylesheet>true</RaskUiWriteStylesheet>`. Exactly two do.

`UiStylesheet.Css` stays, and `Rask.Dashboard` still inlines deliberately: its host references the dashboard rather than the kit, so it never gets the build hook, and a `<link>` there would point at a file nothing produced.

`**/wwwroot/css/rask-ui.css` is gitignored beside the existing Tailwind rule — it is build output, not source.

## The two hosts need different URLs, and getting it wrong is invisible

`Rask.Example.Shared` ships its wwwroot as static web assets under `_content/Rask.Example.Shared/`, so the app-root `/css/rask-ui.css` **404s** there. The showcase's own code already warned about this two lines away, about `app.css`:

> Linking `/css/app.css` 404s, and a 404 stylesheet is invisible: the page renders, unstyled, with nothing failing.

Which is precisely the failure that shipped rask.sh grey earlier today. The showcase passes the `_content` prefix; the site uses the app root. Verified against the real publish rather than by reading: the server's published output contains `_content/Rask.Example.Shared/css/rask-ui.css` (plus `.br`/`.gz`) at the URL the page links.

## The picker

`UiThemeDropdown` puts the kit's whole theme set behind one trigger. It works on the landing page *because* that page ships no JavaScript — daisyUI matches the checked radio in CSS.

The showcase's light/dark toggle had been deleted when the showcase went light on the kit's palette, with the note that there was "no second theme to flip to". There are thirty-five now, so it returns as the whole set — without reintroducing the `IJSRuntime` injection that layout had shed.

It is a `<details>` rather than built on `UiDropdown`, structurally: that component supplies its own `<ul class="menu">` for children and the picker is already a `<ul>`, so composing them would nest one list directly inside another. The content scrolls, because thirty-five rows is taller than most viewports.

## Testing

Full local gate: `dotnet format`, warnings-as-errors build, unit suite, and **98/98 browser E2E**.

The prerendered landing page was checked for what actually matters — all **35** `theme-controller` inputs present, and the document at 73 KB rather than 268 KB.
