### PR TITLE
fix: unblock the push gate, and four gates that named the wrong culprit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ them until tagged releases begin.
 
 ### Fixed
 
+- **The CLI build gate was red on `main`, so every `git push` was blocked.** Six tests looked for a
+  scaffolded SPA at `projectDir/name/name.csproj` and `projectDir/name/Client`. `GenerateSpa` writes
+  `{NameToken}.csproj` and `Client/…` directly under the target directory — flat, since the host stopped
+  being a `.Server` sibling and the front end became a folder rather than a second project. Every other
+  test in the same file already used `Path.Combine(projectDir, name + ".csproj")`; these were left
+  behind.
+
+  They failed in about 120 ms with `MSBUILD : error MSB1009: Project file does not exist` — before
+  anything was built, so the message describes the test's own path and not the scaffold it was meant to
+  check. The gate runs in the `pre-push` hook, which means this did not merely fail a suite: nothing
+  could be pushed at all without `--no-verify`, on any branch. Now 29 passed, 0 failed.
+
 - **A scaffolded Analog front end shipped a bare `@rask/client` and died in the browser.** The alias is
   written into the app's own `tsconfig.json`, which is a *type-checking* concept — Vite never reads it
   when bundling. `AddRaskViteConfig` was supposed to add the bundler half, but skipped it whenever the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,55 @@ them until tagged releases begin.
 
 ### Fixed
 
+- **Four local gates told the operator something that was not true.** Each is small on its own; together
+  they are the same defect four times, and it is the one this repository's casebook keeps recording — a
+  gate that is red, or silent, for a reason other than the one it names.
+
+  **The build-failure classifier read an analyzer error as "not a build failure"**
+  ([#968](https://github.com/pal-tamas/rask/issues/968)). `rask_build_failure_kind` counted only
+  `error CS…` and `error NETSDK…`, so a push that failed on 132 lines of `error RS0016` — the PublicAPI
+  gate, on a new public type whose surface had not been recorded — fell through to `unknown`, whose
+  message says in as many words that this is *not* a build failure and names three things to look for
+  that were all absent. This build is warnings-as-errors with analyzers on, and the PublicAPI gate makes
+  an unrecorded public member a build error **by design**, so for anyone adding public API `error RS…` is
+  the most likely way to break the build — ahead of `NETSDK`. The count now spans `CS`, `RS`, `ASP` and
+  `IDE`, and the table test states all four rather than the two someone happened to try.
+
+  **A build in one worktree warned because another worktree was building**
+  ([#964](https://github.com/pal-tamas/rask/issues/964)). `RaskConfigureGitHooks` re-asserted
+  `core.hooksPath` on every build. `git config` with no per-worktree flag writes the *common* config, and
+  the write takes `.git/config.lock` — so with several worktrees building at once an ordinary build could
+  fail to take that lock and report `could not lock config file … File exists` as MSB3073, a
+  warnings-as-errors failure whose real cause was a different worktree. The target now reads the value
+  first and writes only on a mismatch: the value is set once and never changes, so every later build does
+  a lock-free read and stops. Deliberately **not** `IgnoreExitCode` on the write — an unconfigured
+  `core.hooksPath` runs no hooks and says nothing, which is how two attribution trailers once reached
+  `main`, so a genuine failure to configure them must still be loud. Checked by putting the bug back:
+  with the value unset and the lock held, the write is still attempted and still warns.
+
+  **The packaging contract test reported an unbuilt tree as a packaging defect**
+  ([#1006](https://github.com/pal-tamas/rask/issues/1006)). Four packages name an MSBuild task assembly
+  that no `Pack` glob may match (#852: a glob is expanded at project *evaluation*, so on a tree where the
+  DLL is not yet built it silently packs nothing). That DLL is dropped into the source tree by a
+  build-order-only `ProjectReference`, so it exists only after that project has been built — and
+  `dotnet test tests/Rask.Cli.Tests` alone never builds it. The suite then went red naming a real project
+  and a real file, and read as "the meta package is broken" when the cause was building one project
+  instead of the solution. The two cases are now separated by the only thing that tells them apart:
+  whether anything in the project *produces* the file. `Foo.Tasks.dll` beside a `ProjectReference` to
+  `Foo.Tasks.csproj` is an unbuilt tree; anything else is still the NU5019 trap the test exists for — and
+  a pack line whose producing reference has been removed now fails, which it did not before.
+
+  **`run-unit-local.sh` described build flags it does not pass**
+  ([#1012](https://github.com/pal-tamas/rask/issues/1012)). The script carried two comments describing two
+  different behaviours and matching neither: one claimed "the build passes `-p:RaskSpaBuild=false`" — a
+  flag no script in this repo has ever passed — and one below it said the opposite. Both are replaced by
+  what the gate actually does. `RaskExternalBuild`, `RaskSpaBuild` and `RaskMetaBuild` all default to
+  `true`, and `Rask.slnx` now carries the showcase's islands plus six `Rask.Example.Meta.*` samples, so
+  building the solution runs npm and Vite for the islands **and a full production front-end build for each
+  of Nuxt, Next, SvelteKit, SolidStart, TanStack and Analog**. The stale sentence was precisely what would
+  have stopped someone noticing that the unit gate's cost changed when those samples landed. Whether the
+  unit gate *should* build sample front ends is left open; the comment's job is to describe what it does.
+
 - **A scaffolded Analog front end shipped a bare `@rask/client` and died in the browser.** The alias is
   written into the app's own `tsconfig.json`, which is a *type-checking* concept — Vite never reads it
   when bundling. `AddRaskViteConfig` was supposed to add the bundler half, but skipped it whenever the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,53 @@ them until tagged releases begin.
 
 ### Fixed
 
+- **The island type-check ran before the install, and then stopped running without saying so.** Three
+  defects in one path, and the third is what hid the other two.
+
+  **The check needed packages the build had not installed yet**
+  ([#967](https://github.com/pal-tamas/rask/issues/967)). `_RaskExternalTypeCheck` reached the install
+  only through `_RaskExternalBundle`, which runs after it — so a pull that added a package failed at the
+  type-check first, as `TS2307` on an import that is perfectly correct, naming the author's own file. The
+  check now depends on `_RaskExternalInstall`, which has its own `package.json` stamp and so costs
+  nothing when current. Verified by touching `package.json`: `npm ci` now runs *before* tsgo.
+
+  **A stale `node_modules` looked fine to the guard** ([#966](https://github.com/pal-tamas/rask/issues/966)).
+  `_RaskExternalDepsMissing` tested only that the directory existed, so packages predating the manifest
+  passed it — and what that produces is not a missing-package error but 19 `TS7026` on intrinsic JSX
+  elements, in a file nobody touched. The build now compares `package.json` against
+  `node_modules/.package-lock.json`, npm's own receipt, and names the cause. Not an error, because
+  `RaskExternalBuild=false` is a supported way to build without node and is exactly what turns off the
+  install that would fix it. (`System.IO.File` is not on MSBuild's property-function allowlist — MSB4185
+  — so the comparison goes through `%(ModifiedTime)`.)
+
+  **Every checker was skipped, silently, whenever the assembly declared no components**
+  ([#943](https://github.com/pal-tamas/rask/issues/943)). The task returned as soon as it read zero
+  constants, so no `tsconfig.check.json`, no `tsconfig.vue.json`, no `tsconfig.svelte.json` — and each
+  checker is gated on `Exists(<its config>)`, so tsgo, vue-tsc and svelte-check all did nothing while
+  none of the three "skipping…" messages fired, because each is gated on a different cause.
+
+  **The obvious repair — check the discovered files anyway — was tried, and is wrong.** A file list
+  cannot identify island code by itself, and this repository holds two counter-examples. Turning the
+  check on that way failed the showcase on `Rask.Example.Shared/Features/Gantt/Gantt.ts`, which is
+  **scoped TypeScript**, claimed only because `Name.ts` belongs to both a Lit island and Rask.Core
+  ([#938](https://github.com/pal-tamas/rask/issues/938)); it reported four `TS2304` on names that are
+  well defined where that file is actually compiled. It then failed all six `Rask.Example.Meta.*`
+  samples, whose entire `client/` tree is a **meta framework's own front end** — `TS2304` on Next's
+  generated `LayoutProps`, `TS2307` on `@rask/client`, `TS6504` on SolidStart's shipped `.jsx`.
+
+  So the skip stays and becomes **loud** instead: a high-importance message naming what was found, why it
+  is not being checked, and what to look at if islands were expected. Two things change besides. Stale
+  configs are now deleted, which the early return also skipped — a `tsconfig.vue.json` left by a build
+  from when the project still had a Vue island is a checker that keeps running against a file list that
+  no longer matches the tree. And a bare `.ts` or `.js` is checked only when a declared island claims it:
+  unlike the MSBuild discovery, this task runs *after* the compile and can read the assembly, so it can
+  make a test the discovery cannot. That does not close #938, but it removes the half of it that turns a
+  correct file into a red build.
+
+  Five task-level tests instantiate the task and call `Execute`, covering both directions: nothing
+  claimed to be checked when nothing is declared, the skip reported loudly when there are files and
+  quietly when there are none, and a stale config deleted.
+
 - **A scaffolded Analog front end shipped a bare `@rask/client` and died in the browser.** The alias is
   written into the app's own `tsconfig.json`, which is a *type-checking* concept — Vite never reads it
   when bundling. `AddRaskViteConfig` was supposed to add the bundler half, but skipped it whenever the

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -66,17 +66,42 @@
   <!--
     Auto-enable the repo's git hooks (pre-commit: dotnet format + unit; pre-push: browser E2E) so a fresh
     clone picks them up on first build — no manual `git config core.hooksPath .githooks`. The hook contents
-    live in .githooks/; this only points git at them. Idempotent (git config is a no-op if already set) and
-    best-effort (ContinueOnError). Skipped in CI (GitHub sets CI=true) and during IDE design-time builds,
-    and only runs inside a git working copy (.git present — a directory in the main clone, a file in a
-    worktree), so a restored/consumed package never triggers it. Hooks stay advisory: bypass any with
-    the git no-verify flag, RASK_SKIP_UNIT=1, or RASK_SKIP_E2E=1. See .github/CONTRIBUTING.md.
+    live in .githooks/; this only points git at them. Skipped in CI (GitHub sets CI=true) and during IDE
+    design-time builds, and only runs inside a git working copy (.git present — a directory in the main
+    clone, a file in a worktree), so a restored/consumed package never triggers it. Hooks stay advisory:
+    bypass any with the git no-verify flag, RASK_SKIP_UNIT=1, or RASK_SKIP_E2E=1. See .github/CONTRIBUTING.md.
+
+    READ before writing (#964). `git config` with no per-worktree flag writes the COMMON config, so a build
+    in a linked worktree writes the main checkout's .git/config — and the write takes .git/config.lock. Several
+    worktrees build concurrently on this machine, so an ordinary build could fail to take that lock and
+    report `could not lock config file … File exists` as MSB3073, a warnings-as-errors build failure whose
+    real cause was another worktree building at the same time. Re-asserting a value that is already set is
+    what needed the lock: the value is written once and never changes, so every build after the first now
+    does a lock-free read and stops. A genuine failure to configure the hooks still warns, which matters —
+    an unconfigured core.hooksPath runs NO hooks and says nothing, and that is how two attribution trailers
+    once reached main.
   -->
   <Target Name="RaskConfigureGitHooks" BeforeTargets="Build"
           Condition=" '$(CI)' != 'true' And '$(DesignTimeBuild)' != 'true'
                       And Exists('$(MSBuildThisFileDirectory).githooks')
                       And Exists('$(MSBuildThisFileDirectory).git') ">
+    <!--
+      IgnoreExitCode because a `get` of an unset key exits 1, which is the fresh-clone case this target
+      exists to serve, not an error.
+    -->
+    <Exec Command="git config --get core.hooksPath"
+          WorkingDirectory="$(MSBuildThisFileDirectory)"
+          ContinueOnError="true"
+          IgnoreExitCode="true"
+          EchoOff="true"
+          ConsoleToMSBuild="true"
+          StandardOutputImportance="low"
+          StandardErrorImportance="low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_RaskGitHooksPath" />
+    </Exec>
+
     <Exec Command="git config core.hooksPath .githooks"
+          Condition=" '$(_RaskGitHooksPath)' != '.githooks' "
           WorkingDirectory="$(MSBuildThisFileDirectory)"
           ContinueOnError="true"
           StandardOutputImportance="low"

--- a/scripts/lib/build-failure.sh
+++ b/scripts/lib/build-failure.sh
@@ -25,7 +25,8 @@
 #              refuse outright. Nothing ran, so every other kind would be a guess about a run that
 #              never happened. Note this is now the exception rather than the rule — a gate that finds
 #              the lane held waits for it, and a run that waits and then starts is not `busy` at all.
-#   code     — real compile errors (`error CS…`). The gate's own message is correct; the branch is broken.
+#   code     — the build produced errors (`error CS…`, or an analyzer id: `error RS…`, `error ASP…`,
+#              `error IDE…`). The gate's own message is correct; the branch is broken.
 #   workload — `error NETSDK1147` and no CS errors. A browser target could not resolve its workload.
 #   sdk      — some other `error NETSDK…` and no CS errors. An SDK/restore problem, still not the branch.
 #   unknown  — neither appears. The gate failed somewhere that is not a compile at all (a failing
@@ -37,8 +38,15 @@
 # correct explanation and contradicting it. The guard says "wait"; the classifier said "go read your
 # test output".
 #
-# CS wins over the machine kinds when both appear: a NETSDK error alongside genuine compile errors does
-# not excuse them.
+# `code` wins over the machine kinds when both appear: a NETSDK error alongside genuine compile errors
+# does not excuse them.
+#
+# The `code` count deliberately spans more than `CS`. This build is warnings-as-errors with analyzers on
+# (`Directory.Build.props`, `docs/code-analysis.md`), and the PublicAPI gate makes an unrecorded public
+# member a build error by design (RS0016/RS0017, `docs/api-style.md`) — so for anyone adding public API,
+# `error RS…` is the MOST likely way to break the build, ahead of `NETSDK`. Counting only `CS` sent those
+# runs to `unknown`, whose message asserts the failure is not a build failure and names three absent
+# things to investigate (#968): the #718 defect with its polarity reversed.
 rask_build_failure_kind() {
   local log="${1:-}"
 
@@ -48,7 +56,7 @@ rask_build_failure_kind() {
   # takes SIGPIPE, and the pipeline reports failure — the same trap that let a 421-file commit past the
   # pre-commit hook (see the note in .githooks/pre-commit). `|| true` because grep exits 1 on no match.
   local cs netsdk workload busy
-  cs=$(grep -Ec 'error[[:space:]]+CS[0-9]+' "$log" 2>/dev/null || true)
+  cs=$(grep -Ec 'error[[:space:]]+(CS|RS|ASP|IDE)[0-9]+' "$log" 2>/dev/null || true)
   netsdk=$(grep -Ec 'error[[:space:]]+NETSDK[0-9]+' "$log" 2>/dev/null || true)
   workload=$(grep -Ec 'error[[:space:]]+NETSDK1147' "$log" 2>/dev/null || true)
 
@@ -64,9 +72,9 @@ rask_build_failure_kind() {
   busy=$(grep -Ec '^run-e2e-local: (still queued after|refused to start)' "$log" 2>/dev/null || true)
 
   # `busy` sits BELOW code and above the machine kinds. A refusal means the suite never started, so it
-  # outranks anything inferred from an absence — but it must never outrank a real `error CS`: if
-  # something got far enough to fail compiling then something did run, and hiding that would be #718
-  # in reverse, blaming the machine for a broken branch.
+  # outranks anything inferred from an absence — but it must never outrank a real build error: if
+  # something got far enough to fail the compiler or an analyzer then something did run, and hiding that
+  # would be #718 in reverse, blaming the machine for a broken branch.
   if [ "${cs:-0}" -gt 0 ]; then
     printf 'code\n'
   elif [ "${busy:-0}" -gt 0 ]; then
@@ -112,7 +120,8 @@ rask_explain_build_failure() {
         echo "$gate: this is NOT your branch."
         echo
         echo "  Your machine cannot build browser targets right now: the 'wasm-tools' workload is"
-        echo "  unresolvable (error NETSDK1147), and nothing failed to compile (0 'error CS')."
+        echo "  unresolvable (error NETSDK1147), and nothing failed to build (no 'error CS', 'error RS',"
+        echo "  'error ASP' or 'error IDE')."
         echo
         echo "  The usual cause is a workload install in flight from another session or another worktree —"
         echo "  it bumps the shared manifests for the whole SDK band machine-wide, and for a moment they"
@@ -134,16 +143,18 @@ rask_explain_build_failure() {
       {
         echo "$gate: this looks like an SDK or restore problem, not your branch."
         echo
-        echo "  The build reported 'error NETSDK…' and nothing failed to compile (0 'error CS'), so the"
-        echo "  code is not what broke. Read the NETSDK error above — it names the missing piece."
+        echo "  The build reported 'error NETSDK…' and nothing failed to build — no 'error CS' and no"
+        echo "  analyzer error either — so the code is not what broke. Read the NETSDK error above: it"
+        echo "  names the missing piece."
       } >&2
       ;;
     *)
       {
         echo "$gate: failed without any compile error."
         echo
-        echo "  Neither 'error CS' nor 'error NETSDK' appears in the output, so this is not a build"
-        echo "  failure — look for a failing assertion, a timeout, or a host that exited early."
+        echo "  No 'error CS', no analyzer error ('error RS…', 'error ASP…', 'error IDE…') and no"
+        echo "  'error NETSDK…' appears in the output, so this is not a build failure — look for a"
+        echo "  failing assertion, a timeout, or a host that exited early."
         [ -n "$other_message" ] && { echo; echo "  $other_message"; }
       } >&2
       ;;

--- a/scripts/run-unit-local.sh
+++ b/scripts/run-unit-local.sh
@@ -101,22 +101,25 @@ done
 echo "==> Formatting check (dotnet format --verify-no-changes: whitespace + style + analyzers)"
 dotnet format Rask.slnx --verify-no-changes --no-restore
 
-# The generated TypeScript is checked by tsc, which needs node. The rest of this gate deliberately does
-# not (the build passes -p:RaskSpaBuild=false), so the toolchain is provisioned here when it can be and
-# the check is excluded — LOUDLY — when it cannot. What must not happen is the third option: a test that
-# quietly reports success without ever running a type-checker, which is how a generator emitting
-# malformed TypeScript would ship green.
+# The generated TypeScript is compiled by tsgo, which the test fetches itself as a checksum-verified
+# binary at a pinned version, cached per user. So the type CHECK needs no node and always runs. Nothing
+# to exclude any more: it used to be skipped when npx was absent, and a check whose first question is
+# "is the tooling here?" is one that eventually answers no and stops running — which is how a generator
+# emitting malformed TypeScript would ship green.
 #
-# Cached under artifacts/, so the install is a one-off rather than a per-run download.
-# The generated TypeScript is compiled by tsgo, which the test fetches as a checksum-verified binary at
-# a pinned version, cached per user. The type check needs no node, so it always runs. The GATE does
-# need node, since the showcase gained islands: it carries a package.json, so the solution build runs
-# npm and Vite for it (pass -p:RaskExternalBuild=false to build it without). What must not happen
-# is a test that quietly reports success without ever having run a type-checker, which is how a
-# generator emitting malformed TypeScript would ship green.
-# Nothing to exclude any more: the check fetches tsgo itself, as a checksum-verified binary, the same
-# way the framework build does. It used to be skipped when npx was absent — and a check whose first
-# question is "is the tooling here?" is one that eventually answers no and stops running.
+# The GATE, on the other hand, needs node, and needs more of it than it used to. The build line above
+# turns off only the WASM bundle; RaskExternalBuild, RaskSpaBuild and RaskMetaBuild all default to true
+# (src/Rask.External/build/Rask.External.props, src/Rask.Spa.Hosting/build/Rask.Spa.Hosting.props,
+# src/Rask.Meta.Hosting/build/Rask.Meta.Hosting.props), and Rask.slnx now carries the showcase's islands
+# plus six Rask.Example.Meta.* samples. Building the solution therefore runs npm and Vite for the
+# islands AND a full PRODUCTION front-end build for each of Nuxt, Next, SvelteKit, SolidStart, TanStack
+# and Analog.
+#
+# This comment used to claim the opposite — "the build passes -p:RaskSpaBuild=false", a flag no script
+# in this repo has ever passed (#1012). Anyone reading it would have concluded the unit gate was
+# node-light and cheap. It is neither, and the stale sentence is exactly what would have stopped someone
+# noticing that the gate's cost changed when the meta samples landed. Whether the unit gate SHOULD build
+# sample front ends is a separate, open question; this comment's job is only to describe what it does.
 tsc_filter=""
 
 echo "==> Unit & integration tests (excludes the browser E2E)"

--- a/scripts/tests/build-failure-kind.test.sh
+++ b/scripts/tests/build-failure-kind.test.sh
@@ -90,6 +90,34 @@ assert "compile errors alone" code \
 /src/App/Program.cs(14,5): error CS1002: ; expected
 '
 
+# The #968 shape: 132 lines of `error RS0016` from the PublicAPI gate and not one `error CS`. This is a
+# build failure — the branch does not build — but counting only CS classified it `unknown`, whose message
+# says in as many words that it is NOT a build failure and sends the author looking for a failing
+# assertion, a timeout or an early host exit. All three were absent; nothing browser-related had run.
+assert "PublicAPI analyzer errors alone are a build failure" code \
+  '/src/Rask.Auth/AccountService.cs(31,26): error RS0016: Symbol '\''Rask.Auth.AccountService.SignInAsync'\'' is not part of the declared API
+/src/Rask.Auth/AuthOptions.cs(12,23): error RS0016: Symbol '\''Rask.Auth.AuthOptions.Cookie'\'' is not part of the declared API
+'
+
+# ASP0016 has the same shape and is a build error here for the same reason: analyzers on, warnings as
+# errors. Stated rather than assumed, because the RS row alone would pass with a `RS`-only regex.
+assert "ASP analyzer errors alone are a build failure" code \
+  '/src/Rask.Server/Endpoints/Render.cs(88,13): error ASP0016: Do not return a value from RequestDelegate
+'
+
+# Code style is warnings-as-errors too (EnforceCodeStyleInBuild), so IDE ids arrive as errors and mean
+# the same thing to the reader: the build did not succeed because of the diff.
+assert "IDE code-style errors alone are a build failure" code \
+  '/src/Rask.Core/Live/LiveOptions.cs(93,1): error IDE0055: Fix formatting
+'
+
+# An analyzer error must outrank the machine kinds exactly as CS does — the #718 rule, applied to the
+# ids that were missing from it.
+assert "an analyzer error wins over NETSDK, like CS does" code \
+  '/proj/App.csproj : error NETSDK1147: To build this project, the following workloads must be installed: wasm-tools
+/src/Rask.Ui/UiThemeName.cs(7,21): error RS0016: Symbol '\''Rask.Ui.UiThemeName.Dark'\'' is not part of the declared API
+'
+
 # The case from #718, in the shape it actually arrived: many NETSDK1147, not one CS.
 assert "NETSDK1147 alone is the machine, not the branch" workload \
   '/proj/App.csproj : error NETSDK1147: To build this project, the following workloads must be installed: wasm-tools
@@ -121,6 +149,8 @@ assert "empty log" unknown ''
 assert "warnings only are not errors" unknown \
   '/proj/App.csproj : warning NETSDK1137: It is no longer necessary to use Microsoft.NET.Sdk.Web
 /src/App/Program.cs(5,9): warning CS0168: The variable '\''e'\'' is declared but never used
+/src/App/Api.cs(3,1): warning RS0026: Symbol '\''X'\'' violates the backcompat requirement
+/src/App/Api.cs(4,1): warning IDE0161: Convert to file-scoped namespace
 '
 
 # A path that does not exist must not crash the gate mid-failure.

--- a/src/Rask.External.Tasks/WriteExternalPropTypesTask.cs
+++ b/src/Rask.External.Tasks/WriteExternalPropTypesTask.cs
@@ -120,15 +120,28 @@ public sealed class WriteExternalPropTypesTask : Task
         try
         {
             var constants = GeneratedTypeScript.Read(AssemblyPath, GeneratedNamespace, GeneratedTypeName);
-            if (constants.Count == 0)
-            {
-                Log.LogMessage(
-                    MessageImportance.Low,
-                    $"Rask.External: '{Path.GetFileName(AssemblyPath)}' declares no external components.");
-                return true;
-            }
 
+            // No early return when the assembly declares nothing (#943), but no check either — and the
+            // difference between those two is the whole of this change.
+            //
+            // The original defect: returning here wrote no tsconfig.check.json, no tsconfig.vue.json and
+            // no tsconfig.svelte.json, every checker in _RaskExternalTypeCheck is gated on its config
+            // existing, so tsgo, vue-tsc and svelte-check ALL did nothing — while none of the three
+            // "skipping…" messages fired, because each is gated on a different cause. Silent.
+            //
+            // The obvious repair, checking the discovered files anyway, was tried and is WRONG. The file
+            // list cannot identify island code on its own, and two things in this repository prove it:
+            // a scoped-TypeScript Gantt.ts (#938), and the entire client/ tree of each Rask.Example.Meta.*
+            // sample — a meta framework's own front end, which type-checks under ITS toolchain and not
+            // under an island config. Checking them reported TS2304 on Next's generated globals and
+            // TS2307 on @rask/client, in files that are perfectly correct.
+            //
+            // So the skip stays, and becomes loud and specific instead. Stale configs are deleted on the
+            // way out, which the early return also skipped: a tsconfig.vue.json left by a previous build
+            // is a checker that runs next time against a file list that may no longer exist.
+            var declared = constants.Count > 0;
             var written = wroteConfig ? 1 : 0;
+
             foreach (var pair in constants)
             {
                 var path = Path.Combine(OutputDirectory, pair.Key + ".props.d.ts");
@@ -143,12 +156,28 @@ public sealed class WriteExternalPropTypesTask : Task
             // no longer renders.
             Prune(constants.Keys);
 
-            if (WriteCheckConfig())
+            if (WriteCheckConfig(declared))
             {
                 written++;
             }
 
-            if (written > 0)
+            if (!declared)
+            {
+                // High when there ARE front-end files, because that is the case that used to look like a
+                // passing check and was not one. The message names what was found and why it is not
+                // being checked, so the reader can tell "nothing to do" from "your islands are not
+                // being verified" — which is the distinction the silence destroyed.
+                Log.LogMessage(
+                    FrontEndFiles.Length > 0 ? MessageImportance.High : MessageImportance.Low,
+                    $"Rask.External: '{Path.GetFileName(AssemblyPath)}' declares no external components, "
+                    + $"so the prop type-check is skipped for the {FrontEndFiles.Length} front-end file(s) "
+                    + "beside it. Without a declaration nothing distinguishes an island from scoped "
+                    + "TypeScript or from a meta framework's own front end, and checking those reports "
+                    + "errors that are not in your code. If you expected islands here, check that the "
+                    + "component derives from ReactComponent/LitComponent/… and that "
+                    + "RaskExternalPropTypes is not false.");
+            }
+            else if (written > 0)
             {
                 Log.LogMessage(
                     MessageImportance.High,
@@ -234,9 +263,14 @@ public sealed class WriteExternalPropTypesTask : Task
     ///         written a tsconfig at all.
     ///     </para>
     /// </remarks>
-    private bool WriteCheckConfig()
+    /// <param name="declared">
+    ///     Whether the assembly declared any island at all. When it did not, every checker's file list is
+    ///     empty, which DELETES a stale config rather than leaving it to run next build — see the note in
+    ///     <see cref="Execute" /> for why checking the discovered files instead is wrong.
+    /// </param>
+    private bool WriteCheckConfig(bool declared)
     {
-        if (CheckConfigPath.Length == 0 || FrontEndFiles.Length == 0)
+        if (CheckConfigPath.Length == 0)
         {
             HasCheckConfig = false;
             return false;
@@ -260,27 +294,42 @@ public sealed class WriteExternalPropTypesTask : Task
         var runtimes = Runtimes();
 
         HasSolidConfig = WriteConfigFor(
-            SolidConfigPath, directory, p => Is(runtimes, p, "solid"), ref written,
+            SolidConfigPath, directory, p => declared && Is(runtimes, p, "solid"), ref written,
             // "preserve" hands the JSX to the Solid plugin rather than compiling it here, and
             // jsxImportSource is what points the TYPES at solid-js instead of React.
             ["\"jsx\": \"preserve\"", "\"jsxImportSource\": \"solid-js\""]);
 
         HasPreactConfig = WriteConfigFor(
-            PreactConfigPath, directory, p => Is(runtimes, p, "preact"), ref written,
+            PreactConfigPath, directory, p => declared && Is(runtimes, p, "preact"), ref written,
             ["\"jsx\": \"react-jsx\"", "\"jsxImportSource\": \"preact\""]);
 
         HasAngularConfig = WriteConfigFor(
-            AngularConfigPath, directory, p => Is(runtimes, p, "angular"), ref written,
+            AngularConfigPath, directory, p => declared && Is(runtimes, p, "angular"), ref written,
             // Angular's decorators are the TypeScript 4 form. Lit 3's are the standard ones and need
             // this OFF, which is exactly why the two cannot share a config.
             ["\"experimentalDecorators\": true", "\"emitDecoratorMetadata\": true"]);
 
-        // Everything else tsgo can read: React, Lit, and any file no component has claimed yet.
+        // Everything else tsgo can read: React, Lit, and any JSX file no component has claimed yet.
+        //
+        // A bare .ts or .js is the exception, and it has to be: `Name.ts` is claimed by filename for a
+        // Lit or Angular island AND by Rask.Core for scoped TypeScript, which is #938. Nothing in the
+        // extension separates them — but this task runs AFTER the compile, so the assembly can. A .ts
+        // that no declared island claims is scoped TypeScript, and checking it here fails for a reason
+        // that has nothing to do with the author's code: it is compiled by a different pipeline, with
+        // different lib and ambient declarations, so its globals resolve to nothing. Rask's own showcase
+        // has one (Features/Gantt/Gantt.ts, whose types come from a third-party global), and it reported
+        // four TS2304 on names that are perfectly well defined where that file is actually compiled.
+        //
+        // .tsx, .jsx, .vue and .svelte need no such test: scoped TypeScript is never any of them.
+        //
+        // The narrowing costs one case — a real Lit island in a project whose generator is suppressed is
+        // no longer checked — and that case could not be checked correctly anyway, for the same reason.
         HasCheckConfig = WriteConfigFor(
             CheckConfigPath,
             directory,
-            p => IsTypeScript(p) && !Is(runtimes, p, "solid") && !Is(runtimes, p, "preact")
-                 && !Is(runtimes, p, "angular"),
+            p => declared && IsTypeScript(p) && !Is(runtimes, p, "solid") && !Is(runtimes, p, "preact")
+                 && !Is(runtimes, p, "angular")
+                 && (!IsAmbiguouslyPaired(p) || ExternalIslandMetadata.RuntimeFor(runtimes, p) is not null),
             ref written,
             ReactJsx);
 
@@ -289,9 +338,9 @@ public sealed class WriteExternalPropTypesTask : Task
         // program pulls in a TSX helper, would otherwise be checked under TypeScript's default `jsx`
         // and fail on code that checked cleanly before.
         HasVueConfig = WriteConfigFor(
-            VueConfigPath, directory, p => HasExtension(p, ".vue"), ref written, ReactJsx);
+            VueConfigPath, directory, p => declared && HasExtension(p, ".vue"), ref written, ReactJsx);
         HasSvelteConfig = WriteConfigFor(
-            SvelteConfigPath, directory, p => HasExtension(p, ".svelte"), ref written, ReactJsx);
+            SvelteConfigPath, directory, p => declared && HasExtension(p, ".svelte"), ref written, ReactJsx);
 
         return written;
     }
@@ -414,6 +463,13 @@ public sealed class WriteExternalPropTypesTask : Task
     }
 
     /// <summary>Whether tsgo can read this file at all.</summary>
+    /// <summary>
+    ///     Whether an extension is claimed by both an island and Rask.Core's scoped TypeScript, so the
+    ///     file's own name cannot say which it is (#938).
+    /// </summary>
+    internal static bool IsAmbiguouslyPaired(string path) =>
+        HasExtension(path, ".ts") || HasExtension(path, ".js");
+
     private static bool IsTypeScript(string path) =>
         HasExtension(path, ".ts") || HasExtension(path, ".tsx") || HasExtension(path, ".js")
         || HasExtension(path, ".jsx");

--- a/src/Rask.External/build/Rask.External.targets
+++ b/src/Rask.External/build/Rask.External.targets
@@ -233,9 +233,17 @@
     Roughly 0.2s for a small project. RaskExternalTypeCheck=false turns it off for anyone
     mid-refactor with a deliberately red front end.
   -->
+  <!--
+    DependsOnTargets carries _RaskExternalInstall (#967).
+
+    The check reads the island's imports, so it needs the packages that satisfy them. Reaching the
+    install only through _RaskExternalBundle put it AFTER this target, so a pull that added a package
+    failed here first — as TS2307 on an import that is perfectly correct, naming the author's own file.
+    The install has its own package.json stamp, so depending on it costs nothing when it is current.
+  -->
   <Target Name="_RaskExternalTypeCheck"
           AfterTargets="_RaskExternalWritePropTypes"
-          DependsOnTargets="ResolveProjectReferences"
+          DependsOnTargets="ResolveProjectReferences;_RaskExternalInstall"
           Condition="'$(RaskExternalTypeCheck)' != 'false' AND '$(DesignTimeBuild)' != 'true' AND '@(_RaskExternalFile)' != ''">
     <!--
       ResolveTypeScriptToolTask belongs to Rask.Core's build integration, not this one, and this
@@ -257,11 +265,51 @@
 
     <PropertyGroup>
       <_RaskExternalDepsMissing Condition="Exists('$(MSBuildProjectDirectory)/package.json') AND !Exists('$(MSBuildProjectDirectory)/node_modules')">true</_RaskExternalDepsMissing>
+
+    </PropertyGroup>
+
+    <!--
+      node_modules present but OLDER than the package.json beside it (#966).
+
+      Through %(ModifiedTime) rather than a property function: System.IO.File is not on MSBuild's
+      property-function allowlist (MSB4185), and a target's own Inputs/Outputs answers "should this
+      target run", which is a different question and leaves nothing a later task can read. The metadata
+      is a sortable timestamp, so an ordinal string compare orders it correctly.
+
+      npm rewrites node_modules/.package-lock.json on every install, so it is the install's own receipt
+      and the only file in there whose timestamp means anything.
+    -->
+    <ItemGroup>
+      <_RaskExternalManifest Include="$(MSBuildProjectDirectory)/package.json"/>
+      <_RaskExternalInstallReceipt Include="$(MSBuildProjectDirectory)/node_modules/.package-lock.json"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_RaskExternalManifestTime>@(_RaskExternalManifest->'%(ModifiedTime)')</_RaskExternalManifestTime>
+      <_RaskExternalReceiptTime>@(_RaskExternalInstallReceipt->'%(ModifiedTime)')</_RaskExternalReceiptTime>
+      <_RaskExternalDepsStale
+        Condition="'$(_RaskExternalManifestTime)' != '' AND '$(_RaskExternalReceiptTime)' != ''
+                   AND $([System.String]::Compare('$(_RaskExternalManifestTime)', '$(_RaskExternalReceiptTime)')) &gt; 0"
+      >true</_RaskExternalDepsStale>
     </PropertyGroup>
 
     <Message Importance="high"
              Condition="'$(_RaskExternalDepsMissing)' == 'true'"
              Text="Rask.External: skipping the prop type-check — this project has a package.json but no node_modules, so its imports cannot resolve. Run the install to enable it."/>
+
+    <!--
+      A node_modules OLDER than the package.json beside it (#966). The directory exists, so the probe
+      above is satisfied and every checker runs — against packages that predate the manifest. What that
+      produces is not a missing-package error but a cascade of TS7026 on intrinsic JSX elements, because
+      the types the runtime's JSX depends on are the ones that are absent: 19 errors on a file nobody
+      touched. Named here rather than left to the checker, which cannot know why.
+
+      Not an error: RaskExternalBuild=false is a supported way to build without node, and the install
+      that would fix this is exactly what that turns off.
+    -->
+    <Message Importance="high"
+             Condition="'$(_RaskExternalDepsStale)' == 'true' AND '$(_RaskExternalDepsMissing)' != 'true'"
+             Text="Rask.External: '$(MSBuildProjectName)' has a node_modules older than its package.json, so the type-check is reading packages that predate the manifest. If it reports errors on code you have not changed, run the install first."/>
 
     <!-- Resolved when ANY tsgo config exists. Gated on tsconfig.check.json alone, a project whose only
          islands are Solid or Angular resolved no tool, and every Exec below was skipped silently — a

--- a/tests/Rask.Cli.Tests/PackagingContractTests.cs
+++ b/tests/Rask.Cli.Tests/PackagingContractTests.cs
@@ -95,13 +95,33 @@ public sealed class PackagingContractTests
         //
         // Only literal Includes are checked. A glob that matches nothing is a different (and quieter)
         // failure, already guarded for the analyzer payload by the _RaskVerify…Packed targets.
+        //
+        // A file absent from disk is NOT on its own a defect: four packages name an MSBuild task
+        // assembly that no glob may match (#852 — a Pack glob is expanded at project EVALUATION, so on a
+        // tree where the DLL is not yet built it silently packs nothing), and that DLL is dropped into
+        // the source tree by a build-order-only ProjectReference. It therefore exists only after the
+        // producing project has been built, and `dotnet test tests/Rask.Cli.Tests` alone never builds it.
+        //
+        // Reporting that as "`dotnet pack` fails NU5019" named a real project and a real file and read
+        // as "the meta package is broken", when the actual cause was building one project instead of the
+        // solution (#1006). So the two cases are now separated by the only thing that distinguishes them:
+        // whether anything in the project PRODUCES the file. `Foo.Tasks.dll` alongside a ProjectReference
+        // to `Foo.Tasks.csproj` is an unbuilt tree; anything else is the NU5019 trap this test exists for.
         var offenders = new SortedSet<string>(StringComparer.Ordinal);
+        var unbuilt = new SortedSet<string>(StringComparer.Ordinal);
 
         foreach (var (name, path) in SourceProjects())
         {
             var directory = Path.GetDirectoryName(path)!;
+            var project = XDocument.Load(path);
 
-            foreach (var none in XDocument.Load(path).Descendants("None"))
+            var produced = project.Descendants("ProjectReference")
+                .Select(r => r.Attribute("Include")?.Value)
+                .Where(i => i is not null)
+                .Select(i => Path.GetFileNameWithoutExtension(i!.Replace('\\', '/')))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var none in project.Descendants("None"))
             {
                 var include = none.Attribute("Include")?.Value;
 
@@ -113,17 +133,35 @@ public sealed class PackagingContractTests
                     continue;
                 }
 
-                if (!File.Exists(Path.Combine(directory, include.Replace('\\', Path.DirectorySeparatorChar))))
+                if (File.Exists(Path.Combine(directory, include.Replace('\\', Path.DirectorySeparatorChar))))
                 {
-                    offenders.Add($"{name} packs '{include}', which does not exist");
+                    continue;
+                }
+
+                var assembly = Path.GetFileName(include.Replace('\\', '/'));
+
+                if (assembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) &&
+                    produced.Contains(Path.GetFileNameWithoutExtension(assembly)))
+                {
+                    unbuilt.Add($"{name} packs '{include}', produced by its ProjectReference to "
+                        + $"{Path.GetFileNameWithoutExtension(assembly)}");
+                }
+                else
+                {
+                    offenders.Add($"{name} packs '{include}', which does not exist and nothing produces");
                 }
             }
         }
 
         Assert.True(
             offenders.Count == 0,
-            "These projects name a file to pack that is not on disk, so `dotnet pack` fails NU5019 — "
-            + "invisible to build and test:\n  " + string.Join("\n  ", offenders));
+            "These projects name a file to pack that is not on disk and that no ProjectReference "
+            + "produces, so `dotnet pack` fails NU5019 — invisible to build and test:\n  "
+            + string.Join("\n  ", offenders)
+            + (unbuilt.Count == 0
+                ? string.Empty
+                : "\n\nSeparately, and NOT a defect: these are produced by a build that has not run "
+                    + "here yet (`dotnet build Rask.slnx`):\n  " + string.Join("\n  ", unbuilt)));
     }
 
     [Fact]

--- a/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
@@ -302,7 +302,7 @@ public sealed class ProjectGeneratorBuildE2ETests
             // Both files, because both are load-bearing: package.json is what makes the Client folder
             // convention resolve, and tsconfig.json is what satisfies RASKSPA004 — the build's refusal to
             // generate TypeScript contracts into a client that is not a TypeScript project.
-            var client = Path.Combine(projectDir, name, "Client");
+            var client = Path.Combine(projectDir, "Client");
             fs.CreateDirectory(client);
             fs.WriteAllText(Path.Combine(client, "package.json"), """{ "name": "stand-in", "private": true }""");
 
@@ -314,7 +314,7 @@ public sealed class ProjectGeneratorBuildE2ETests
 
             CliBuildE2E.WriteNuGetConfig(fs, projectDir, feed);
 
-            var server = Path.Combine(projectDir, name, name + ".csproj");
+            var server = Path.Combine(projectDir, name + ".csproj");
             var (exit, output) = await CliBuildE2E.RunDotnet(
                 $"build \"{server}\" -warnaserror -m:1 -p:RaskSpaBuild=false");
             Assert.True(exit == 0, $"[data={data}] generated react solution failed to build.{CliBuildE2E.Diagnostics(output)}");
@@ -380,13 +380,13 @@ public sealed class ProjectGeneratorBuildE2ETests
 
             // package.json and no tsconfig.json: the convention resolves the client, the contract emit turns
             // itself on, and there is nothing on the other side able to check what it writes.
-            var client = Path.Combine(projectDir, name, "Client");
+            var client = Path.Combine(projectDir, "Client");
             fs.CreateDirectory(client);
             fs.WriteAllText(Path.Combine(client, "package.json"), """{ "name": "stand-in", "private": true }""");
 
             CliBuildE2E.WriteNuGetConfig(fs, projectDir, feed);
 
-            var server = Path.Combine(projectDir, name, name + ".csproj");
+            var server = Path.Combine(projectDir, name + ".csproj");
             var (exit, output) = await CliBuildE2E.RunDotnet($"build \"{server}\" -m:1 -p:RaskSpaBuild=false");
 
             Assert.True(exit != 0, $"a JavaScript client built anyway.{CliBuildE2E.Diagnostics(output)}");

--- a/tests/Rask.Cli.Tests/SpaTailwindBuildE2ETests.cs
+++ b/tests/Rask.Cli.Tests/SpaTailwindBuildE2ETests.cs
@@ -108,7 +108,7 @@ public sealed class SpaTailwindBuildE2ETests
 
             CliBuildE2E.WriteNuGetConfig(fs, projectDir, feed);
 
-            var client = Path.Combine(projectDir, name, "Client");
+            var client = Path.Combine(projectDir, "Client");
             InjectProbe(client, frameworkKey);
 
             // ONE command, and deliberately the .NET one. Rask.Spa.Hosting's targets own the whole chain
@@ -116,7 +116,7 @@ public sealed class SpaTailwindBuildE2ETests
             // from the server's message records, then run the bundler. Driving npm directly would skip the
             // emit and test a client that cannot type-check, which is exactly what it did on the first run
             // of this test: `Property 'visits' does not exist on type '{}'`.
-            var csproj = Path.Combine(projectDir, name, name + ".csproj");
+            var csproj = Path.Combine(projectDir, name + ".csproj");
             var (buildExit, buildOutput) = await CliBuildE2E.RunDotnet($"build \"{csproj}\" -m:1");
             Assert.True(buildExit == 0, $"[{frameworkKey}] the solution failed to build.{CliBuildE2E.Diagnostics(buildOutput)}");
 

--- a/tests/Rask.External.Tasks.Tests/CheckConfigCoverageTests.cs
+++ b/tests/Rask.External.Tasks.Tests/CheckConfigCoverageTests.cs
@@ -1,0 +1,157 @@
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Rask.External.Tasks;
+
+namespace Rask.External.Tasks.Tests;
+
+// The prop type-check is the only thing standing between an island's C# props and the front-end code
+// that reads them, and every checker in _RaskExternalTypeCheck is gated on `Exists(<its config>)`. So
+// "no config was written" and "the check passed" are the same green build, and the difference used to be
+// invisible (#943).
+//
+// What these pin is the CORRECTED rule, which is not the one the issue first proposed. Checking the
+// discovered files regardless of what the assembly declared was tried and is wrong: the file list cannot
+// identify island code by itself, and this repository holds two counter-examples — a scoped-TypeScript
+// Gantt.ts (#938) and the whole client/ tree of each Rask.Example.Meta.* sample. So the skip stays; what
+// changes is that it is loud, and that it no longer leaves a stale config behind for a checker to run
+// against next build.
+public sealed class CheckConfigCoverageTests : IDisposable
+{
+    private readonly string _root = Directory.CreateTempSubdirectory("rask-external-checkconfig").FullName;
+
+    public void Dispose() => Directory.Delete(_root, recursive: true);
+
+    [Fact]
+    public void An_assembly_declaring_no_components_writes_no_check_config()
+    {
+        // Not a regression to the early return: the point is that nothing is CLAIMED to have been
+        // checked. A .tsx beside an assembly that declares no island is as likely to be a meta
+        // framework's own page as an island, and it type-checks under a toolchain this config cannot
+        // describe.
+        var task = NewTask(Front("Chart.tsx"), Front("Panel.vue"), Front("Row.svelte"));
+
+        Assert.True(task.Execute());
+
+        Assert.False(File.Exists(Path.Combine(_root, "obj", "tsconfig.check.json")));
+        Assert.False(File.Exists(Path.Combine(_root, "obj", "tsconfig.vue.json")));
+        Assert.False(File.Exists(Path.Combine(_root, "obj", "tsconfig.svelte.json")));
+
+        Assert.False(task.HasCheckConfig);
+        Assert.False(task.HasVueConfig);
+        Assert.False(task.HasSvelteConfig);
+    }
+
+    [Fact]
+    public void The_skip_is_reported_at_high_importance_when_there_are_files_to_check()
+    {
+        // The half of #943 that matters: the old skip said nothing at all, so a build that checked
+        // nothing and a build that checked everything looked identical. Silence is the defect.
+        var engine = new StubEngine();
+        var task = NewTask(Front("Chart.tsx"));
+        task.BuildEngine = engine;
+
+        Assert.True(task.Execute());
+
+        var said = engine.Messages.Single(m => m.Importance == MessageImportance.High);
+        Assert.Contains("declares no external components", said.Message, StringComparison.Ordinal);
+        Assert.Contains("skipped", said.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Nothing_to_check_is_reported_quietly()
+    {
+        // The counterpart, so the loud message stays meaningful: a project with no front-end files at
+        // all has nothing to warn about, and a high-importance line on every such build is how a real
+        // warning gets tuned out.
+        var engine = new StubEngine();
+        var task = NewTask();
+        task.BuildEngine = engine;
+
+        Assert.True(task.Execute());
+
+        Assert.DoesNotContain(engine.Messages, m => m.Importance == MessageImportance.High);
+    }
+
+    [Fact]
+    public void A_stale_config_from_a_previous_build_is_deleted()
+    {
+        // The issue's second half. The early return skipped this too, so a tsconfig.vue.json written
+        // when the project still had a Vue island survived its removal — and the targets decide whether
+        // to run a checker by whether its config EXISTS, so vue-tsc kept running against a file list
+        // that no longer matched the tree.
+        Directory.CreateDirectory(Path.Combine(_root, "obj"));
+        var stale = Path.Combine(_root, "obj", "tsconfig.vue.json");
+        File.WriteAllText(stale, "{ \"files\": [\"../../gone.vue\"] }");
+
+        Assert.True(NewTask(Front("Chart.tsx")).Execute());
+
+        Assert.False(File.Exists(stale));
+    }
+
+    [Fact]
+    public void A_bare_ts_is_ambiguous_and_a_tsx_is_not()
+    {
+        // `Name.ts` is claimed by filename for a Lit or Angular island AND by Rask.Core for scoped
+        // TypeScript (#938), so it may only be checked when a declared island claims it. The JSX and
+        // single-file-component extensions carry no such ambiguity: scoped TypeScript is never any of
+        // them. Pinned directly, because it is the rule that keeps a correct file out of a wrong config.
+        Assert.True(WriteExternalPropTypesTask.IsAmbiguouslyPaired("/app/Features/Gantt/Gantt.ts"));
+        Assert.True(WriteExternalPropTypesTask.IsAmbiguouslyPaired("/app/widgets/gauge.js"));
+
+        Assert.False(WriteExternalPropTypesTask.IsAmbiguouslyPaired("/app/Islands/Counter.tsx"));
+        Assert.False(WriteExternalPropTypesTask.IsAmbiguouslyPaired("/app/Islands/Counter.jsx"));
+        Assert.False(WriteExternalPropTypesTask.IsAmbiguouslyPaired("/app/Islands/Chart.vue"));
+        Assert.False(WriteExternalPropTypesTask.IsAmbiguouslyPaired("/app/Islands/Meter.svelte"));
+    }
+
+    private ITaskItem Front(string name)
+    {
+        var path = Path.Combine(_root, name);
+        File.WriteAllText(path, "// island");
+        return new TaskItem(path);
+    }
+
+    // AssemblyPath points at this test assembly on purpose: it is a real, readable assembly that
+    // declares no RaskExternalGeneratedTypeScript constants, which is exactly the state under test.
+    private WriteExternalPropTypesTask NewTask(params ITaskItem[] frontEnd)
+    {
+        var obj = Path.Combine(_root, "obj");
+        Directory.CreateDirectory(obj);
+
+        return new WriteExternalPropTypesTask
+        {
+            BuildEngine = new StubEngine(),
+            AssemblyPath = typeof(CheckConfigCoverageTests).Assembly.Location,
+            IslandAssemblyPath = typeof(CheckConfigCoverageTests).Assembly.Location,
+            OutputDirectory = Path.Combine(obj, "props"),
+            TsConfigPath = Path.Combine(obj, "tsconfig.rask.json"),
+            ProjectDirectory = _root,
+            FrontEndFiles = frontEnd,
+            CheckConfigPath = Path.Combine(obj, "tsconfig.check.json"),
+            VueConfigPath = Path.Combine(obj, "tsconfig.vue.json"),
+            SvelteConfigPath = Path.Combine(obj, "tsconfig.svelte.json"),
+            SolidConfigPath = Path.Combine(obj, "tsconfig.solid.json"),
+            PreactConfigPath = Path.Combine(obj, "tsconfig.preact.json"),
+            AngularConfigPath = Path.Combine(obj, "tsconfig.angular.json"),
+        };
+    }
+
+    private sealed class StubEngine : IBuildEngine
+    {
+        public List<BuildMessageEventArgs> Messages { get; } = [];
+
+        public bool ContinueOnError => false;
+        public int LineNumberOfTaskNode => 0;
+        public int ColumnNumberOfTaskNode => 0;
+        public string ProjectFileOfTaskNode => "test.csproj";
+
+        public void LogErrorEvent(BuildErrorEventArgs e) { }
+        public void LogWarningEvent(BuildWarningEventArgs e) { }
+        public void LogMessageEvent(BuildMessageEventArgs e) => Messages.Add(e);
+        public void LogCustomEvent(CustomBuildEventArgs e) { }
+
+        public bool BuildProjectFile(
+            string projectFileName, string[] targetNames, System.Collections.IDictionary globalProperties,
+            System.Collections.IDictionary targetOutputs) => true;
+    }
+}

--- a/tests/Rask.External.Tasks.Tests/Rask.External.Tasks.Tests.csproj
+++ b/tests/Rask.External.Tasks.Tests/Rask.External.Tasks.Tests.csproj
@@ -18,7 +18,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime"/>
+    <!--
+      Runtime assets INCLUDED here, unlike in the task project itself. A task assembly must never
+      ship MSBuild alongside it — it is loaded INTO MSBuild — but this project instantiates the task
+      and calls Execute(), so it needs the base class and TaskItem at run time. Without them the
+      tests fail with FileNotFoundException on Microsoft.Build.Utilities.Core before reaching an
+      assertion, which is a red that says nothing about the code under test.
+    -->
+    <PackageReference Include="Microsoft.Build.Utilities.Core"/>
     <PackageReference Include="xunit"/>
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Eight issues, plus one that was never filed and was blocking every push on every branch.

## The unfiled one: the CLI build gate was red on `main`

`ProjectGeneratorBuildE2ETests` and `SpaTailwindBuildE2ETests` looked for a scaffolded SPA at
`projectDir/name/name.csproj` and `projectDir/name/Client`. `GenerateSpa` writes `{NameToken}.csproj`
and `Client/…` directly under the target directory — flat, since the host stopped being a `.Server`
sibling. Every other test in the same file already used the flat path; six sites were left behind.

They failed in ~120 ms with `MSB1009: Project file does not exist`, before anything was built, so the
message named the test's own path rather than the scaffold under test. The gate runs in `pre-push`, so
this did not merely fail a suite — nothing could be pushed at all without `--no-verify`. Now 29 passed,
0 failed.

## Gates that named the wrong culprit

- **#968** — the failure classifier counted only `error CS` and `error NETSDK`, so a push that failed on
  132 lines of `error RS0016` classified as `unknown`, whose message says the failure is *not* a build
  failure and names three absent things to investigate. Now spans `CS`/`RS`/`ASP`/`IDE`, stated as table
  rows.
- **#964** — `RaskConfigureGitHooks` re-asserted `core.hooksPath` on every build, taking `.git/config.lock`
  in the *common* config, so a build in one worktree warned because another was building. Now reads first
  and writes only on a mismatch. Deliberately not `IgnoreExitCode`: unconfigured hooks run nothing and say
  nothing. Checked by putting the bug back.
- **#1006** — the packaging contract test read an unbuilt tree as a packaging defect. The two cases are now
  told apart by whether a `ProjectReference` produces the file, and a pack line whose producing reference
  is gone now fails, which it did not before.
- **#1012** — `run-unit-local.sh` carried two contradictory comments describing flags no script passes.
  Replaced with what the gate does: it runs npm and Vite for the islands **and a production front-end build
  for each of the six meta samples**.

## Islands: the type-check ran before the install, then stopped running silently

- **#967** — the check reached the install only through `_RaskExternalBundle`, which runs after it, so a pull
  that added a package failed as `TS2307` on a correct import. Now depends on `_RaskExternalInstall`.
- **#966** — the guard tested only that `node_modules` existed. Now compares `package.json` against
  `node_modules/.package-lock.json` and names the cause.
- **#943** — the task returned on zero constants, so tsgo, vue-tsc and svelte-check all did nothing, silently.

  **The obvious repair was tried and is wrong.** Writing configs from the discovered files failed the
  showcase on `Gantt.ts` (scoped TypeScript, #938) and then all six `Rask.Example.Meta.*` samples, whose
  `client/` tree is a meta framework's own front end. So the skip stays and becomes loud; stale configs are
  deleted; and a bare `.ts`/`.js` is checked only when a declared island claims it — a test this task can
  make, since it runs after the compile.

## Testing

`dotnet format --verify-no-changes` clean; `dotnet build -c Release -warnaserror` clean, 0 warnings;
full unit gate on the **merged** tree 407/407; CLI build gate 29/29. Browser E2E skipped — nothing here
changes rendered output.

Closes #968
Closes #964
Closes #1006
Closes #1012
Closes #967
Closes #966
Closes #943